### PR TITLE
(ENG-762) APIs to retrieve recipe ingredients from Galley

### DIFF
--- a/galley/queries.py
+++ b/galley/queries.py
@@ -45,7 +45,7 @@ def get_recipe_data() -> Optional[List[Dict]]:
     # Initiate a query
     query = Operation(Query)
     # Call sub-type you need to build the query.
-    query.viewer().recipes().__fields__('id', 'externalName', 'instructions', 'notes', 'description')
+    query.viewer.recipes.__fields__('id', 'externalName', 'instructions', 'notes', 'description')
     # pass query as an argument to make_request_to_galley function.
     raw_data = make_request_to_galley(op=query)
     return validate_response_data(raw_data, 'recipes')
@@ -73,6 +73,7 @@ def get_recipe_ingredients(recipe_id) -> Optional[List[Dict]]:
     query.viewer.recipe.recipeItems.ingredient.categoryValues.__fields__('name')
     raw_data = make_request_to_galley(op=query, variables={'id': recipe_id})
     return validate_response_data(raw_data, 'recipe')
+
 
 # Returns a Dict of main recipe ingredients and ingredients of standalone components
 # { ingredients: [], standalone_components: [] }

--- a/galley/queries.py
+++ b/galley/queries.py
@@ -9,6 +9,9 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+FOOD_PACKAGING = 'food pkg'
+STANDALONE = 'standalone'
+
 class Viewer(Type):
     recipes = Field(Recipe, args=(ArgDict({'where': FilterInput})))
     recipe = Field(Recipe, args={'id': str})
@@ -29,7 +32,7 @@ class Query(Type):
                         'externalName': str,
                         'instructions': Any,
                         'notes': Any,
-                        'description': Any
+                        'description': Any                                                
                     }]
                 }
             }
@@ -42,7 +45,7 @@ def get_recipe_data() -> Optional[List[Dict]]:
     # Initiate a query
     query = Operation(Query)
     # Call sub-type you need to build the query.
-    query.viewer().recipes().__fields__('id', 'externalName', 'instructions', 'notes', 'description')
+    query.viewer.recipes().__fields__('id', 'externalName', 'instructions', 'notes', 'description')
     # pass query as an argument to make_request_to_galley function.
     raw_data = make_request_to_galley(op=query)
     return validate_response_data(raw_data, 'recipes')
@@ -60,3 +63,55 @@ def get_week_menu_data(name: str) -> Optional[List[Dict]]:
     query.viewer().menus(where=FilterInput(name=name)).__fields__('id', 'name', 'date', 'location', 'menuItems')
     raw_data = make_request_to_galley(op=query.__to_graphql__(auto_select_depth=3), variables={'name': name})
     return validate_response_data(raw_data, 'menus')
+
+
+def get_recipe_ingredients(recipe_id) -> Optional[List[Dict]]:
+    query = Operation(Query)
+    query.viewer.recipe(id=recipe_id).__fields__('id', 'recipeItems')
+    query.viewer.recipe.recipeItems.__fields__('ingredient', 'subRecipe', 'preparations')
+    query.viewer.recipe.recipeItems.ingredient.__fields__('externalName', 'categoryValues')
+    query.viewer.recipe.recipeItems.ingredient.categoryValues.__fields__('name')
+    raw_data = make_request_to_galley(op=query, variables={'id': recipe_id})
+    return validate_response_data(raw_data, 'recipe')
+
+# Returns a Dict of main recipe ingredients and ingredients of standalone components
+# { ingredients: [], standalone_components: [] }
+# Ingredients within each list are de-duped. Packaging 'ingredients' are disregarded.
+def get_formatted_recipe_ingredients(recipe_id) -> Optional[Dict]:
+    recipe_ingredients_data = get_recipe_ingredients(recipe_id)
+    if recipe_ingredients_data:
+        recipe_items = recipe_ingredients_data['recipeItems']
+        ingredients = []
+        standalone_ingredients = []
+
+        for recipe_item in recipe_items:
+
+            # Top Level Ingredient
+            if recipe_item['ingredient']:
+                category_values = recipe_item['ingredient']['categoryValues']
+                is_packaging = next((True for cval in category_values if cval['name'] == FOOD_PACKAGING), False)
+
+                if not is_packaging and recipe_item['ingredient']['externalName'] not in ingredients: 
+                    ingredients.append(recipe_item['ingredient']['externalName'])
+
+            # SubRecipe Ingredients
+            elif recipe_item['subRecipe']:                    
+                is_standalone = False
+                item_ingredients = recipe_item['subRecipe']['allIngredients']
+                preparations = recipe_item['preparations']
+            
+                if preparations:
+                    is_standalone = next((True for prep in preparations if prep['name'] == STANDALONE), False)                        
+
+                if is_standalone:
+                    for ingredient in item_ingredients:
+                        if ingredient not in standalone_ingredients:
+                            standalone_ingredients.append(ingredient)
+                else:        
+                    for ingredient in item_ingredients:
+                        if ingredient not in ingredients:
+                            ingredients.append(ingredient)
+
+        return {'ingredients': ingredients, 'standalone_ingredients': standalone_ingredients}
+    else:
+        return None

