### PR TITLE
(ENG-796) Retrieve batched nutritional data

### DIFF
--- a/galley/queries.py
+++ b/galley/queries.py
@@ -55,11 +55,12 @@ def get_recipe_nutrition_data(recipe_ids: list) -> Optional[Dict]:
         query = Operation(Query)
         query.viewer().recipe(id=recipe_id).__fields__('id', 'externalName', 'notes', 'description', 'categoryValues', 'reconciledNutritionals')
         raw_data = make_request_to_galley(op=query, variables={'id': recipe_id})
-        recipes.setdefault(recipe_id, validate_response_data(raw_data, 'recipe'))
-    return recipes
+        if validate_response_data(raw_data, 'recipe'):
+            recipes.setdefault(recipe_id, validate_response_data(raw_data, 'recipe'))
+    return recipes if recipes else None
 
 
-def get_week_menu_data(name: str) -> Optional[List[Dict]]:
+def get_week_menu_data(name: str) -> Optional[List]:
     query = Operation(Query)
     query.viewer().menus(where=MenuNameInput(name=name)).__fields__('id', 'name', 'date', 'location', 'menuItems')
     raw_data = make_request_to_galley(op=query.__to_graphql__(auto_select_depth=3), variables={'name': name})

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -52,6 +52,7 @@ class TestQueryRecipes(TestCase):
                 'description': None
             }
         ]
+
         mock_retrieval_method.return_value = {
             'data': {
                 'viewer': {
@@ -72,6 +73,7 @@ class TestQueryRecipes(TestCase):
                 }
             }
         }
+
         result = get_recipe_data()
         self.assertEqual(result, None)
 
@@ -177,10 +179,10 @@ class TestQueryRecipeNutritionData(TestCase):
     @mock.patch('galley.queries.make_request_to_galley')
     def test_get_recipe_nutrition_data_successful(self, mock_retrieval_method):
         recipe = {
-            'id': '1',
-            'externalName': 'test recipe 1',
-            'notes': 'No need to heat! Eat directly from the fridge.',
-            'description': 'Inspired by the traditional Balinese dish, this salad features lots of crunchy veggies.',
+            'id': 'recipeID',
+            'externalName': 'Test Recipe Name',
+            'notes': 'Notes on how to cook this meal.',
+            'description': 'Description of this delicious recipe.',
             'categoryValues': [
                 {
                     'name': 'vegan',
@@ -210,7 +212,6 @@ class TestQueryRecipeNutritionData(TestCase):
                         'name': 'is perishable'
                     }
                 }
-                
             ],
             'reconciledNutritionals': {
                 'addedSugarG': 0,
@@ -275,7 +276,7 @@ class TestQueryRecipeNutritionData(TestCase):
             }
         }
 
-        mock_retrieval_method.return_value = {
+        return1 = {
             'data': {
                 'viewer': {
                     'recipe': recipe
@@ -283,8 +284,28 @@ class TestQueryRecipeNutritionData(TestCase):
             }
         }
 
-        result = get_recipe_nutrition_data('1')
-        self.assertEqual(result, recipe)
+        return2 = {
+            'data': {
+                'viewer': {
+                    'recipe': None
+                }
+            }
+        }
+
+        mock_retrieval_method.side_effect = [return1, return2, return1, return1, return1]
+
+        # test with one valid input and one invalid input
+        result1 = get_recipe_nutrition_data(['1', '2'])
+        self.assertEqual(result1, {'1': recipe})
+
+        # test with one valid input
+        result2 = get_recipe_nutrition_data(['1'])
+        self.assertEqual(result2, {'1': recipe})
+
+        # test with multiple valid input
+        result3 = get_recipe_nutrition_data(['1', '2'])
+        self.assertEqual(result3, {'1': recipe, '2': recipe})
+
 
     @mock.patch('galley.queries.make_request_to_galley')
     def test_get_recipe_nutrition_data_validation_failure(self, mock_retrieval_method):
@@ -295,13 +316,14 @@ class TestQueryRecipeNutritionData(TestCase):
                 }
             }
         }
-        result = get_recipe_nutrition_data('1')
+
+        result = get_recipe_nutrition_data(['1'])
         self.assertEqual(result, None)
 
     @mock.patch('galley.queries.make_request_to_galley')
     def test_nutrition_data_null(self, mock_retrieval_method):
         mock_retrieval_method.return_value = None
-        result = get_recipe_nutrition_data('2')
+        result = get_recipe_nutrition_data(['2'])
         self.assertEqual(result, None)
 
 
@@ -372,6 +394,7 @@ class TestQueryWeekMenuData(TestCase):
             },
 
         ]
+
         mock_retrieval_method.return_value = {
             'data': {
                 'viewer': {
@@ -392,6 +415,7 @@ class TestQueryWeekMenuData(TestCase):
                 }
             }
         }
+
         result = get_week_menu_data('YYYY-MM-DD 1_2_3')
         self.assertEqual(result, None)
 


### PR DESCRIPTION
## Description
This PR focuses on refactoring our original function to retrieve nutritional data to take in a list of `recipe_ids` in order to retrieve nutritional data for many recipes at once. 

## Test Plan
Open python interactive within galley-sdk: `$ python`
`>>> from pprint import pprint` (optional: to apply pretty print format to returned data)
`>>> from galley.queries import *` 

### With all valid recipe ids passed in:
`>>> pprint(get_recipe_nutrition_data(['cmVjaXBlOjE2NzEwOQ==','cmVjaXBlOjE2OTEyMg==', 'cmVjaXBlOjE2NTY5MA==']))`

> **Expectation:** A dictionary return value similar to:
> ```python3
> { 
>   'cmVjaXBlOjE2NTY5MA==':  {
>       'categoryValues': [{...}],
>       'description': ...,
>       'externalName': ...,
>       'id': 'cmVjaXBlOjE2NTY5MA==',
>       'notes': ...,
>       'reconciledNutritionals': {...}
>   },
>   'cmVjaXBlOjE2NzEwOQ==':  {
>       'categoryValues': [{...}],
>       'description': ...,
>       'externalName': ...,
>       'id': 'cmVjaXBlOjE2NzEwOQ==',
>       'notes': ...,
>       'reconciledNutritionals': {...}
>   },
>   'cmVjaXBlOjE2OTEyMg==':  {
>       'categoryValues': [{...}],
>       'description': ...,
>       'externalName': ...,
>       'id': 'cmVjaXBlOjE2OTEyMg==',
>       'notes': ...,
>       'reconciledNutritionals': {...}
>   }
> }
> ```

### With an invalid recipe id passed in:
`>>> pprint(get_recipe_nutrition_data(['cmVjaXBlOjE2NzEwOQ==','cmVjaXBlOjE2OTEyMg==', 'cmVjaXBlOjE2NTY5MA==', 'invalidRecipeID==']))`

> **Expectation:**
> 1.) Return value same as above for all valid recipe ids passed in
> 2.) A GalleyError log messsage for any invalid ids passed in:
> ```
> GraphQL query failed with 1 errors
> (GalleyError) Error retrieving response data: [{'message': 'Invalid id', ...
> ```

### Run unittests
Exit python interactive and stay within the galley-sdk directory to run tests:
`(galley-env) $ python -m unittest tests/test_queries.py`