### PR TITLE
(ENG-837) Retrieve batched weekly menu data

### DIFF
--- a/galley/types.py
+++ b/galley/types.py
@@ -1,4 +1,4 @@
-from sgqlc.types import Field, Type, Input, datetime as d, Enum, ID
+from sgqlc.types import Field, Type, Input, datetime as d, Enum, ID, list_of
 
 class CategoryItemTypeEnum(Enum):
     __choices__ = ('menuItem',
@@ -81,7 +81,6 @@ class Nutrition(Type):
     zincPercentRDI = float
 
 
-
 class Ingredient(Type):
     externalName = str
     categoryValues = Field(CategoryValue)
@@ -152,4 +151,4 @@ class Menu(Type):
 
 class FilterInput(Input):
     id = ID
-    name = str
+    name = list_of(str)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # are dependencies that are required on remote installs, not local development.
 setup(
     name='galley_sdk',
-    version='0.7.0',
+    version='0.8.0',
     packages=['galley'],
     install_requires=['sgqlc==14.0', 'backoff==1.11.1']
 )


### PR DESCRIPTION
## Description
This PR focuses on refactoring our original function `get_week_menu_data` to take in a list of menu names so that only one request is sent to Galley for batched weekly menu data.

## Test Plan
Open python interactive within galley-sdk: `$ python`
`>>> from pprint import pprint` (optional: to apply pretty print format to returned data)
`>>> from galley.queries import *` 

### With all valid menu names passed in:
`>>> pprint(get_week_menu_data(["2021-10-04 1_2_3", "2021-10-04 4_5_6", "2021-10-25 1_2_3", "2021-10-25 4_5_6"]))`

> **Expectation:** A dictionary return value similar to:
> ```python3
> [{
>    "name": "2021-10-04 1_2_3",
>    "id": "bWVudTo2MzQ2NTY=",
>    "date": "2021-10-04",
>    "location": {"name": "Vacaville"},
>    "menuItems": [{
>       "recipeId": "cmVjaXBlOjE3NDc5MA==",
>       "categoryValues": [{
>          "name": "side",
>          "category": {"itemType": "menuItem", "name": "menu item type"}
>       }]
>    }, { 
>       ... 
>    }]
>  }, {
>    "name": "2021-10-04 4_5_6",
>    "id": "bWVudTo2MzQ2NjM=",
>    "date": "2021-10-07",
>    "location": {"name": "Vacaville"},
>    "menuItems": [{
>       "recipeId": "cmVjaXBlOjE3NDc5Nw==",
>       "categoryValues": [{
>          "name": "side",
>          "category": {"itemType": "menuItem", "name": "menu item type"}
>       }]
>    }, {
>       ... 
>    }]
>  }, {
>    "name": "2021-10-25 1_2_3",
>    "id": "bWVudTo3NjM2MjA=",
>    "date": "2021-10-25",
>    "location": {"name": "Vacaville"},
>    "menuItems": [{
>       "recipeId": "cmVjaXBlOjE2NTY5MA==",
>       "categoryValues": [{
>          "name": "b3a",
>          "category": {"itemType": "menuItem", "name": "menu item type"}
>       }]
>    }, { 
>       ... 
>    }]
>  }, {
>    "name": "2021-10-25 4_5_6",
>    "id": "bWVudTo4MjY0NTE=",
>    "date": "2021-10-28",
>    "location": {"name": "Vacaville"},
>    "menuItems": [{
>       "recipeId": "cmVjaXBlOjE4MTgxMA==",
>       "categoryValues": [{
>          "name": "b4",
>          "category": {"itemType": "menuItem", "name": "menu item type"}
>       }]
>    }, { 
>       ... 
>    }]
>  }]
>```

### With an invalid menu name passed in:
`>>> pprint(get_week_menu_data(["2021-10-04 1_2_3", "2021-10-04 4_5_6", "invalid-menu-name 4_5_6"]))`

> **Expectation:**
> Return value should be the same as the one above for all valid recipe ids passed in; any invalid ids will be ignored and no error should return

`>>> pprint(get_week_menu_data(["invalid-menu-name 4_5_6"]))`

> **Expectation:**
> Return value of `[]`

### Run unittests
Exit python interactive and stay within the galley-sdk directory to run tests:
`(galley-env) $ python -m unittest tests/test_queries.py`

## Versioning
v0.7.0 -> v0.8.0