--- a/galley/queries.py
+++ b/galley/queries.py
@@ -45,7 +45,7 @@ def get_recipe_data() -> Optional[List[Dict]]:
     # Initiate a query
     query = Operation(Query)
     # Call sub-type you need to build the query.
-    query.viewer.recipes().__fields__('id', 'externalName', 'instructions', 'notes', 'description')
+    query.viewer().recipes().__fields__('id', 'externalName', 'instructions', 'notes', 'description')
     # pass query as an argument to make_request_to_galley function.
     raw_data = make_request_to_galley(op=query)
     return validate_response_data(raw_data, 'recipes')
@@ -89,7 +89,7 @@ def get_formatted_recipe_ingredients(recipe_id) -> Optional[Dict]:
             # Top Level Ingredient
             if recipe_item['ingredient']:
                 category_values = recipe_item['ingredient']['categoryValues']
-                is_packaging = next((True for cval in category_values if cval['name'] == FOOD_PACKAGING), False)
+                is_packaging = any(cval['name'] == FOOD_PACKAGING for cval in category_values)
 
                 if not is_packaging and recipe_item['ingredient']['externalName'] not in ingredients: 
                     ingredients.append(recipe_item['ingredient']['externalName'])
@@ -101,7 +101,7 @@ def get_formatted_recipe_ingredients(recipe_id) -> Optional[Dict]:
                 preparations = recipe_item['preparations']
             
                 if preparations:
-                    is_standalone = next((True for prep in preparations if prep['name'] == STANDALONE), False)                        
+                    is_standalone = any(prep['name'] == STANDALONE for prep in preparations)                       
 
                 if is_standalone:
                     for ingredient in item_ingredients:

--- a/galley/queries.py
+++ b/galley/queries.py
@@ -65,7 +65,7 @@ def get_week_menu_data(name: str) -> Optional[List[Dict]]:
     return validate_response_data(raw_data, 'menus')
 
 
-def get_recipe_ingredients(recipe_id) -> Optional[List[Dict]]:
+def get_recipe_ingredients(recipe_id) -> Optional[Dict]:
     query = Operation(Query)
     query.viewer.recipe(id=recipe_id).__fields__('id', 'recipeItems')
     query.viewer.recipe.recipeItems.__fields__('ingredient', 'subRecipe', 'preparations')

--- a/galley/types.py
+++ b/galley/types.py
@@ -81,6 +81,26 @@ class Nutrition(Type):
     zincPercentRDI = float
 
 
+
+class Ingredient(Type):
+    externalName = str
+    categoryValues = Field(CategoryValue)
+
+
+class SubRecipe(Type):
+    allIngredients = str
+
+
+class Preparation(Type):
+    name = str
+
+
+class RecipeItem(Type):
+    ingredient = Field(Ingredient)
+    subRecipe = Field(SubRecipe)
+    preparations = Field(Preparation)
+
+
 class Recipe(Type):
     id = str
     externalName = str
