### PR TITLE
(ENG-825) Add recipeItems to week menu data retrieval

### DIFF
--- a/galley/queries.py
+++ b/galley/queries.py
@@ -67,6 +67,10 @@ def get_week_menu_data(names: list) -> Optional[List[Dict]]:
     query.viewer.menus(where=FilterInput(name=names)).__fields__(
         'id', 'name', 'date', 'location', 'menuItems'
     )
+    query.viewer.menus.menuItems.__fields__('recipeId', 'categoryValues', 'recipe')
+    query.viewer.menus.menuItems.recipe.__fields__('externalName', 'recipeItems')
+    query.viewer.menus.menuItems.recipe.recipeItems.__fields__('subRecipeId', 'preparations')
+    query.viewer.menus.menuItems.recipe.recipeItems.preparations.__fields__('name')
     raw_data = make_request_to_galley(op=query.__to_graphql__(auto_select_depth=3), variables={'name': names})
     return validate_response_data(raw_data, 'menus')
 

--- a/galley/types.py
+++ b/galley/types.py
@@ -97,6 +97,7 @@ class Preparation(Type):
 class RecipeItem(Type):
     ingredient = Field(Ingredient)
     subRecipe = Field(SubRecipe)
+    subRecipeId = str
     preparations = Field(Preparation)
 
 
@@ -139,6 +140,7 @@ class Location(Type):
 class MenuItem(Type):
     recipeId = str
     categoryValues = Field(CategoryValue)
+    recipe = Field(Recipe)
 
 
 class Menu(Type):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # are dependencies that are required on remote installs, not local development.
 setup(
     name='galley_sdk',
-    version='0.8.0',
+    version='0.9.0',
     packages=['galley'],
     install_requires=['sgqlc==14.0', 'backoff==1.11.1']
 )

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -351,6 +351,15 @@ class TestQueryWeekMenuData(TestCase):
             itemType
             }
             }
+            recipe {
+            externalName
+            recipeItems {
+            subRecipeId
+            preparations {
+            name
+            }
+            }
+            }
             }
             }
             }
@@ -358,7 +367,13 @@ class TestQueryWeekMenuData(TestCase):
 
     def test_week_menu_data_query(self):
         query_operation = Operation(Query)
-        query_operation.viewer().menus(where=FilterInput(name=["2021-10-04 1_2_3", "2021-10-04 4_5_6"])).__fields__('id', 'name', 'date', 'location', 'menuItems')
+        query_operation.viewer().menus(where=FilterInput(name=["2021-10-04 1_2_3", "2021-10-04 4_5_6"])).__fields__(
+            'id', 'name', 'date', 'location', 'menuItems'
+        )
+        query_operation.viewer.menus.menuItems.__fields__('recipeId', 'categoryValues', 'recipe')
+        query_operation.viewer.menus.menuItems.recipe.__fields__('externalName', 'recipeItems')
+        query_operation.viewer.menus.menuItems.recipe.recipeItems.__fields__('subRecipeId', 'preparations')
+        query_operation.viewer.menus.menuItems.recipe.recipeItems.preparations.__fields__('name')
         query_str = query_operation.__to_graphql__(auto_select_depth=3)
         self.assertEqual(query_str.replace(' ', ''), self.expected_query.replace(' ', ''))
 
@@ -382,6 +397,15 @@ class TestQueryWeekMenuData(TestCase):
                                 'name': 'menu item type'
                             }
                         }],
+                        'recipe': {
+                            'externalName': 'Test Recipe Name 1',
+                            'recipeItems': [{
+                                'preparations': [
+                                    {'name':  'standalone'}
+                                ],
+                                'subRecipeId': 'SUBRECIPEID456'
+                            }]
+                        },
                     },
                     {
                         'recipeId': 'RECIPE2DEF',
@@ -392,6 +416,15 @@ class TestQueryWeekMenuData(TestCase):
                                 'name': 'menu item type'
                             }
                         }],
+                        'recipe': {
+                            'externalName': 'Test Recipe Name 2',
+                            'recipeItems': [{
+                                'preparations': [
+                                    {'name':  'standalone'}
+                                ],
+                                'subRecipeId': 'SUBRECIPEID789'
+                            }]
+                        },
                     },
                 ]
             }) if name.split()[0] != '21-12-05' else []


### PR DESCRIPTION
## Description
This PR focuses on updating the `get_week_menu_data` function to retrieve specific fields from `recipeItems`; more specifically, the `subRecipeId` and the `name` objects from `preparations` list.

## Test Plan
Open python interactive within galley-sdk: `$ python`
`>>> from pprint import pprint` (optional: to apply pretty print format to returned data)
`>>> from galley.queries import *` 

### With all valid menu names passed in:
`>>> pprint(get_week_menu_data(["2021-10-25 4_5_6"]))`

> **Expectation:** A return value **similar** to:
> ```python3
> [{
>    "name": "2021-10-25 4_5_6",
>    "id": "bWVudTo4MjY0NTE=",
>    "date": "2021-10-28",
>    "location": {"name": "Vacaville"},
>    "menuItems": [{
>       "recipeId": "cmVjaXBlOjE3NDc5MA==",
>       "categoryValues": [{
>          "name": "lv4",
>          "category": {"itemType": "menuItem", "name": "menu item type"}
>       }],
>       "recipe": {
>          "externalName": None,
>          "recipeItems": [{
>             "preparations": [],
>             "subRecipeId": "cmVjaXBlOjE4MDkzOA=="
>          }, {
>             "preparations": [{"name": "3.25 oz RAM"}],
>             "subRecipeId": "cmVjaXBlOjE3NDI1OQ=="
>          }, { 
>             ...
>          }]
>       }
>    }]  
> }]
>```

### Run unittests
Exit python interactive and stay within the galley-sdk directory to run tests:
`(galley-env) $ python -m unittest tests/test_queries.py`
**[OPTIONAL SANITY CHECK]** `(galley-env) $ python -m unittest tests/test_*.py`

## Versioning
v0.8.0 -> v0.9.0
