### PR TITLE
(ENG-822) Format menu data

### DIFF
--- a/galley/common.py
+++ b/galley/common.py
@@ -73,6 +73,7 @@ def validate_response_data(data, *fields):
         logger.error(f"{GALLEY_ERROR_PREFIX} Error retrieving response data")
         return None
 
+
 def validate_fields(data, keys):
     _data = data
     for key in keys:
@@ -82,6 +83,7 @@ def validate_fields(data, keys):
             logger.error(f"{GALLEY_ERROR_PREFIX} Error retrieving '{key}' data")
             return None
     return _data
+
 
 def validate_response_data_structure(forecasted_data_struct: Any, response_data: Any) -> bool:
     if isinstance(forecasted_data_struct, dict) and isinstance(response_data, dict):
@@ -100,4 +102,3 @@ def validate_response_data_structure(forecasted_data_struct: Any, response_data:
         return True
     else:
         return False
-

--- a/galley/formatted_queries.py
+++ b/galley/formatted_queries.py
@@ -1,10 +1,11 @@
 from typing import Dict, Optional, List
 
-from galley.queries import get_raw_recipes_data
+from galley.queries import get_raw_recipes_data, get_raw_menu_data
 from galley.pagination import paginate_results
 
 FOOD_PACKAGING = 'food pkg'
 STANDALONE = 'standalone'
+
 
 def ingredients_from_recipe_items(recipe_items: List[Dict]) -> Optional[List]:
     ingredients = []
@@ -35,9 +36,22 @@ def ingredients_from_recipe_items(recipe_items: List[Dict]) -> Optional[List]:
                 for ingredient in item_ingredients:
                     if ingredient not in ingredients:
                         ingredients.append(ingredient)
-
     return ingredients
 
+
+# Returns the subRecipeId if any 'standalone' item exists within recipeItems, else returns None
+# It is assumed that there is a max of ONE standalone item within the list of recipeItems, if any.
+def get_standalone(recipe_items):
+    for recipe_item in recipe_items:
+        preparations = recipe_item.get('preparations', [])
+        is_standalone = any(prep['name'] == STANDALONE for prep in preparations)
+
+        if is_standalone:
+            return recipe_item.get('subRecipeId')
+    return None
+
+
+# DATA TRANSFORMATION FUNCTIONS
 
 @paginate_results()
 def get_formatted_recipes_data(recipe_ids: List[str]) -> Optional[List[Dict]]:
@@ -68,5 +82,35 @@ def get_formatted_recipes_data(recipe_ids: List[str]) -> Optional[List[Dict]]:
         formatted_recipe['ingredients'] = ingredients_from_recipe_items(recipe_items=recipe_items)
 
         formatted_recipes.append(formatted_recipe)
-
     return formatted_recipes
+
+
+@paginate_results()
+def get_formatted_menu_data(names: list) -> Optional[List[Dict]]:
+    menus = get_raw_menu_data(names)
+    formatted_menus = []
+
+    if not menus:
+        return None
+
+    for menu in menus:
+        formatted_menu = ({
+            'name': menu.get('name'),
+            'id': menu.get('id'),
+            'date': menu.get('date'),
+            'location': menu['location'].get('name'),
+            'menuItems': []
+        }) # type: Dict
+
+        menu_items = menu.get('menuItems', [])
+        for menu_item in menu_items:
+            recipe_items = menu_item.get('recipe', {}).get('recipeItems', [])
+
+            formatted_menu['menuItems'].append({
+                'itemCode': next((cv.get('name') for cv in menu_item['categoryValues']), None),
+                'recipeId': menu_item.get('recipeId'),
+                'standaloneRecipeId': get_standalone(recipe_items)
+            })
+
+        formatted_menus.append(formatted_menu)
+    return formatted_menus

--- a/galley/formatted_queries.py
+++ b/galley/formatted_queries.py
@@ -31,11 +31,11 @@ def ingredients_from_recipe_items(recipe_items: List[Dict]) -> Optional[List]:
             if preparations:
                 is_standalone = any(prep.get('name') == STANDALONE for prep in preparations)
 
-            if not is_standalone:                    
+            if not is_standalone:
                 for ingredient in item_ingredients:
                     if ingredient not in ingredients:
                         ingredients.append(ingredient)
-    
+
     return ingredients
 
 
@@ -43,7 +43,7 @@ def ingredients_from_recipe_items(recipe_items: List[Dict]) -> Optional[List]:
 def get_formatted_recipes_data(recipe_ids: List[str]) -> Optional[List[Dict]]:
     recipes_data = get_raw_recipes_data(recipe_ids=recipe_ids) or []
     formatted_recipes = []
-    
+
     for recipe in recipes_data:
         formatted_recipe = {
             'id': recipe.get('id'),
@@ -66,7 +66,7 @@ def get_formatted_recipes_data(recipe_ids: List[str]) -> Optional[List[Dict]]:
 
         recipe_items = recipe.get('recipeItems', [])
         formatted_recipe['ingredients'] = ingredients_from_recipe_items(recipe_items=recipe_items)
-        
+
         formatted_recipes.append(formatted_recipe)
 
     return formatted_recipes

--- a/galley/pagination.py
+++ b/galley/pagination.py
@@ -25,11 +25,11 @@ def paginate_results(page_size=25):
                 return result
 
             for partition in range((len(input_list) // page_size) + 1):
-                try:
-                    chunk = input_list[partition * page_size: (partition + 1) * page_size]
-                    result.extend(func(chunk)) if len(chunk) > 0 else None
-                except Exception as e:
-                    logger.error(e)
+                chunk = input_list[partition * page_size: (partition + 1) * page_size]
+                funk = func(chunk) if chunk else None
+                if funk:
+                    result.extend(funk)
+
             return result
         return wrapper
     return decorating_function

--- a/galley/pagination.py
+++ b/galley/pagination.py
@@ -25,9 +25,11 @@ def paginate_results(page_size=25):
                 return result
 
             for partition in range((len(input_list) // page_size) + 1):
-                chunk = input_list[partition * page_size: (partition + 1) * page_size]
-                result.extend(func(chunk)) if len(chunk) > 0 else None
-
+                try:
+                    chunk = input_list[partition * page_size: (partition + 1) * page_size]
+                    result.extend(func(chunk)) if len(chunk) > 0 else None
+                except Exception as e:
+                    logger.error(e)
             return result
         return wrapper
     return decorating_function

--- a/galley/queries.py
+++ b/galley/queries.py
@@ -81,3 +81,45 @@ def get_week_menu_data(names: list) -> Optional[List[Dict]]:
     raw_data = make_request_to_galley(op=query.__to_graphql__(auto_select_depth=3), variables={'name': names})
     return validate_response_data(raw_data, 'menus')
 
+
+def get_formatted_menu_data(names: list) -> Optional[List[Dict]]:
+    menus = get_week_menu_data(names)
+    formatted_menus = []
+
+    if not menus:
+        return None
+
+    for menu in menus:
+        formatted_menu = ({
+            'name': menu.get('name'),
+            'id': menu.get('id'),
+            'date': menu.get('date'),
+            'location': menu['location'].get('name'),
+            'menuItems': []
+        }) # type: Dict
+
+        menu_items = menu.get('menuItems', [])
+
+        for menu_item in menu_items:
+            recipe_items = menu_item.get('recipe', {}).get('recipeItems', [])
+
+            formatted_menu['menuItems'].append({
+                'itemCode': next((cv.get('name') for cv in menu_item['categoryValues']), None),
+                'recipeId': menu_item.get('recipeId'),
+                'standaloneRecipeId': get_standalone(recipe_items)
+            })
+
+        formatted_menus.append(formatted_menu)
+    return formatted_menus
+
+
+# Returns the subRecipeId if any 'standalone' item exists within recipeItems, else returns None
+# It is assumed that there is a max of ONE standalone item within the list of recipeItems, if any.
+def get_standalone(recipe_items):
+    for recipe_item in recipe_items:
+        preparations = recipe_item.get('preparations', [])
+        is_standalone = any(prep['name'] == 'standalone' for prep in preparations)
+
+        if is_standalone:
+            return recipe_item.get('subRecipeId')
+    return None

--- a/galley/queries.py
+++ b/galley/queries.py
@@ -9,8 +9,6 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-
-
 class Viewer(Type):
     recipes = Field(Recipe, args=(ArgDict({'where': FilterInput})))
     recipe = Field(Recipe, args={'id': str})
@@ -60,8 +58,8 @@ def recipes_data_query(recipe_ids: List[str]) -> Optional[Operation]:
     query.viewer.recipe.recipeItems.__fields__('ingredient', 'subRecipe', 'preparations')
     query.viewer.recipe.recipeItems.ingredient.__fields__('externalName', 'categoryValues')
     query.viewer.recipe.recipeItems.ingredient.categoryValues.__fields__('name')
-
     return query
+
 
 def get_raw_recipes_data(recipe_ids: List[str]) -> Optional[List[Dict]]:
     query = recipes_data_query(recipe_ids=recipe_ids)
@@ -99,7 +97,6 @@ def get_formatted_menu_data(names: list) -> Optional[List[Dict]]:
         }) # type: Dict
 
         menu_items = menu.get('menuItems', [])
-
         for menu_item in menu_items:
             recipe_items = menu_item.get('recipe', {}).get('recipeItems', [])
 

--- a/galley/queries.py
+++ b/galley/queries.py
@@ -82,6 +82,6 @@ def menu_data_query(names: List[str]) -> Optional[Operation]:
 
 
 def get_raw_menu_data(names: List[str]) -> Optional[List[Dict]]:
-    query = menu_data_query(names=names)
+    query = menu_data_query(names=names) # type: Operation
     raw_data = make_request_to_galley(op=query.__to_graphql__(auto_select_depth=3), variables={'name': names})
     return validate_response_data(raw_data, 'menus')

--- a/galley/queries.py
+++ b/galley/queries.py
@@ -67,7 +67,9 @@ def get_raw_recipes_data(recipe_ids: List[str]) -> Optional[List[Dict]]:
     return validate_response_data(raw_data, 'recipes')
 
 
-def get_week_menu_data(names: list) -> Optional[List[Dict]]:
+# MENU QUERIES
+
+def menu_data_query(names: List[str]) -> Optional[Operation]:
     query = Operation(Query)
     query.viewer.menus(where=FilterInput(name=names)).__fields__(
         'id', 'name', 'date', 'location', 'menuItems'
@@ -76,47 +78,10 @@ def get_week_menu_data(names: list) -> Optional[List[Dict]]:
     query.viewer.menus.menuItems.recipe.__fields__('externalName', 'recipeItems')
     query.viewer.menus.menuItems.recipe.recipeItems.__fields__('subRecipeId', 'preparations')
     query.viewer.menus.menuItems.recipe.recipeItems.preparations.__fields__('name')
+    return query
+
+
+def get_raw_menu_data(names: List[str]) -> Optional[List[Dict]]:
+    query = menu_data_query(names=names)
     raw_data = make_request_to_galley(op=query.__to_graphql__(auto_select_depth=3), variables={'name': names})
     return validate_response_data(raw_data, 'menus')
-
-
-def get_formatted_menu_data(names: list) -> Optional[List[Dict]]:
-    menus = get_week_menu_data(names)
-    formatted_menus = []
-
-    if not menus:
-        return None
-
-    for menu in menus:
-        formatted_menu = ({
-            'name': menu.get('name'),
-            'id': menu.get('id'),
-            'date': menu.get('date'),
-            'location': menu['location'].get('name'),
-            'menuItems': []
-        }) # type: Dict
-
-        menu_items = menu.get('menuItems', [])
-        for menu_item in menu_items:
-            recipe_items = menu_item.get('recipe', {}).get('recipeItems', [])
-
-            formatted_menu['menuItems'].append({
-                'itemCode': next((cv.get('name') for cv in menu_item['categoryValues']), None),
-                'recipeId': menu_item.get('recipeId'),
-                'standaloneRecipeId': get_standalone(recipe_items)
-            })
-
-        formatted_menus.append(formatted_menu)
-    return formatted_menus
-
-
-# Returns the subRecipeId if any 'standalone' item exists within recipeItems, else returns None
-# It is assumed that there is a max of ONE standalone item within the list of recipeItems, if any.
-def get_standalone(recipe_items):
-    for recipe_item in recipe_items:
-        preparations = recipe_item.get('preparations', [])
-        is_standalone = any(prep['name'] == 'standalone' for prep in preparations)
-
-        if is_standalone:
-            return recipe_item.get('subRecipeId')
-    return None

--- a/galley/types.py
+++ b/galley/types.py
@@ -1,5 +1,6 @@
 from sgqlc.types import Field, Type, Input, datetime as d, Enum, ID, list_of
 
+
 class CategoryItemTypeEnum(Enum):
     __choices__ = ('menuItem',
                    'ingredient',

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,3 +1,3 @@
 [mypy]
-ignore_missing_imports=True
+ignore_missing_imports = True
 strict_optional = True

--- a/tests/mock_responses/mock_menu_data.py
+++ b/tests/mock_responses/mock_menu_data.py
@@ -1,0 +1,69 @@
+def mock_menu(name):
+    return ({
+        'name': name,
+        'id': 'MENU123ABC',
+        'date': 'YYYY-MM-DD',
+        'location': {
+            'name': 'Vacaville'
+        },
+        'menuItems': [
+            {
+                'recipeId': 'RECIPE1ABC',
+                'categoryValues': [{
+                    'name': 'dv1',
+                    'category': {
+                        'itemType': 'menuItem',
+                        'name': 'product_code'
+                    }
+                }],
+                'recipe': {
+                    'externalName': 'Test Recipe Name 1',
+                    'recipeItems': [{
+                        'preparations': [
+                            {'name':  'standalone'}
+                        ],
+                        'subRecipeId': 'SUBRECIPEID456'
+                    }]
+                },
+            },
+            {
+                'recipeId': 'RECIPE2DEF',
+                'categoryValues': [{
+                    'name': 'dv2',
+                    'category': {
+                        'itemType': 'menuItem',
+                        'name': 'product_code'
+                    }
+                }],
+                'recipe': {
+                    'externalName': 'Test Recipe Name 2',
+                    'recipeItems': [{
+                        'preparations': [
+                            {'name':  '2 oz RAM'}
+                        ],
+                        'subRecipeId': 'SUBRECIPEID789'
+                    }]
+                },
+            },
+            {
+                'recipeId': 'RECIPE3GHI',
+                'categoryValues': [{
+                    'name': 'lm2',
+                    'category': {
+                        'itemType': 'menuItem',
+                        'name': 'product_code'
+                    }
+                }],
+                'recipe': {
+                    'externalName': 'Test Recipe Name 3',
+                    'recipeItems': [{
+                        'preparations': [
+                            {'name':  '3 oz RAM'},
+                            {'name': 'standalone'}
+                        ],
+                        'subRecipeId': 'SUBRECIPEID321'
+                    }]
+                },
+            }
+        ]
+    }) if name.split()[0] != '21-12-05' else []

--- a/tests/test_common_utils.py
+++ b/tests/test_common_utils.py
@@ -65,7 +65,6 @@ class TestValidateResponseData(TestCase):
                 "name": "Test Recipe",
             }
         }
-
         self.return_value = {
             "data": {
                 "viewer": self.data
@@ -96,7 +95,6 @@ class TestValidateResponseData(TestCase):
             'name': 'Test Testovich',
             'description': 'Test description.'
         }
-
         self.fields = {
             'item1': {
                 'item2': {
@@ -104,7 +102,6 @@ class TestValidateResponseData(TestCase):
                 }
             }
         }
-
         self.return_value = {
             'data': self.fields
         }

--- a/tests/test_formatted_queries.py
+++ b/tests/test_formatted_queries.py
@@ -1,12 +1,13 @@
 from unittest import mock, TestCase
 
-from galley.formatted_queries import get_formatted_recipes_data, ingredients_from_recipe_items
+from galley.formatted_queries import get_formatted_recipes_data, ingredients_from_recipe_items, \
+    get_formatted_menu_data
 
 from tests.mock_responses import mock_nutrition_data, mock_recipes_data, mock_recipe_items
+from tests.mock_responses.mock_menu_data import mock_menu
 
 
 class TestIngredientsFromRecipeItems(TestCase):
-
     def test_ingredients_from_recipes_successful(self):
         expected_result = [
             'Unique 1',
@@ -16,15 +17,12 @@ class TestIngredientsFromRecipeItems(TestCase):
             'Unique 2',
             'Unique 4'
         ]
-
         result = ingredients_from_recipe_items(mock_recipe_items.mock_data)
         self.assertEqual(result, expected_result)
-
 
     def test_ingredients_from_recipes_null(self):
         result = get_formatted_recipes_data(None)
         self.assertEqual(result, [])
-
 
     def test_ingredients_from_recipes_empty(self):
         result = ingredients_from_recipe_items([])
@@ -32,7 +30,6 @@ class TestIngredientsFromRecipeItems(TestCase):
 
 
 class TestGetFormattedRecipesData(TestCase):
-
     @mock.patch('galley.queries.make_request_to_galley')
     def test_get_formatted_recipes_data_successful(self, mock_retrieval_method):
         expected_result = [
@@ -47,7 +44,7 @@ class TestGetFormattedRecipesData(TestCase):
                 'mealType': 'dinner',
                 'ingredients': [
                     'Unique 1',
-                    'Duplicate 1',                    
+                    'Duplicate 1',
                     'Duplicate 2',
                     'Duplicate 3',
                     'Unique 2',
@@ -78,18 +75,17 @@ class TestGetFormattedRecipesData(TestCase):
             'data': {
                 'viewer': {
                     'recipes': [
-                        mock_recipes_data.mock_recipe('1'), 
+                        mock_recipes_data.mock_recipe('1'),
                         mock_recipes_data.mock_recipe('2')
                     ]
                 }
             }
         }
-
         result = get_formatted_recipes_data(['1', '2'])
         self.assertEqual(result, expected_result)
 
     @mock.patch('galley.queries.make_request_to_galley')
-    def test_get_formatted_recipes_data_empty(self, mock_retrieval_method):        
+    def test_get_formatted_recipes_data_empty(self, mock_retrieval_method):
         mock_retrieval_method.return_value = {
             'data': {
                 'viewer': {
@@ -97,12 +93,11 @@ class TestGetFormattedRecipesData(TestCase):
                 }
             }
         }
-
         result = get_formatted_recipes_data(['1', '2'])
         self.assertEqual(result, [])
 
     @mock.patch('galley.queries.make_request_to_galley')
-    def test_get_formatted_recipes_data_missing(self, mock_retrieval_method):        
+    def test_get_formatted_recipes_data_missing(self, mock_retrieval_method):
         mock_retrieval_method.return_value = {
             'data': {
                 'viewer': {
@@ -110,6 +105,68 @@ class TestGetFormattedRecipesData(TestCase):
                 }
             }
         }
-
         result = get_formatted_recipes_data(['1', '2'])
+        self.assertEqual(result, [])
+
+
+class TestGetFormattedMenuData(TestCase):
+    def response(self, *menus):
+        return ({
+            'data': {
+                'viewer': {
+                    'menus': [m for m in menus if m]
+                }
+            }
+        })
+
+    def formatted_menu(self, name):
+            return ({
+                'name': name,
+                'id': 'MENU123ABC',
+                'date': 'YYYY-MM-DD',
+                'location': 'Vacaville',
+                'menuItems': [{
+                    'itemCode': 'dv1',
+                    'recipeId': 'RECIPE1ABC',
+                    'standaloneRecipeId': 'SUBRECIPEID456'
+                }, {
+                    'itemCode': 'dv2',
+                    'recipeId': 'RECIPE2DEF',
+                    'standaloneRecipeId': None
+                }, {
+                    'itemCode': 'lm2',
+                    'recipeId': 'RECIPE3GHI',
+                    'standaloneRecipeId': 'SUBRECIPEID321'
+                }]
+            })
+
+    @mock.patch('galley.queries.make_request_to_galley')
+    def test_get_formatted_menu_data_successful(self, mock_retrieval_method):
+        mock_retrieval_method.side_effect = [
+            self.response(mock_menu('21-11-14 123')),
+            self.response(mock_menu('21-11-21 123'), mock_menu('21-11-21 456'), mock_menu('21-11-28 123')),
+            self.response(mock_menu('21-11-28 456'), mock_menu('21-12-05 123')),
+            self.response(mock_menu('21-12-05 456')),
+        ]
+
+        # one valid menu name
+        result1 = get_formatted_menu_data(['21-11-14 123'])
+        self.assertEqual(result1, [self.formatted_menu('21-11-14 123')])
+
+        # multiple valid menu names
+        result2 = get_formatted_menu_data(['21-11-21 123', '21-11-21 456', '21-11-28 123'])
+        self.assertEqual(result2, [self.formatted_menu('21-11-21 123'), self.formatted_menu('21-11-21 456'), self.formatted_menu('21-11-28 123')])
+
+        # one valid menu name and one invalid menu name
+        result3 = get_formatted_menu_data(['21-11-28 456', '21-12-05 123'])
+        self.assertEqual(result3, [self.formatted_menu('21-11-28 456')])
+
+        # one invalid menu name
+        result4 = get_formatted_menu_data(['21-12-05 456'])
+        self.assertEqual(result4, [])
+
+    @mock.patch('galley.queries.make_request_to_galley')
+    def test_get_formatted_menu_data_null(self, mock_retrieval_method):
+        mock_retrieval_method.return_value = None
+        result = get_formatted_menu_data([])
         self.assertEqual(result, [])

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -1,9 +1,9 @@
 from unittest import mock, TestCase
 from sgqlc.operation import Operation
 
-from galley.queries import Query, get_recipe_data, get_recipe_nutrition_data, \
-    get_week_menu_data, get_recipe_ingredients, get_formatted_recipe_ingredients, \
-    get_formatted_menu_data, get_raw_recipes_data
+from galley.queries import Query, get_raw_recipes_data, get_recipe_data, \
+    get_week_menu_data, recipes_data_query, get_recipe_ingredients, \
+    get_formatted_recipe_ingredients, get_formatted_menu_data
 from galley.types import FilterInput
 from tests.mock_responses import mock_recipes_data, mock_nutrition_data
 
@@ -193,13 +193,13 @@ class TestQueryWeekMenuData(TestCase):
         }) if name.split()[0] != '21-12-05' else []
 
     def response(self, *menus):
-            return ({
-                'data': {
-                    'viewer': {
-                        'menus': [m for m in menus if m]
-                    }
+        return ({
+            'data': {
+                'viewer': {
+                    'menus': [m for m in menus if m]
                 }
-            })
+            }
+        })
 
     def test_week_menu_data_query(self):
         query_operation = Operation(Query)
@@ -310,7 +310,7 @@ class TestQueryWeekMenuData(TestCase):
         self.assertEqual(result, None)
 
 
-class TestQueryRecipeIngredients(TestCase):
+class TestRecipesDataQuery(TestCase):
     def setUp(self) -> None:
         self.expected_query = '''query {
             viewer {
@@ -438,14 +438,8 @@ class TestQueryGetRawRecipesData(TestCase):
             }
         }
 
-        result = get_recipe_ingredients('1')
-        self.assertEqual(result, self.recipe)
-
-    @mock.patch('galley.queries.make_request_to_galley')
-    def test_get_recipe_ingredients_null(self, mock_retrieval_method):
-        mock_retrieval_method.return_value = None
-        result = get_recipe_ingredients('2')
-        self.assertEqual(result, None)
+        result = get_raw_recipes_data(['1'])
+        self.assertEqual(result, recipe_data)
 
     @mock.patch('galley.queries.make_request_to_galley')
     def test_get_raw_recipes_data_empty(self, mock_retrieval_method):
@@ -459,12 +453,6 @@ class TestQueryGetRawRecipesData(TestCase):
 
         result = get_raw_recipes_data(['Fake'])
         self.assertEqual(result, [])
-
-    @mock.patch('galley.queries.make_request_to_galley')
-    def test_get_formatted_recipe_ingredients_null(self, mock_retrieval_method):
-        mock_retrieval_method.return_value = None
-        result = get_formatted_recipe_ingredients('2')
-        self.assertEqual(result, None)
 
     @mock.patch('galley.queries.make_request_to_galley')
     def test_get_raw_recipes_data_missing(self, mock_retrieval_method):

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -2,10 +2,9 @@ from unittest import mock, TestCase
 from sgqlc.operation import Operation
 
 from galley.queries import Query, get_raw_recipes_data, get_recipe_data, \
-    get_week_menu_data, recipes_data_query, get_recipe_ingredients, \
-    get_formatted_recipe_ingredients, get_formatted_menu_data
-from galley.types import FilterInput
-from tests.mock_responses import mock_recipes_data, mock_nutrition_data
+    get_raw_menu_data, recipes_data_query, menu_data_query
+from tests.mock_responses import mock_recipes_data
+from tests.mock_responses.mock_menu_data import mock_menu
 
 import logging
 
@@ -50,7 +49,7 @@ class TestQueryRecipes(TestCase):
             },
             {
                 'id': '10000',
-                'externalName': 'test recipe 1',
+                'externalName': 'test recipe 2',
                 'instructions': None,
                 'notes': None,
                 'description': None
@@ -64,7 +63,6 @@ class TestQueryRecipes(TestCase):
                 }
             }
         }
-
         result = get_recipe_data()
         self.assertEqual(result, recipes)
 
@@ -77,7 +75,6 @@ class TestQueryRecipes(TestCase):
                 }
             }
         }
-
         result = get_recipe_data()
         self.assertEqual(result, None)
 
@@ -122,76 +119,6 @@ class TestQueryWeekMenuData(TestCase):
             }
             }'''.replace(' '*12, '')
 
-    def menus(self, name):
-        return ({
-            'name': name,
-            'id': 'MENU123ABC',
-            'date': 'YYYY-MM-DD',
-            'location': {
-                'name': 'Vacaville'
-            },
-            'menuItems': [
-                {
-                    'recipeId': 'RECIPE1ABC',
-                    'categoryValues': [{
-                        'name': 'dv1',
-                        'category': {
-                            'itemType': 'menuItem',
-                            'name': 'product_code'
-                        }
-                    }],
-                    'recipe': {
-                        'externalName': 'Test Recipe Name 1',
-                        'recipeItems': [{
-                            'preparations': [
-                                {'name':  'standalone'}
-                            ],
-                            'subRecipeId': 'SUBRECIPEID456'
-                        }]
-                    },
-                },
-                {
-                    'recipeId': 'RECIPE2DEF',
-                    'categoryValues': [{
-                        'name': 'dv2',
-                        'category': {
-                            'itemType': 'menuItem',
-                            'name': 'product_code'
-                        }
-                    }],
-                    'recipe': {
-                        'externalName': 'Test Recipe Name 2',
-                        'recipeItems': [{
-                            'preparations': [
-                                {'name':  '2 oz RAM'}
-                            ],
-                            'subRecipeId': 'SUBRECIPEID789'
-                        }]
-                    },
-                },
-                {
-                    'recipeId': 'RECIPE3GHI',
-                    'categoryValues': [{
-                        'name': 'lm2',
-                        'category': {
-                            'itemType': 'menuItem',
-                            'name': 'product_code'
-                        }
-                    }],
-                    'recipe': {
-                        'externalName': 'Test Recipe Name 3',
-                        'recipeItems': [{
-                            'preparations': [
-                                {'name':  '3 oz RAM'},
-                                {'name': 'standalone'}
-                            ],
-                            'subRecipeId': 'SUBRECIPEID321'
-                        }]
-                    },
-                }
-            ]
-        }) if name.split()[0] != '21-12-05' else []
-
     def response(self, *menus):
         return ({
             'data': {
@@ -202,44 +129,37 @@ class TestQueryWeekMenuData(TestCase):
         })
 
     def test_week_menu_data_query(self):
-        query_operation = Operation(Query)
-        query_operation.viewer().menus(where=FilterInput(name=["2021-10-04 1_2_3", "2021-10-04 4_5_6"])).__fields__(
-            'id', 'name', 'date', 'location', 'menuItems'
-        )
-        query_operation.viewer.menus.menuItems.__fields__('recipeId', 'categoryValues', 'recipe')
-        query_operation.viewer.menus.menuItems.recipe.__fields__('externalName', 'recipeItems')
-        query_operation.viewer.menus.menuItems.recipe.recipeItems.__fields__('subRecipeId', 'preparations')
-        query_operation.viewer.menus.menuItems.recipe.recipeItems.preparations.__fields__('name')
-        query_str = query_operation.__to_graphql__(auto_select_depth=3)
+        query = menu_data_query(["2021-10-04 1_2_3", "2021-10-04 4_5_6"])
+        query_str = query.__to_graphql__(auto_select_depth=3)
         self.assertEqual(query_str.replace(' ', ''), self.expected_query.replace(' ', ''))
 
     @mock.patch('galley.queries.make_request_to_galley')
-    def test_get_week_menu_data_successful(self, mock_retrieval_method):
+    def test_get_raw_menu_data_successful(self, mock_retrieval_method):
         mock_retrieval_method.side_effect = [
-            self.response(self.menus('21-11-14 123')),
-            self.response(self.menus('21-11-21 123'), self.menus('21-11-21 456'), self.menus('21-11-28 123')),
-            self.response(self.menus('21-11-28 456'), self.menus('21-12-05 123')),
-            self.response(self.menus('21-12-05 456')),
+            self.response(mock_menu('21-11-14 123')),
+            self.response(mock_menu('21-11-21 123'), mock_menu('21-11-21 456'), mock_menu('21-11-28 123')),
+            self.response(mock_menu('21-11-28 456'), mock_menu('21-12-05 123')),
+            self.response(mock_menu('21-12-05 456')),
         ]
 
         # one valid menu name
-        result1 = get_week_menu_data(['21-11-14 123'])
-        self.assertEqual(result1, [self.menus('21-11-14 123')])
+        result1 = get_raw_menu_data(['21-11-14 123'])
+        self.assertEqual(result1, [mock_menu('21-11-14 123')])
 
         # multiple valid menu names
-        result2 = get_week_menu_data(['21-11-21 123', '21-11-21 456', '21-11-28 123'])
-        self.assertEqual(result2, [self.menus('21-11-21 123'), self.menus('21-11-21 456'), self.menus('21-11-28 123')])
+        result2 = get_raw_menu_data(['21-11-21 123', '21-11-21 456', '21-11-28 123'])
+        self.assertEqual(result2, [mock_menu('21-11-21 123'), mock_menu('21-11-21 456'), mock_menu('21-11-28 123')])
 
         # one valid menu name and one invalid menu name
-        result3 = get_week_menu_data(['21-11-28 456', '21-12-05 123'])
-        self.assertEqual(result3, [self.menus('21-11-28 456')])
+        result3 = get_raw_menu_data(['21-11-28 456', '21-12-05 123'])
+        self.assertEqual(result3, [mock_menu('21-11-28 456')])
 
         # one invalid menu name
-        result4 = get_week_menu_data(['21-12-05 456'])
+        result4 = get_raw_menu_data(['21-12-05 456'])
         self.assertEqual(result4, [])
 
     @mock.patch('galley.queries.make_request_to_galley')
-    def test_get_week_menu_data_validation_failure(self, mock_retrieval_method):
+    def test_get_raw_menu_data_validation_failure(self, mock_retrieval_method):
         mock_retrieval_method.return_value = {
             'data': {
                 'viewer': {
@@ -247,66 +167,13 @@ class TestQueryWeekMenuData(TestCase):
                 }
             }
         }
-
-        result = get_week_menu_data('YYYY-MM-DD 1_2_3')
+        result = get_raw_menu_data('YYYY-MM-DD 1_2_3')
         self.assertEqual(result, None)
 
     @mock.patch('galley.queries.make_request_to_galley')
-    def test_get_week_menu_data_null(self, mock_retrieval_method):
+    def test_get_raw_menu_data_null(self, mock_retrieval_method):
         mock_retrieval_method.return_value = None
-        result = get_week_menu_data([])
-        self.assertEqual(result, None)
-
-    @mock.patch('galley.queries.make_request_to_galley')
-    def test_get_formatted_menu_data_successful(self, mock_retrieval_method):
-        def formatted_menu(name):
-            return ({
-                'name': name,
-                'id': 'MENU123ABC',
-                'date': 'YYYY-MM-DD',
-                'location': 'Vacaville',
-                'menuItems': [{
-                    'itemCode': 'dv1',
-                    'recipeId': 'RECIPE1ABC',
-                    'standaloneRecipeId': 'SUBRECIPEID456'
-                }, {
-                    'itemCode': 'dv2',
-                    'recipeId': 'RECIPE2DEF',
-                    'standaloneRecipeId': None
-                }, {
-                    'itemCode': 'lm2',
-                    'recipeId': 'RECIPE3GHI',
-                    'standaloneRecipeId': 'SUBRECIPEID321'
-                }]
-            })
-
-        mock_retrieval_method.side_effect = [
-            self.response(self.menus('21-11-14 123')),
-            self.response(self.menus('21-11-21 123'), self.menus('21-11-21 456'), self.menus('21-11-28 123')),
-            self.response(self.menus('21-11-28 456'), self.menus('21-12-05 123')),
-            self.response(self.menus('21-12-05 456')),
-        ]
-
-        # one valid menu name
-        result1 = get_formatted_menu_data(['21-11-14 123'])
-        self.assertEqual(result1, [formatted_menu('21-11-14 123')])
-
-        # multiple valid menu names
-        result2 = get_formatted_menu_data(['21-11-21 123', '21-11-21 456', '21-11-28 123'])
-        self.assertEqual(result2, [formatted_menu('21-11-21 123'), formatted_menu('21-11-21 456'), formatted_menu('21-11-28 123')])
-
-        # one valid menu name and one invalid menu name
-        result3 = get_formatted_menu_data(['21-11-28 456', '21-12-05 123'])
-        self.assertEqual(result3, [formatted_menu('21-11-28 456')])
-
-        # one invalid menu name
-        result4 = get_formatted_menu_data(['21-12-05 456'])
-        self.assertEqual(result4, None)
-
-    @mock.patch('galley.queries.make_request_to_galley')
-    def test_get_formatted_menu_data_null(self, mock_retrieval_method):
-        mock_retrieval_method.return_value = None
-        result = get_formatted_menu_data([])
+        result = get_raw_menu_data([])
         self.assertEqual(result, None)
 
 
@@ -437,7 +304,6 @@ class TestQueryGetRawRecipesData(TestCase):
                 }
             }
         }
-
         result = get_raw_recipes_data(['1'])
         self.assertEqual(result, recipe_data)
 
@@ -450,7 +316,6 @@ class TestQueryGetRawRecipesData(TestCase):
                 }
             }
         }
