### PR TITLE
(maint) update a couple field names and menu item type handling

### DIFF
--- a/galley/queries.py
+++ b/galley/queries.py
@@ -26,7 +26,7 @@ class Query(Type):
                 'viewer': {
                     'recipes': [{
                         'id': str,
-                        'name': str,
+                        'externalName': str,
                         'instructions': Any,
                         'notes': Any,
                         'description': Any
@@ -42,7 +42,7 @@ def get_recipe_data() -> Optional[List[Dict]]:
     # Initiate a query
     query = Operation(Query)
     # Call sub-type you need to build the query.
-    query.viewer().recipes().__fields__('id', 'name', 'instructions', 'notes', 'description')
+    query.viewer().recipes().__fields__('id', 'externalName', 'instructions', 'notes', 'description')
     # pass query as an argument to make_request_to_galley function.
     raw_data = make_request_to_galley(op=query)
     return validate_response_data(raw_data, 'recipes')
@@ -50,7 +50,7 @@ def get_recipe_data() -> Optional[List[Dict]]:
 
 def get_recipe_nutrition_data(recipe_id) -> Optional[List[Dict]]:
     query = Operation(Query)
-    query.viewer().recipe(id=recipe_id).__fields__('id', 'name', 'calculatedNutritionals')
+    query.viewer().recipe(id=recipe_id).__fields__('id', 'externalName', 'reconciledNutritionals')
     raw_data = make_request_to_galley(op=query, variables={'id': recipe_id})
     return validate_response_data(raw_data, 'recipe')
 

--- a/galley/types.py
+++ b/galley/types.py
@@ -65,11 +65,11 @@ class Nutrition(Type):
 
 class Recipe(Type):
     id = str
-    name = str
+    externalName = str
     instructions = str
     notes = str
     description = str
-    calculatedNutritionals = Field(Nutrition)
+    reconciledNutritionals = Field(Nutrition)
 
 
 class RecipeInstruction(Type):
@@ -107,10 +107,12 @@ class CategoryItemTypeEnum(Enum):
 
 
 class Category(Type):
+    name = str
     itemType = Field(CategoryItemTypeEnum)
 
 
 class CategoryValue(Type):
+    name = str
     category = Field(Category)
 
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='galley_sdk',
-    version='0.3.0',
+    version='0.3.1',
     packages=['galley'],
     install_requires=['sgqlc==14.0', 'mypy==0.770', 'backoff==1.11.1']
 )

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -15,7 +15,7 @@ class TestQueryRecipes(TestCase):
             viewer {
             recipes {
             id
-            name
+            externalName
             instructions
             notes
             description
@@ -25,7 +25,7 @@ class TestQueryRecipes(TestCase):
 
     def test_recipe_query(self):
         query_operation = Operation(Query)
-        query_operation.viewer().recipes().__fields__('id', 'name', 'instructions', 'notes', 'description')
+        query_operation.viewer().recipes().__fields__('id', 'externalName', 'instructions', 'notes', 'description')
         query_str = bytes(query_operation).decode('utf-8')
         self.assertEqual(query_str, self.expected_query)
 
@@ -39,14 +39,14 @@ class TestQueryRecipes(TestCase):
         recipes = [
             {
                 'id': '10000',
-                'name': 'test recipe 1',
+                'externalName': 'test recipe 1',
                 'instructions': 'testing',
                 'notes': 'testing notes',
                 'description': 'test'
             },
             {
                 'id': '10000',
-                'name': 'test recipe 1',
+                'externalName': 'test recipe 1',
                 'instructions': None,
                 'notes': None,
                 'description': None
@@ -88,8 +88,8 @@ class TestQueryRecipeNutritionData(TestCase):
             viewer {
             recipe(id: "cmVjaXBlOjE2NDgzMw") {
             id
-            name
-            calculatedNutritionals {
+            externalName
+            reconciledNutritionals {
             addedSugarG
             calciumMg
             calciumPercentRDI
@@ -156,7 +156,7 @@ class TestQueryRecipeNutritionData(TestCase):
 
     def test_nutrition_query(self):
         query_operation = Operation(Query)
-        query_operation.viewer().recipe(id="cmVjaXBlOjE2NDgzMw").__fields__('id', 'name', 'calculatedNutritionals')
+        query_operation.viewer().recipe(id="cmVjaXBlOjE2NDgzMw").__fields__('id', 'externalName', 'reconciledNutritionals')
         query_str = bytes(query_operation).decode('utf-8')
         self.assertEqual(query_str, self.expected_query)
 
@@ -169,8 +169,8 @@ class TestQueryRecipeNutritionData(TestCase):
     def test_get_recipe_nutrition_data_successful(self, mock_retrieval_method):
         recipe = {
             'id': '1',
-            'name': 'test recipe 1',
-            'calculatedNutritionals': {
+            'externalName': 'test recipe 1',
+            'reconciledNutritionals': {
                 'addedSugarG': 0,
                 'calciumMg': 111.98919574121712,
                 'calciumPercentRDI': 0.086,
@@ -277,7 +277,9 @@ class TestQueryWeekMenuData(TestCase):
             menuItems {
             recipeId
             categoryValues {
+            name
             category {
+            name
             itemType
             }
             }
@@ -293,7 +295,7 @@ class TestQueryWeekMenuData(TestCase):
         self.assertEqual(query_str.replace(' ', ''), self.expected_query.replace(' ', ''))
 
     @mock.patch('galley.queries.make_request_to_galley')
-    def test_get_recipe_data_successful(self, mock_retrieval_method):
+    def test_get_week_menu_data_successful(self, mock_retrieval_method):
         menus = [
             {
                 'name': 'YYYY-MM-DD 1_2_3',
@@ -306,16 +308,20 @@ class TestQueryWeekMenuData(TestCase):
                     {
                         'recipeId': 'RECIPE123ABC',
                         'categoryValues': [{
+                            'name': 'dv1',
                             'category': {
-                                'itemType': 'menuItem'
+                                'itemType': 'menuItem',
+                                'name': 'menu item type'
                             }
                         }],
                     },
                     {
                         'recipeId': 'RECIPE456DEF',
                         'categoryValues': [{
+                            'name': 'dv2',
                             'category': {
-                                'itemType': 'menuItem'
+                                'itemType': 'menuItem',
+                                'name': 'menu item type'
                             }
                         }],
                     },
@@ -336,7 +342,7 @@ class TestQueryWeekMenuData(TestCase):
         self.assertEqual(result, menus)
 
     @mock.patch('galley.queries.make_request_to_galley')
-    def test_get_recipe_data_validation_failure(self, mock_retrieval_method):
+    def test_get_week_menu_data_validation_failure(self, mock_retrieval_method):
         mock_retrieval_method.return_value = {
             'data': {
                 'viewer': {


### PR DESCRIPTION
## Description
This makes a few small updates to our data retrieval functions (unit tests and mocks are updated to account for all changes included here):

- First, we need to work with recipe externalName instead of name, so this switches over all recipe.name references to recipe.externalName. 
- Second, we need to work with recipe.reconciledNutritionals instead of calculatedNutritionals, so those references are also switched. 
- Finally, we need to know the meal code for menu items (i.e. B1, LV2, etc.). The meal code is represented by the name of the categoryValue where the associated category is named menu item type. So, this adds the name field to the Category and CategoryValue types so that we pull back that info. 

## Test Plan
1) Automated tests should be green, can run with `python -m unittest tests/test_* `
2) Manual testing of retrieval functions should return the expected data. To verify:
Open python interactive within galley-sdk: `$ python`
`>>> import galley`
`>>> galley.api_key = <API-KEY>`
`>>> galley.api_url = <STAGING-URL>`
`>>> from galley.queries import *`
`>>> get_week_menu_data("2021-10-04 1_2_3")`
`>>> get_recipe_nutrition_data('cmVjaXBlOjE3OTk1Mw==')`
`>>> get_recipe_data()`