### PR TITLE
(maint) add CHANGELOG.md to project with first couple entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- README.md updated with more detailed installation, usage, and testing information.
+
+## [0.1.0] - 2021-10-14
+### Added
+- Project created with initial functionality to make both query and mutation requests to Galley.


### PR DESCRIPTION
## Description
This adds a CHANGELOG to the project that we could choose to use to document/communicate the changes included in each release. 

I'm putting up this draft PR in order to help facilitate a team discussion during Engineering Forum on 10/20 about on how we'll handle versioning/tracking changes for this project. Using a CHANGELOG like this is one option, another option I think we could consider is to use Github releases with [auto-generated release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes).

## Test Plan
- Take a look at the included CHANGELOG, compare/contrast it to the [auto-generated Github release notes](https://github.com/Thistle/galley-sdk/releases/tag/0.1.0) that were generated for our first release.