-
         result = get_raw_recipes_data(['Fake'])
         self.assertEqual(result, [])
 
@@ -463,6 +328,5 @@ class TestQueryGetRawRecipesData(TestCase):
                 }
             }
         }
-
         result = get_raw_recipes_data(['Fake'])
         self.assertEqual(result, None)


### PR DESCRIPTION
## Description
This PR is focused on formatting menu data returned from `get_week_menu_data` by creating a wrapper function, `get_formatted_menu_data`. Notes to consider when reviewing this PR:

> 1.) What we need to know about each menuItem is:
>    - what product_code does it relate to on the thistle-web side (represented by `itemCode` in the expected return value e.g. LV1 or DM3 or RSK)
>    - what top-level recipe is it related to (represented by `recipeId`, e.g. "cmVjaXBlOjE3ODAxMA==" is the id for "Thistle Pad Thai with Sesame Baked Tofu" recipe)
>    - what standalone item is associated with the top-level recipe (represented by `standaloneRecipeId` e.g. "Thistle Pad Thai with Sesame Baked Tofu" recipe has a standalone item with an id of "cmVjaXBlOjE3NDQxMg==" to represent "Chili Tamarind Sauce")
>    - any non-standalone recipe will have a `None` value for `standaloneRecipeId`

> 2.) We only need the `recipeItems` so that we can identify any 'standalone' recipe. Once we've identified it, we just want its id, which should be returned as `standaloneRecipeId`.

