### PR TITLE
(maint) add python-dotenv and related handling for environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,17 +19,17 @@ To use galley-sdk within your application, you can install from this repository 
 pip install git+git://github.com/Thistle/galley-sdk.git@<git-ref>#egg=galley-sdk
 ```
 
+## Configuration
+First, you will need to set up credentials. Create a file called `.env` in the root directory of the project and set these two environment variables with your valid credentials for Galley's API:
+```
+GALLEY_API_KEY=<your-organization's-API-key>
+GALLEY_URL=<Galley's-staging-or-production-url>
+```
+
 ## Using galley-sdk
-After installing, you will need to set up credentials:
+Now you can use the package to make requests to Galley. For example, to retrieve recipe data:
 ```
 import galley
-
-galley.api_key = <YOUR_API_KEY>
-galley.api_url = <YOUR_API_URL>
-```
-
-Then you can use the package to access Galley's API, for example to retrieve recipe data:
-```
 from galley.queries import get_recipe_data
 
 get_recipe_data()

--- a/galley/__init__.py
+++ b/galley/__init__.py
@@ -1,3 +1,8 @@
-api_key = ''
-api_url = ''
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+api_key = os.getenv('GALLEY_API_KEY')
+api_url = os.getenv('GALLEY_URL')
 max_retries = 2

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='galley_sdk',
-    version='0.4.0',
+    version='0.5.0',
     packages=['galley'],
-    install_requires=['sgqlc==14.0', 'mypy==0.770', 'backoff==1.11.1']
+    install_requires=['sgqlc==14.0', 'mypy==0.770', 'backoff==1.11.1', 'python-dotenv==0.19.1']
 )


### PR DESCRIPTION
## Description
This adds the python-dotenv package as a requirement and updates handling of the GALLEY_API_KEY and GALLEY_URL environment variables so they can be stored and accessed from a .env file.

## Test Plan
- Add a file named `.env` to the root of the project, with the contents from [here](https://paper.dropbox.com/doc/Galley-sdk-development-.env-file--BU8FwrhliRezeQcthCA7LkklAg-TjQKmPQ7BpJJkd9y9JDo8)
- Run `python setup.py install` to bring in the new python-dotenv package
- You should now be able to access Galley data without manually setting api_key and api_url. For example:

Open python interactive within galley-sdk: `$ python`
`>>> import galley`
`>>> from galley.queries import *`
`>>> get_recipe_nutrition_data('cmVjaXBlOjE3OTk1Mw==')`
