### PR TITLE
(bugfix) update setup.py with correct project name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,8 @@ from setuptools import setup
 
 
 setup(
-    name='galley_api',
-    version='0.0.1',
+    name='galley_sdk',
+    version='0.1.0',
     packages=['galley'],
     install_requires=['sgqlc==14.0', 'mypy==0.770']
 )


### PR DESCRIPTION
## Description
This updates setup.py to use galley-sdk as the project name, in hopes of fixing an issue where some users cannot install this project. The version is also updated to 0.1.0, to align with semantic versioning.
## Test Plan
- Update the galley statement in the importing project to point to this commit and verify that the package is installed correctly, for example: `git+https://github.com/Thistle/galley-sdk.git@3a39acf3e65c626c4379a8ac27d5cb23f160dab3#egg=galley-sdk`