> 3.) There will be a max of **one** `standaloneRecipeId` per menu item within `menuItems` list, if any.

## Test Plan
Open python interactive within galley-sdk: `$ python`
`>>> from pprint import pprint` (optional: to apply pretty print format to returned data)
`>>> from galley.queries import *` 

### 1. All valid menu names passed in:
`>>> pprint(get_formatted_menu_data(["2021-10-04 1_2_3", "2021-10-25 1_2_3"]))`

> **Expectation:** A return value **similar** to:
> ```python3
> [
>  {'name': '2021-10-04 1_2_3',
>   'date': '2021-10-04',
>   'id': 'bWVudTo2MzQ2NTY=',
>   'location': 'Vacaville',
>   'menuItems': [{'itemCode': None,
>                  'recipeId': 'cmVjaXBlOjE3NDc5MA==',
>                  'standaloneRecipeId': None},
>                 {'itemCode': 's2',
>                  'recipeId': 'cmVjaXBlOjE3Mjk3NQ==',
>                  'standaloneRecipeId': None},
>                 {'itemCode': 'dm3',
>                  'recipeId': 'cmVjaXBlOjE3ODAxOQ==',
>                  'standaloneRecipeId': None},
>                 {'itemCode': 'dv3',
>                  'recipeId': 'cmVjaXBlOjE3ODAxMA==',
>                  'standaloneRecipeId': 'cmVjaXBlOjE3NDQxMg=='},
>                 {'itemCode': None,
>                  'recipeId': 'cmVjaXBlOjE3NDc5Nw==',
>                  'standaloneRecipeId': None},
>                 { ... # total len of menuItems should be 25 with 3 containing a 'standaloneRecipeId' }]},
>  {'name': '2021-10-25 1_2_3',
>   'date': '2021-10-25',
>   'id': 'bWVudTo3NjM2MjA=',
>   'location': 'Vacaville',
>   'menuItems': [{'itemCode': 'b1',
>                  'recipeId': 'cmVjaXBlOjE4MDcxMA==',
>                  'standaloneRecipeId': None},
>                 {'itemCode': 'lv1',
>                  'recipeId': 'cmVjaXBlOjE4MjEzOA==',
>                  'standaloneRecipeId': None},
>                 {'itemCode': 'lm1',
>                  'recipeId': 'cmVjaXBlOjE4MjE0Ng==',
>                  'standaloneRecipeId': None},
>                 {'itemCode': 'dv1',
>                  'recipeId': 'cmVjaXBlOjE3OTk1Mw==',
>                  'standaloneRecipeId': 'cmVjaXBlOjE3NDI2MQ=='},
>                 {'itemCode': None,
>                  'recipeId': 'cmVjaXBlOjE4MjI0NQ==',
>                  'standaloneRecipeId': 'cmVjaXBlOjE3NDI2MQ=='},
>                 {'itemCode': 'dm1',
>                  'recipeId': 'cmVjaXBlOjE3OTk2MA==',
>                  'standaloneRecipeId': 'cmVjaXBlOjE3NDI2MQ=='},
>                 {'itemCode': 's1',
>                  'recipeId': 'cmVjaXBlOjE4MDk2Mg==',
>                  'standaloneRecipeId': None},
>                 { ... # total len of menuItems should be 42 with 4 containing a 'standaloneRecipeId' }]}
> ]
>```

### 3. Some valid menu names passed in:
`>>> pprint(get_formatted_menu_data(["2021-10-04 1_2_3", "2021-10-25 1_2_3", "invalid-menu-name 1_2_3"]))`

> **Expectation:** Same return value as above

### 4. Invalid or no menu names passed in:
`>>> pprint(get_formatted_menu_data(["invalid-menu-name 4_5_6"]))`
> **Expectation:** A return value of `[]`

`>>> pprint(get_formatted_menu_data([]))`
> **Expectation:** A return value of `[]`

### 5. Run unittests
Exit python interactive and stay within the galley-sdk directory to run tests:
`(galley-env) $ python -m unittest tests/test_queries.py`
**[OPTIONAL SANITY CHECK]** `(galley-env) $ python -m unittest tests/test_*.py`

## Versioning
Updated to v0.11.0