@@ -89,6 +109,7 @@ class Recipe(Type):
     description = str
     reconciledNutritionals = Field(Nutrition)
     categoryValues = Field(CategoryValue)
+    recipeItems = Field(RecipeItem)
 
 
 class RecipeInstruction(Type):

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -432,96 +432,96 @@ class TestQueryRecipeIngredients(TestCase):
 
     def setUp(self) -> None:
         self.recipe = {
-            "id": "1",
-            "recipeItems": [
+            'id': '1',
+            'recipeItems': [
             {
-                "ingredient": None,
-                "subRecipe": {
-                "allIngredients": [
-                    "Unique 1",
-                    "Unique 2",
-                    "Duplicate 1",
-                    "Duplicate 2",
-                    "Duplicate 3"
+                'ingredient': None,
+                'subRecipe': {
+                'allIngredients': [
+                    'Unique 1',
+                    'Unique 2',
+                    'Duplicate 1',
+                    'Duplicate 2',
+                    'Duplicate 3'
                 ]
                 },
-                "preparations": []
+                'preparations': []
             },
             {
-                "ingredient": None,
-                "subRecipe": {
-                "allIngredients": [
-                    "Unique 3",
-                    "Duplicate 1",
-                    "Duplicate 2"                    
+                'ingredient': None,
+                'subRecipe': {
+                'allIngredients': [
+                    'Unique 3',
+                    'Duplicate 1',
+                    'Duplicate 2'                    
                 ]
                 },
-                "preparations": []
+                'preparations': []
             },
             {
-                "ingredient": None,
-                "subRecipe": {
-                "allIngredients": [
-                    "Unique 4",                               
-                    "Duplicate 2",
-                    "Duplicate 3"
+                'ingredient': None,
+                'subRecipe': {
+                'allIngredients': [
+                    'Unique 4',                               
+                    'Duplicate 2',
+                    'Duplicate 3'
                 ]
                 },
-                "preparations": [
+                'preparations': [
                 {
-                    "name": "2 oz RAM"                    
+                    'name': '2 oz RAM'                    
                 },
                 {
-                    "name": "standalone"                
+                    'name': 'standalone'                
                 }
                 ]
             },
             {
-                "ingredient": {
-                "externalName": "Unique 5",
-                "categoryValues": [
+                'ingredient': {
+                'externalName': 'Unique 5',
+                'categoryValues': [
                     {
-                    "name": "send to plate",
-                    "category": {
-                        "itemType": "ingredient"
+                    'name': 'send to plate',
+                    'category': {
+                        'itemType': 'ingredient'
                     }
                     },
                     {
-                    "name": None,           # Test empty categoryValue['name']
-                    "category": {
-                        "itemType": None    # Test empty category['itemType']
+                    'name': None,           # Test empty categoryValue['name']
+                    'category': {
+                        'itemType': None    # Test empty category['itemType']
                     }
                     }
                 ]
                 },
-                "subRecipe": None,
-                "preparations": [                    
+                'subRecipe': None,
+                'preparations': [                    
                 {
-                    "name": None            # Test empty preparations['name']
+                    'name': None            # Test empty preparations['name']
                 }
                 ]
             },
             {
-                "ingredient": {
-                "externalName": "32 oz Meal Boxes",
-                "categoryValues": [
+                'ingredient': {
+                'externalName': '32 oz Meal Boxes',
+                'categoryValues': [
                     {
-                    "name": "food pkg",
-                    "category": {
-                        "itemType": "ingredient"
+                    'name': 'food pkg',
+                    'category': {
+                        'itemType': 'ingredient'
                     }
                     }
                 ]
                 },
-                "subRecipe": None,
-                "preparations": []
+                'subRecipe': None,
+                'preparations': []
             },
             
             # Test empty recipeItem
             {
-                "ingredient": None,
-                "subRecipe": None,
-                "preparations": []
+                'ingredient': None,
+                'subRecipe': None,
+                'preparations': []
             }
             ]
         }
@@ -552,18 +552,18 @@ class TestQueryRecipeIngredients(TestCase):
     def test_get_formatted_recipe_ingredients_successful(self, mock_retrieval_method):
         expected_result = { 
             'ingredients': [
-                "Unique 1",
-                "Unique 2",
-                "Duplicate 1",
-                "Duplicate 2",
-                "Duplicate 3",
-                "Unique 3",
-                "Unique 5"
+                'Unique 1',
+                'Unique 2',
+                'Duplicate 1',
+                'Duplicate 2',
+                'Duplicate 3',
+                'Unique 3',
+                'Unique 5'
             ],
             'standalone_ingredients': [
-                "Unique 4",                               
-                "Duplicate 2",
-                "Duplicate 3"
+                'Unique 4',                               
+                'Duplicate 2',
+                'Duplicate 3'
             ]
         }
         mock_retrieval_method.return_value = {
@@ -591,8 +591,8 @@ class TestQueryRecipeIngredients(TestCase):
             'data': {
                 'viewer': {
                     'recipe': {
-                        "id": "3",
-                        "recipeItems": []
+                        'id': '3',
+                        'recipeItems': []
                     }
                 }
             }

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -1,5 +1,4 @@
 from unittest import mock, TestCase
-from unittest.case import expectedFailure
 from sgqlc.operation import Operation
 
 from galley.queries import Query, get_recipe_data, get_recipe_nutrition_data, \

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -485,11 +485,21 @@ class TestQueryRecipeIngredients(TestCase):
                     "category": {
                         "itemType": "ingredient"
                     }
+                    },
+                    {
+                    "name": None,           # Test empty categoryValue['name']
+                    "category": {
+                        "itemType": None    # Test empty category['itemType']
+                    }
                     }
                 ]
                 },
                 "subRecipe": None,
-                "recipeItemPreparations": []
+                "preparations": [                    
+                {
+                    "name": None            # Test empty preparations['name']
+                }
+                ]
             },
             {
                 "ingredient": {
@@ -505,7 +515,15 @@ class TestQueryRecipeIngredients(TestCase):
                 },
                 "subRecipe": None,
                 "preparations": []
-            }]
+            },
+            
+            # Test empty recipeItem
+            {
+                "ingredient": None,
+                "subRecipe": None,
+                "preparations": []
+            }
+            ]
         }
 
 


### PR DESCRIPTION
## Description
Added galley-sdk methods for retrieving recipe ingredients.
get_recipe_ingredients returns the raw graphql objects for the recipe's ingredients.
get_formatted_recipe_ingredients separates the ingredients into ingredients (ingredients
for the main recipe) and standalone_ingredients (ingredients for any standalone components).
The formatted ingredients list removes all packaging "ingredients" and de-dups ingredients
within each list.

One question I have: There were several places where we made the query using viewer(), but my understanding is that adding the () returns all possible fields. That didn't seem desirable, so I removed the parentheses, but want a sanity check that my understanding is correct. (I can add them back in if that's the correct usage)

## Test Plan
- Check that tests pass
- Run the following in python interactive to sanity check that it is correctly handling packaging, standalone components, and top-level ingredients correctly:

```
import pprint; import galley; 
from galley.queries import *
raw_data = get_recipe_ingredients("cmVjaXBlOjE3OTk1Mw==")
formatted_data = get_formatted_recipe_ingredients("cmVjaXBlOjE3OTk1Mw==")
```

This is the recipe tested above (it has packaging, duplicate ingredients, and a standalone component): https://staging-app.galleysolutions.com/recipes/cmVjaXBlOjE3OTk1Mw==

A recipe that has a top-level ingredient has id "cmVjaXBlOjE3Mjg4Mg==" (https://staging-app.galleysolutions.com/recipes/cmVjaXBlOjE3Mjg4Mg==)
