### PR TITLE
(ENG-823) Bug Fix - corrects viewer.recipe to viewer.recipes for batch query

### DIFF
--- a/galley/queries.py
+++ b/galley/queries.py
@@ -55,9 +55,9 @@ def recipes_data_query(recipe_ids: List[str]) -> Optional[Operation]:
     query.viewer.recipes(where=FilterInput(id=recipe_ids)).__fields__(
         'id', 'externalName', 'notes', 'description', 'categoryValues', 'reconciledNutritionals', 'recipeItems'
     )
-    query.viewer.recipe.recipeItems.__fields__('ingredient', 'subRecipe', 'preparations')
-    query.viewer.recipe.recipeItems.ingredient.__fields__('externalName', 'categoryValues')
-    query.viewer.recipe.recipeItems.ingredient.categoryValues.__fields__('name')
+    query.viewer.recipes.recipeItems.__fields__('ingredient', 'subRecipe', 'preparations')
+    query.viewer.recipes.recipeItems.ingredient.__fields__('externalName', 'categoryValues')
+    query.viewer.recipes.recipeItems.ingredient.categoryValues.__fields__('name')
     return query
 
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # are dependencies that are required on remote installs, not local development.
 setup(
     name='galley_sdk',
-    version='0.11.0',
+    version='0.11.1',
     packages=['galley'],
     install_requires=['sgqlc==14.0', 'backoff==1.11.1']
 )

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -263,11 +263,11 @@ class TestRecipesDataQuery(TestCase):
             }
             subRecipe {
             allIngredients
-            }            
+            }
             preparations {
             name
             }
-            }                        
+            }
             }
             }
             }'''.replace(' '*12, '')

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -257,31 +257,17 @@ class TestRecipesDataQuery(TestCase):
             recipeItems {
             ingredient {
             externalName
-            }
-            subRecipe {
-            allIngredients
-            }
-            subRecipeId
-            preparations {
-            name
-            }
-            }
-            }
-            recipe {
-            recipeItems {
-            ingredient {
-            externalName
             categoryValues {
             name
             }
             }
             subRecipe {
             allIngredients
-            }
+            }            
             preparations {
             name
             }
-            }
+            }                        
             }
             }
             }'''.replace(' '*12, '')


### PR DESCRIPTION
## Description
This updates the query to correctly batch the request for multiple recipe ids. We should now be correctly filtering packaging, whereas previously packaging ingredients were being included in the ingredients list. It also updates the test to correct the expected query.
## Test Plan
In interactive python, run:

`import pprint; import galley`
`from galley.formatted_queries import *`

`pprint(get_formatted_recipes_data(["cmVjaXBlOjE3OTk1Mw==", "cmVjaXBlOjE3Mjg4Mg==", "FAKE!!!"]))`

You can compare these results to the recipes on galley. Note that all packaging and standalone items should be excluded from the ingredients list.

https://staging-app.galleysolutions.com/recipes/cmVjaXBlOjE3OTk1Mw==
https://staging-app.galleysolutions.com/recipes/cmVjaXBlOjE3Mjg4Mg==

## Versioning
Updated to 0.11.1