### PR TITLE
(ENG-763) retrieve additional recipe details

### DIFF
--- a/galley/queries.py
+++ b/galley/queries.py
@@ -50,7 +50,7 @@ def get_recipe_data() -> Optional[List[Dict]]:
 
 def get_recipe_nutrition_data(recipe_id) -> Optional[List[Dict]]:
     query = Operation(Query)
-    query.viewer().recipe(id=recipe_id).__fields__('id', 'externalName', 'reconciledNutritionals')
+    query.viewer().recipe(id=recipe_id).__fields__('id', 'externalName', 'notes', 'description', 'categoryValues', 'reconciledNutritionals')
     raw_data = make_request_to_galley(op=query, variables={'id': recipe_id})
     return validate_response_data(raw_data, 'recipe')
 

--- a/galley/types.py
+++ b/galley/types.py
@@ -1,5 +1,23 @@
 from sgqlc.types import Field, Type, Input, datetime as d, Enum
 
+class CategoryItemTypeEnum(Enum):
+    __choices__ = ('menuItem',
+                   'ingredient',
+                   'recipe',
+                   'menu',
+                   'vendorItem',
+                   'purchaseOrder')
+
+
+class Category(Type):
+    name = str
+    itemType = Field(CategoryItemTypeEnum)
+
+
+class CategoryValue(Type):
+    name = str
+    category = Field(Category)
+
 
 class Nutrition(Type):
     addedSugarG = float
@@ -70,6 +88,7 @@ class Recipe(Type):
     notes = str
     description = str
     reconciledNutritionals = Field(Nutrition)
+    categoryValues = Field(CategoryValue)
 
 
 class RecipeInstruction(Type):
@@ -95,25 +114,6 @@ class RecipeInstructionPayload(Type):
 
 class Location(Type):
     name = str
-
-
-class CategoryItemTypeEnum(Enum):
-    __choices__ = ('menuItem',
-                   'ingredient',
-                   'recipe',
-                   'menu',
-                   'vendorItem',
-                   'purchaseOrder')
-
-
-class Category(Type):
-    name = str
-    itemType = Field(CategoryItemTypeEnum)
-
-
-class CategoryValue(Type):
-    name = str
-    category = Field(Category)
 
 
 class MenuItem(Type):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='galley_sdk',
-    version='0.3.1',
+    version='0.4.0',
     packages=['galley'],
     install_requires=['sgqlc==14.0', 'mypy==0.770', 'backoff==1.11.1']
 )

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -89,6 +89,15 @@ class TestQueryRecipeNutritionData(TestCase):
             recipe(id: "cmVjaXBlOjE2NDgzMw") {
             id
             externalName
+            notes
+            description
+            categoryValues {
+            name
+            category {
+            name
+            itemType
+            }
+            }
             reconciledNutritionals {
             addedSugarG
             calciumMg
@@ -156,7 +165,7 @@ class TestQueryRecipeNutritionData(TestCase):
 
     def test_nutrition_query(self):
         query_operation = Operation(Query)
-        query_operation.viewer().recipe(id="cmVjaXBlOjE2NDgzMw").__fields__('id', 'externalName', 'reconciledNutritionals')
+        query_operation.viewer().recipe(id="cmVjaXBlOjE2NDgzMw").__fields__('id', 'externalName', 'notes', 'description', 'categoryValues', 'reconciledNutritionals')
         query_str = bytes(query_operation).decode('utf-8')
         self.assertEqual(query_str, self.expected_query)
 
@@ -170,6 +179,39 @@ class TestQueryRecipeNutritionData(TestCase):
         recipe = {
             'id': '1',
             'externalName': 'test recipe 1',
+            'notes': 'No need to heat! Eat directly from the fridge.',
+            'description': 'Inspired by the traditional Balinese dish, this salad features lots of crunchy veggies.',
+            'categoryValues': [
+                {
+                    'name': 'vegan',
+                    'category': {
+                        'itemType': 'recipe',
+                        'name': 'protein'
+                    }
+                },
+                {
+                    'name': 'TS48',
+                    'category': {
+                        'itemType': 'recipe',
+                        'name': 'meal container'
+                    }
+                },
+                {
+                    'name': 'Dinner',
+                    'category': {
+                        'itemType': 'recipe',
+                        'name': 'meal type'
+                    }
+                },
+                {
+                    'name': 'true',
+                    'category': {
+                        'itemType': 'recipe',
+                        'name': 'is perishable'
+                    }
+                }
+                
+            ],
             'reconciledNutritionals': {
                 'addedSugarG': 0,
                 'calciumMg': 111.98919574121712,


### PR DESCRIPTION
## Description
This updates get_recipe_nutrition_data() to pull in additional details about the recipe, including notes, description, and categories. Tests and mocks are updated to account for the new behavior.

## Test Plan
1) Automated tests should be green, can run with `python -m unittest tests/test_* `
2) Manual testing of get_recipe_nutrition_data() retrieval functions should return the expected data. To verify:
Open python interactive within galley-sdk: `$ python`
`>>> import galley`
`>>> galley.api_key = <API-KEY>`
`>>> galley.api_url = <STAGING-URL>`
`>>> from galley.queries import *`
`>>> get_recipe_nutrition_data('cmVjaXBlOjE3OTk1Mw==')`
