### PR TITLE
Drewdas/eng 821 galley menu data retrieval method refactor

### DIFF
--- a/galley/formatted_queries.py
+++ b/galley/formatted_queries.py
@@ -1,6 +1,6 @@
 from typing import Dict, Optional, List
 
-from galley.queries import get_raw_recipes_data, get_raw_menu_data
+from galley.queries import MenuCategoryEnum, get_raw_recipes_data, get_raw_menu_data
 from galley.pagination import paginate_results
 
 FOOD_PACKAGING = 'food pkg'
@@ -103,6 +103,12 @@ def get_formatted_menu_data(dates: List[str],
             'location': menu['location'].get('name'),
             'menuItems': []
         }) # type: Dict
+
+        categoryValues = menu['categoryValues']
+        for categoryValue in categoryValues:
+            if (categoryValue['category']['id'] ==
+                    MenuCategoryEnum.MENU_TYPE.value):
+                formatted_menu['categoryMenuType'] = categoryValue['name']
 
         menu_items = menu.get('menuItems', [])
         for menu_item in menu_items:

--- a/galley/formatted_queries.py
+++ b/galley/formatted_queries.py
@@ -85,7 +85,6 @@ def get_formatted_recipes_data(recipe_ids: List[str]) -> Optional[List[Dict]]:
     return formatted_recipes
 
 
-@paginate_results()
 def get_formatted_menu_data(dates: List[str],
                             location_name: str="Vacaville",
                             menu_type: str="production"

--- a/galley/formatted_queries.py
+++ b/galley/formatted_queries.py
@@ -86,8 +86,8 @@ def get_formatted_recipes_data(recipe_ids: List[str]) -> Optional[List[Dict]]:
 
 
 @paginate_results()
-def get_formatted_menu_data(names: list) -> Optional[List[Dict]]:
-    menus = get_raw_menu_data(names)
+def get_formatted_menu_data(dates: List[str]) -> Optional[List[Dict]]:
+    menus = get_raw_menu_data(dates)
     formatted_menus = []
 
     if not menus:

--- a/galley/formatted_queries.py
+++ b/galley/formatted_queries.py
@@ -87,8 +87,8 @@ def get_formatted_recipes_data(recipe_ids: List[str]) -> Optional[List[Dict]]:
 
 @paginate_results()
 def get_formatted_menu_data(dates: List[str],
-                            location_name: Optional[str]="Vacaville",
-                            menu_type: Optional[str]="production"
+                            location_name: str="Vacaville",
+                            menu_type: str="production"
                             ) -> Optional[List[Dict]]:
     menus = get_raw_menu_data(dates, location_name, menu_type)
     formatted_menus = []

--- a/galley/formatted_queries.py
+++ b/galley/formatted_queries.py
@@ -86,8 +86,11 @@ def get_formatted_recipes_data(recipe_ids: List[str]) -> Optional[List[Dict]]:
 
 
 @paginate_results()
-def get_formatted_menu_data(dates: List[str]) -> Optional[List[Dict]]:
-    menus = get_raw_menu_data(dates)
+def get_formatted_menu_data(dates: List[str],
+                            location_name: Optional[str]="Vacaville",
+                            menu_type: Optional[str]="production"
+                            ) -> Optional[List[Dict]]:
+    menus = get_raw_menu_data(dates, location_name, menu_type)
     formatted_menus = []
 
     if not menus:

--- a/galley/queries.py
+++ b/galley/queries.py
@@ -6,8 +6,24 @@ from galley.common import make_request_to_galley, validate_response_data
 from galley.types import Recipe, Menu, FilterInput, MenuFilterInput
 import logging
 
+from enum import Enum
+
 logger = logging.getLogger(__name__)
 
+FOOD_PACKAGING = 'food pkg'
+STANDALONE = 'standalone'
+
+class MenuCategoryEnum(Enum):
+    """
+    Enum for categories, for item type menu <category name>: <category id>
+    """
+    MENU_TYPE = 'Y2F0ZWdvcnk6MjQ2NQ=='
+
+class MenuCategoryValueEnum(Enum):
+    """
+    Enum for category values, <category value name>: <category value id>
+    """
+    PRODUCTION = 'Y2F0ZWdvcnlWYWx1ZToxNTQ2NA=='
 
 class Viewer(Type):
     recipes = Field(Recipe, args=(ArgDict({'where': FilterInput})))
@@ -69,7 +85,8 @@ def get_raw_recipes_data(recipe_ids: List[str]) -> Optional[List[Dict]]:
 
 def get_week_menu_data(dates: List[str],
                        location_name: Optional[str]="Vacaville",
-                       menu_type: Optional[str]="production") -> Optional[List[Dict]]:
+                       menu_type: Optional[str]="production"
+                       ) -> Optional[List[Dict]]:
     """
     Returns a list of dictionaries containing the menu data for the week.
     if there is no menu data for the week, returns None.
@@ -108,12 +125,9 @@ def get_week_menu_data(dates: List[str],
             if menu['location']['name'] == location_name:
                 categoryValues = menu['categoryValues']
                 for categoryValue in categoryValues:
-                    if (categoryValue['category']['name'] ==
-                       "menu type" and categoryValue['name'] == menu_type):
-                        """
-                        TODO [Drew] [2021-10-16]: change this to category ids
-                        instead of string matching.
-                        """
+                    if (categoryValue['category']['id'] == MenuCategoryEnum.
+                       MENU_TYPE.value and categoryValue['id'] ==
+                       MenuCategoryValueEnum.PRODUCTION.value):
                         response.append(menu)
                     else:
                         continue

--- a/galley/queries.py
+++ b/galley/queries.py
@@ -19,12 +19,6 @@ class MenuCategoryEnum(Enum):
     """
     MENU_TYPE = 'Y2F0ZWdvcnk6MjQ2NQ=='
 
-class MenuCategoryValueEnum(Enum):
-    """
-    Enum for category values, <category value name>: <category value id>
-    """
-    PRODUCTION = 'Y2F0ZWdvcnlWYWx1ZToxNTQ2NA=='
-
 class Viewer(Type):
     recipes = Field(Recipe, args=(ArgDict({'where': FilterInput})))
     recipe = Field(Recipe, args={'id': str})
@@ -83,10 +77,10 @@ def get_raw_recipes_data(recipe_ids: List[str]) -> Optional[List[Dict]]:
     return validate_response_data(raw_data, 'recipes')
 
 
-def get_week_menu_data(dates: List[str],
-                       location_name: Optional[str]="Vacaville",
-                       menu_type: Optional[str]="production"
-                       ) -> Optional[List[Dict]]:
+def get_menu_data_for_dates(dates: List[str],
+                            location_name: Optional[str]="Vacaville",
+                            menu_type: Optional[str]="production"
+                            ) -> Optional[List[Dict]]:
     """
     Returns a list of dictionaries containing the menu data for the week.
     if there is no menu data for the week, returns None.
@@ -126,15 +120,14 @@ def get_week_menu_data(dates: List[str],
                 categoryValues = menu['categoryValues']
                 for categoryValue in categoryValues:
                     if (categoryValue['category']['id'] == MenuCategoryEnum.
-                       MENU_TYPE.value and categoryValue['id'] ==
-                       MenuCategoryValueEnum.PRODUCTION.value):
+                       MENU_TYPE.value and categoryValue['name'] == menu_type):
                         response.append(menu)
                     else:
                         continue
     return response
 
 
-def get_raw_menu_data(names: List[str]) -> Optional[List[Dict]]:
-    query = get_menu_data_for_date(names=names) # type: Operation
-    raw_data = make_request_to_galley(op=query.__to_graphql__(auto_select_depth=3), variables={'name': names})
+def get_raw_menu_data(dates: List[str]) -> Optional[List[Dict]]:
+    query = get_menu_data_for_dates(dates=dates) # type: Operation
+    raw_data = make_request_to_galley(op=query.__to_graphql__(auto_select_depth=3), variables={'date': dates})
     return validate_response_data(raw_data, 'menus')

--- a/galley/queries.py
+++ b/galley/queries.py
@@ -94,8 +94,8 @@ def get_menu_query(dates: List[str]) -> Optional[List[Dict]]:
 
 
 def get_raw_menu_data(dates: List[str],
-                      location_name: Optional[str]="Vacaville",
-                      menu_type: Optional[str]="production"
+                      location_name: str,
+                      menu_type: str
                       ) -> Optional[List[Dict]]:
     """
     Returns a list of dictionaries containing the menu data for the week.

--- a/galley/queries.py
+++ b/galley/queries.py
@@ -109,11 +109,21 @@ def get_menu_data_for_date(date: str,
                 for categoryValue in menu.get('categoryValues'):
                     if (categoryValue.get('category').get('name') ==
                        "menu type" and categoryValue.get('name') == menu_type):
-                            response.append(menu)
+                        """
+                        TODO [Drew] [2021-10-16]: should we keep a map of
+                        categoryValue ids instead of string matching here?
+                        do the ids match across dev and prod?
+                        """
+                        response.append(menu)
 
     if len(response) > 1:
+        """
+        TODO [Drew] [2021-10-16]: what should we do if there are multiple menus
+        for a date? For now, just return the first one.
+        """
         logger.error(f"Multiple menus found for {date} {location_name} \
             {menu_type}")
+        response = [response[0]]
 
     return response if response else None
 

--- a/galley/types.py
+++ b/galley/types.py
@@ -155,3 +155,8 @@ class Menu(Type):
 class FilterInput(Input):
     id = ID
     name = list_of(str)
+
+
+class MenuFilterInput(Input):
+    id = ID
+    date = d.Date

--- a/galley/types.py
+++ b/galley/types.py
@@ -11,11 +11,13 @@ class CategoryItemTypeEnum(Enum):
 
 
 class Category(Type):
+    id = Field(ID)
     name = str
     itemType = Field(CategoryItemTypeEnum)
 
 
 class CategoryValue(Type):
+    id = Field(ID)
     name = str
     category = Field(Category)
 
@@ -150,6 +152,7 @@ class Menu(Type):
     date = d.Date
     location = Field(Location)
     menuItems = Field(MenuItem)
+    categoryValues = Field(CategoryValue)
 
 
 class FilterInput(Input):

--- a/galley/types.py
+++ b/galley/types.py
@@ -162,4 +162,4 @@ class FilterInput(Input):
 
 class MenuFilterInput(Input):
     id = ID
-    date = d.Date
+    date = list_of(d.Date)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # are dependencies that are required on remote installs, not local development.
 setup(
     name='galley_sdk',
-    version='0.11.0',
+    version='0.12.0',
     packages=['galley'],
     install_requires=['sgqlc==14.0', 'backoff==1.11.1']
 )

--- a/tests/mock_responses/mock_menu_data.py
+++ b/tests/mock_responses/mock_menu_data.py
@@ -1,11 +1,20 @@
-def mock_menu(name):
+def mock_menu(date):
     return ({
-        'name': name,
+        'name': f"{date} 1_2_3",
         'id': 'MENU123ABC',
-        'date': 'YYYY-MM-DD',
+        'date': f"{date}",
         'location': {
             'name': 'Vacaville'
         },
+        'categoryValues': [{
+            'id': 'Y2F0ZWdvcnlWYWx1ZToxNTQ2NA==',
+            'name': 'production',
+            'category': {
+                'id': 'Y2F0ZWdvcnk6MjQ2NQ==',
+                'name': 'menu type',
+                'itemType': 'menu'
+            },
+        }],
         'menuItems': [
             {
                 'recipeId': 'RECIPE1ABC',
@@ -66,4 +75,4 @@ def mock_menu(name):
                 },
             }
         ]
-    }) if name.split()[0] != '21-12-05' else []
+    }) if date != '2021-12-05' else []

--- a/tests/mock_responses/mock_menu_data.py
+++ b/tests/mock_responses/mock_menu_data.py
@@ -1,16 +1,19 @@
-def mock_menu(date):
+from galley.queries import MenuCategoryEnum
+
+
+def mock_menu(date, location_name="Vacaville", menu_type="production"):
     return ({
         'name': f"{date} 1_2_3",
         'id': 'MENU123ABC',
         'date': f"{date}",
         'location': {
-            'name': 'Vacaville'
+            'name': location_name,
         },
         'categoryValues': [{
-            'id': 'Y2F0ZWdvcnlWYWx1ZToxNTQ2NA==',
-            'name': 'production',
+            'id': '1',
+            'name': menu_type,
             'category': {
-                'id': 'Y2F0ZWdvcnk6MjQ2NQ==',
+                'id': MenuCategoryEnum.MENU_TYPE.value,
                 'name': 'menu type',
                 'itemType': 'menu'
             },

--- a/tests/test_formatted_queries.py
+++ b/tests/test_formatted_queries.py
@@ -125,6 +125,7 @@ class TestGetFormattedMenuData(TestCase):
                 'id': 'MENU123ABC',
                 'date': f"{date}",
                 'location': 'Vacaville',
+                'categoryMenuType': 'production',
                 'menuItems': [{
                     'itemCode': 'dv1',
                     'recipeId': 'RECIPE1ABC',

--- a/tests/test_formatted_queries.py
+++ b/tests/test_formatted_queries.py
@@ -119,11 +119,11 @@ class TestGetFormattedMenuData(TestCase):
             }
         })
 
-    def formatted_menu(self, name):
+    def formatted_menu(self, date):
             return ({
-                'name': name,
+                'name': f"{date} 1_2_3",
                 'id': 'MENU123ABC',
-                'date': 'YYYY-MM-DD',
+                'date': f"{date}",
                 'location': 'Vacaville',
                 'menuItems': [{
                     'itemCode': 'dv1',
@@ -143,26 +143,30 @@ class TestGetFormattedMenuData(TestCase):
     @mock.patch('galley.queries.make_request_to_galley')
     def test_get_formatted_menu_data_successful(self, mock_retrieval_method):
         mock_retrieval_method.side_effect = [
-            self.response(mock_menu('21-11-14 123')),
-            self.response(mock_menu('21-11-21 123'), mock_menu('21-11-21 456'), mock_menu('21-11-28 123')),
-            self.response(mock_menu('21-11-28 456'), mock_menu('21-12-05 123')),
-            self.response(mock_menu('21-12-05 456')),
+            self.response(mock_menu('2021-11-14')),
+            self.response(mock_menu('2021-11-21'), mock_menu('2021-11-21'),
+                          mock_menu('2021-11-28')),
+            self.response(mock_menu('2021-11-28'), mock_menu('2021-12-05')),
+            self.response(mock_menu('2021-12-05')),
         ]
 
         # one valid menu name
-        result1 = get_formatted_menu_data(['21-11-14 123'])
-        self.assertEqual(result1, [self.formatted_menu('21-11-14 123')])
+        result1 = get_formatted_menu_data(['2021-11-14'])
+        self.assertEqual(result1, [self.formatted_menu('2021-11-14')])
 
         # multiple valid menu names
-        result2 = get_formatted_menu_data(['21-11-21 123', '21-11-21 456', '21-11-28 123'])
-        self.assertEqual(result2, [self.formatted_menu('21-11-21 123'), self.formatted_menu('21-11-21 456'), self.formatted_menu('21-11-28 123')])
+        result2 = get_formatted_menu_data(['2021-11-21', '2021-11-21',
+                                           '2021-11-28'])
+        self.assertEqual(result2, [self.formatted_menu('2021-11-21'),
+                                   self.formatted_menu('2021-11-21'),
+                                   self.formatted_menu('2021-11-28')])
 
         # one valid menu name and one invalid menu name
-        result3 = get_formatted_menu_data(['21-11-28 456', '21-12-05 123'])
-        self.assertEqual(result3, [self.formatted_menu('21-11-28 456')])
+        result3 = get_formatted_menu_data(['2021-11-28', '2021-12-05'])
+        self.assertEqual(result3, [self.formatted_menu('2021-11-28')])
 
         # one invalid menu name
-        result4 = get_formatted_menu_data(['21-12-05 456'])
+        result4 = get_formatted_menu_data(['2021-12-05'])
         self.assertEqual(result4, [])
 
     @mock.patch('galley.queries.make_request_to_galley')

--- a/tests/test_formatted_queries.py
+++ b/tests/test_formatted_queries.py
@@ -167,10 +167,18 @@ class TestGetFormattedMenuData(TestCase):
 
         # one invalid menu name
         result4 = get_formatted_menu_data(['2021-12-05'])
-        self.assertEqual(result4, [])
+        self.assertEqual(result4, None)
 
     @mock.patch('galley.queries.make_request_to_galley')
     def test_get_formatted_menu_data_null(self, mock_retrieval_method):
         mock_retrieval_method.return_value = None
         result = get_formatted_menu_data([])
-        self.assertEqual(result, [])
+        self.assertEqual(result, None)
+    
+    @mock.patch('galley.formatted_queries.get_raw_menu_data')
+    def test_get_formatted_menu_data_args_defaults(self, mock_grmd):
+        dates = ['2021-11-14', '2021-10-04']
+        get_formatted_menu_data(dates)
+        mock_grmd.assert_called_with(dates, 'Vacaville', 'production')
+        get_formatted_menu_data(dates, 'Montana', 'staging')
+        mock_grmd.assert_called_with(dates, 'Montana', 'staging')

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -191,6 +191,40 @@ class TestQueryWeekMenuData(TestCase):
         mock_retrieval_method.return_value = None
         result = get_raw_menu_data([])
         self.assertEqual(result, [])
+    
+    @mock.patch('galley.queries.make_request_to_galley')
+    def test_get_raw_menu_data_filters_by_location(self, mock_retrieval_method):
+        mock_retrieval_method.return_value = {
+            'data': {
+                'viewer': {
+                    'menus': [
+                        mock_menu('2021-10-04', location_name='Vacaville'),
+                        mock_menu('2021-10-04', location_name='Long Beach'),
+                    ]
+                }
+            }
+        }
+        result = get_raw_menu_data(['2021-10-04'], location_name='Vacaville')
+        self.assertEqual(result, [mock_menu('2021-10-04',
+                                            location_name='Vacaville')])
+        self.assertEqual(len(result), 1)
+
+    @mock.patch('galley.queries.make_request_to_galley')
+    def test_get_raw_menu_data_filter_by_menu_type(self, mock_retrieval_method):
+        mock_retrieval_method.return_value = {
+            'data': {
+                'viewer': {
+                    'menus': [
+                        mock_menu('2021-10-04', menu_type='production'),
+                        mock_menu('2021-10-04', menu_type='development'),
+                    ]
+                }
+            }
+        }
+        result = get_raw_menu_data(['2021-10-04'], menu_type='production')
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result,
+                         [mock_menu('2021-10-04', menu_type='production')])
 
 
 class TestRecipesDataQuery(TestCase):

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -2,10 +2,9 @@ from unittest import mock, TestCase
 from sgqlc.operation import Operation
 
 from galley.queries import Query, get_raw_recipes_data, get_recipe_data, \
-    get_raw_menu_data, recipes_data_query, get_week_menu_data, MenuCategoryEnum, \
-    MenuCategoryValueEnum, get_recipe_nutrition_data
+    get_raw_menu_data, recipes_data_query, get_menu_data_for_dates, MenuCategoryEnum
 from tests.mock_responses.mock_menu_data import mock_menu
-from galley.types import FilterInput, MenuFilterInput
+from galley.types import MenuFilterInput
 
 import logging
 
@@ -266,201 +265,6 @@ class TestRecipesDataQuery(TestCase):
             preparations {
             name
             }
-            }'''.replace(' '*12, '')
-
-    def test_nutrition_query(self):
-        query_operation = Operation(Query)
-        query_operation.viewer().recipes(where=FilterInput(id=["cmVjaXBlOjE2NzEwOQ==", "cmVjaXBlOjE2OTEyMg==", "cmVjaXBlOjE2NTY5MA=="])).__fields__('id', 'externalName', 'notes', 'description', 'categoryValues', 'reconciledNutritionals')
-        query_str = bytes(query_operation).decode('utf-8')
-        self.assertEqual(query_str, self.expected_query)
-
-    def test_nutrition_query_failure(self):
-        query_operation = Operation(Query)
-        query_str = bytes(query_operation).decode('utf-8')
-        self.assertNotEqual(query_str, self.expected_query)
-
-    @mock.patch('galley.queries.make_request_to_galley')
-    def test_get_recipe_nutrition_data_successful(self, mock_retrieval_method):
-        def recipe(ID):
-            return ({
-                'id': ID,
-                'externalName': f'Test Recipe {ID}',
-                'notes': f'Some notes about recipe {ID}.',
-                'description': f'Details about recipe {ID}.',
-                'categoryValues': [
-                    {
-                        'name': 'vegan',
-                        'category': {
-                            'itemType': 'recipe',
-                            'name': 'protein'
-                        }
-                    },
-                    {
-                        'name': 'TS48',
-                        'category': {
-                            'itemType': 'recipe',
-                            'name': 'meal container'
-                        }
-                    },
-                    {
-                        'name': 'Dinner',
-                        'category': {
-                            'itemType': 'recipe',
-                            'name': 'meal type'
-                        }
-                    },
-                    {
-                        'name': 'true',
-                        'category': {
-                            'itemType': 'recipe',
-                            'name': 'is perishable'
-                        }
-                    }
-                ],
-                'reconciledNutritionals': {
-                    'addedSugarG': 0,
-                    'calciumMg': 111.98919574121712,
-                    'calciumPercentRDI': 0.086,
-                    'caloriesKCal': 432.85693190562375,
-                    'carbsG': 36.45962786638635,
-                    'carbsPercentDRV': 0.133,
-                    'cholesterolMg': 0,
-                    'cholesterolPercentDRV': None,
-                    'copperMg': 0.5571680986811711,
-                    'copperPercentRDI': 0.619,
-                    'fiberG': 8.935359363694342,
-                    'fiberPercentDRV': 0.319,
-                    'folateMcg': 66.74783312756712,
-                    'folatePercentRDI': 0.167,
-                    'ironMg': 7.189047392673014,
-                    'ironPercentRDI': 0.399,
-                    'magnesiumMg': 129.71436209264868,
-                    'magnesiumPercentRDI': 0.309,
-                    'manganeseMg': 1.5268803227284646,
-                    'manganesePercentRDI': 0.664,
-                    'niacinMg': 2.591144920835429,
-                    'niacinPercentRDI': 0.162,
-                    'pantothenicAcidMg': 0.4216704338299461,
-                    'phosphorusMg': 296.94409573351317,
-                    'phosphorusPercentRDI': 0.238,
-                    'potassiumMg': 358.1749624292856,
-                    'potassiumPercentRDI': 0.076,
-                    'proteinG': 9.484336690248725,
-                    'proteinPercentRDI': 0.19,
-                    'riboflavinMg': 0.25357865086256715,
-                    'riboflavinPercentRDI': 0.195,
-                    'saturatedFatG': 4.504105090278564,
-                    'seleniumMcg': 25.00140713878487,
-                    'seleniumPercentRDI': 0.455,
-                    'sodiumMg': 259.10792677825793,
-                    'sodiumPercentDRV': 0.113,
-                    'sugarG': 11.64282088688695,
-                    'sugarPercentDRV': None,
-                    'thiaminMg': 0.22938643609988163,
-                    'thiaminPercentRDI': 0.191,
-                    'totalFatG': 29.331998228140108,
-                    'totalFatPercentDRV': 0.376,
-                    'transFatG': 0.013683867180513159,
-                    'vitaminAMcg': 1.3704756299447372,
-                    'vitaminAPercentRDI': 0.002,
-                    'vitaminB12Mcg': 0,
-                    'vitaminB12PercentRDI': None,
-                    'vitaminB6Mg': 0.18718518681601845,
-                    'vitaminB6PercentRDI': 0.11,
-                    'vitaminCMg': 6.507446518274343,
-                    'vitaminCPercentRDI': 0.072,
-                    'vitaminDMcg': 0,
-                    'vitaminDPercentRDI': None,
-                    'vitaminEMg': 9.111428556325356,
-                    'vitaminEPercentRDI': 0.607,
-                    'vitaminKMcg': 0.9909650409871054,
-                    'vitaminKPercentRDI': 0.008,
-                    'zincMg': 1.961309534232711,
-                    'zincPercentRDI': 0.178
-                }
-            }) if ID is not '2' else []
-
-        def response(*recipes):
-            return ({
-                'data': {
-                    'viewer': {
-                        'recipes': [r for r in recipes if r]
-                    }
-                }
-            })
-
-        mock_retrieval_method.side_effect = [
-            response(recipe('1')),
-            response(recipe('1'), recipe('3'), recipe('4')),
-            response(recipe('2'), recipe('4')),
-            response(recipe('2')),
-        ]
-
-        # test one valid input id
-        result1 = get_recipe_nutrition_data(['1'])
-        self.assertEqual(result1, [recipe('1')])
-
-        # test multiple valid input ids
-        result2 = get_recipe_nutrition_data(['1', '3', '4'])
-        self.assertEqual(result2, [recipe('1'), recipe('3'), recipe('4')])
-
-        # test one valid input id and one invalid input id
-        result3 = get_recipe_nutrition_data(['2', '4'])
-        self.assertEqual(result3, [recipe('4')])
-
-        # test one invalid input id
-        result4 = get_recipe_nutrition_data(['2'])
-        self.assertEqual(result4, [])
-
-    @mock.patch('galley.queries.make_request_to_galley')
-    def test_get_recipe_nutrition_data_validation_failure(self, mock_retrieval_method):
-        mock_retrieval_method.return_value = {
-            'data': {
-                'viewer': {
-                    'test': 'test'
-                }
-            }
-        }
-
-        result = get_recipe_nutrition_data(['1'])
-        self.assertEqual(result, None)
-
-    @mock.patch('galley.queries.make_request_to_galley')
-    def test_nutrition_data_null(self, mock_retrieval_method):
-        mock_retrieval_method.return_value = None
-        result = get_recipe_nutrition_data(['2'])
-        self.assertEqual(result, None)
-
-
-class TestQueryWeekMenuData(TestCase):
-    def setUp(self) -> None:
-        self.expected_query = '''query {
-            viewer {
-            menus(where: {date: ["2021-10-04"]}) {
-            id
-            name
-            date
-            location {
-            name
-            }
-            categoryValues {
-            id
-            name
-            category {
-            id
-            name
-            itemType
-            }
-            }
-            menuItems {
-            recipeId
-            categoryValues {
-            id
-            name
-            category {
-            id
-            name
-            itemType
             }
             }
             recipe {
@@ -500,7 +304,7 @@ class TestQueryWeekMenuData(TestCase):
         self.assertEqual(query_str.replace(' ', ''), self.expected_query.replace(' ', ''))
 
     @mock.patch('galley.queries.make_request_to_galley')
-    def test_get_week_menu_data_successful(self, mock_retrieval_method):
+    def test_get_menu_data_for_dates_successful(self, mock_retrieval_method):
         def menus(date):
             return ({
                 'name': f"{date} 1_2_3",
@@ -511,7 +315,7 @@ class TestQueryWeekMenuData(TestCase):
                 },
                 'categoryValues': [
                     {
-                        'id': MenuCategoryValueEnum.PRODUCTION.value,
+                        'id': '1',
                         'name': 'production',
                         'category': {
                             'id': MenuCategoryEnum.MENU_TYPE.value,
@@ -580,25 +384,25 @@ class TestQueryWeekMenuData(TestCase):
         ]
 
         # one valid menu name
-        result1 = get_week_menu_data(['2021-11-14'])
+        result1 = get_menu_data_for_dates(['2021-11-14'])
         self.assertEqual(result1, [menus('2021-11-14')])
 
         # multiple valid menu names
-        result2 = get_week_menu_data(['2021-11-21', '2021-11-21',
+        result2 = get_menu_data_for_dates(['2021-11-21', '2021-11-21',
                                       '2021-11-28'])
         self.assertEqual(result2, [menus('2021-11-21'), menus('2021-11-21'),
                                    menus('2021-11-28')])
 
         # one valid menu name and one invalid menu name
-        result3 = get_week_menu_data(['2021-11-28', '2021-12-05'])
+        result3 = get_menu_data_for_dates(['2021-11-28', '2021-12-05'])
         self.assertEqual(result3, [menus('2021-11-28')])
 
         # one invalid menu name
-        result4 = get_week_menu_data(['2021-12-05'])
+        result4 = get_menu_data_for_dates(['2021-12-05'])
         self.assertEqual(result4, [])
 
     @mock.patch('galley.queries.make_request_to_galley')
-    def test_get_week_menu_data_validation_failure(self, mock_retrieval_method):
+    def test_get_menu_data_for_dates_validation_failure(self, mock_retrieval_method):
         mock_retrieval_method.return_value = {
             'data': {
                 'viewer': {
@@ -608,7 +412,7 @@ class TestQueryWeekMenuData(TestCase):
         }
 
         with self.assertRaises(ValueError):
-            get_week_menu_data(['YYYY-MM-DD'])
+            get_menu_data_for_dates(['YYYY-MM-DD'])
 
 class TestQueryGetRawRecipesData(TestCase):
     @mock.patch('galley.queries.make_request_to_galley')

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -203,8 +203,10 @@ class TestRecipesDataQuery(TestCase):
             notes
             description
             categoryValues {
+            id
             name
             category {
+            id
             name
             itemType
             }

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -157,21 +157,23 @@ class TestQueryWeekMenuData(TestCase):
         ]
 
         # one valid menu name
-        result1 = get_raw_menu_data(['2021-11-14'])
+        result1 = get_raw_menu_data(['2021-11-14'], "Vacaville", "production")
         self.assertEqual(result1, [mock_menu('2021-11-14')])
 
         # multiple valid menu names
-        result2 = get_raw_menu_data(['2021-11-21', '2021-11-21', '2021-11-28'])
+        result2 = get_raw_menu_data(['2021-11-21', '2021-11-21', '2021-11-28'],
+                                    "Vacaville", "production")
         self.assertEqual(result2, [mock_menu('2021-11-21'),
                                    mock_menu('2021-11-21'),
                                    mock_menu('2021-11-28')])
 
         # one valid menu name and one invalid menu name
-        result3 = get_raw_menu_data(['2021-11-28', '2021-12-05'])
+        result3 = get_raw_menu_data(['2021-11-28', '2021-12-05'],
+                                    "Vacaville", "production")
         self.assertEqual(result3, [mock_menu('2021-11-28')])
 
         # one invalid menu name
-        result4 = get_raw_menu_data(['2021-12-05'])
+        result4 = get_raw_menu_data(['2021-12-05'], "Vacaville", "production")
         self.assertEqual(result4, [])
 
     @mock.patch('galley.queries.make_request_to_galley')
@@ -184,12 +186,12 @@ class TestQueryWeekMenuData(TestCase):
             }
         }
         with self.assertRaises(ValueError):
-            get_raw_menu_data(['YYYY-MM-DD'])
+            get_raw_menu_data(['YYYY-MM-DD'], "Vacaville", "production")
 
     @mock.patch('galley.queries.make_request_to_galley')
     def test_get_raw_menu_data_null(self, mock_retrieval_method):
         mock_retrieval_method.return_value = None
-        result = get_raw_menu_data([])
+        result = get_raw_menu_data([], 'Vacaville', 'production')
         self.assertEqual(result, [])
     
     @mock.patch('galley.queries.make_request_to_galley')
@@ -198,13 +200,13 @@ class TestQueryWeekMenuData(TestCase):
             'data': {
                 'viewer': {
                     'menus': [
-                        mock_menu('2021-10-04', location_name='Vacaville'),
-                        mock_menu('2021-10-04', location_name='Long Beach'),
+                        mock_menu('2021-10-04', 'Vacaville'),
+                        mock_menu('2021-10-04', 'Long Beach'),
                     ]
                 }
             }
         }
-        result = get_raw_menu_data(['2021-10-04'], location_name='Vacaville')
+        result = get_raw_menu_data(['2021-10-04'], 'Vacaville', 'production')
         self.assertEqual(result, [mock_menu('2021-10-04',
                                             location_name='Vacaville')])
         self.assertEqual(len(result), 1)
@@ -221,7 +223,7 @@ class TestQueryWeekMenuData(TestCase):
                 }
             }
         }
-        result = get_raw_menu_data(['2021-10-04'], menu_type='production')
+        result = get_raw_menu_data(['2021-10-04'], 'Vacaville', 'production')
         self.assertEqual(len(result), 1)
         self.assertEqual(result,
                          [mock_menu('2021-10-04', menu_type='production')])

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -2,7 +2,8 @@ from unittest import mock, TestCase
 from sgqlc.operation import Operation
 
 from galley.queries import Query, get_raw_recipes_data, get_recipe_data, \
-    get_raw_menu_data, recipes_data_query, get_week_menu_data
+    get_raw_menu_data, recipes_data_query, get_week_menu_data, MenuCategoryEnum, \
+    MenuCategoryValueEnum, get_recipe_nutrition_data
 from tests.mock_responses.mock_menu_data import mock_menu
 from galley.types import FilterInput, MenuFilterInput
 
@@ -510,10 +511,10 @@ class TestQueryWeekMenuData(TestCase):
                 },
                 'categoryValues': [
                     {
-                        'id': '1',
+                        'id': MenuCategoryValueEnum.PRODUCTION.value,
                         'name': 'production',
                         'category': {
-                            'id': '1',
+                            'id': MenuCategoryEnum.MENU_TYPE.value,
                             'name': 'menu type',
                             'itemType': 'menu'
                         }

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -2,9 +2,9 @@ from unittest import mock, TestCase
 from sgqlc.operation import Operation
 
 from galley.queries import Query, get_raw_recipes_data, get_recipe_data, \
-    get_raw_menu_data, recipes_data_query, menu_data_query
-from tests.mock_responses import mock_recipes_data
+    get_raw_menu_data, recipes_data_query, get_week_menu_data
 from tests.mock_responses.mock_menu_data import mock_menu
+from galley.types import FilterInput, MenuFilterInput
 
 import logging
 
@@ -265,6 +265,201 @@ class TestRecipesDataQuery(TestCase):
             preparations {
             name
             }
+            }'''.replace(' '*12, '')
+
+    def test_nutrition_query(self):
+        query_operation = Operation(Query)
+        query_operation.viewer().recipes(where=FilterInput(id=["cmVjaXBlOjE2NzEwOQ==", "cmVjaXBlOjE2OTEyMg==", "cmVjaXBlOjE2NTY5MA=="])).__fields__('id', 'externalName', 'notes', 'description', 'categoryValues', 'reconciledNutritionals')
+        query_str = bytes(query_operation).decode('utf-8')
+        self.assertEqual(query_str, self.expected_query)
+
+    def test_nutrition_query_failure(self):
+        query_operation = Operation(Query)
+        query_str = bytes(query_operation).decode('utf-8')
+        self.assertNotEqual(query_str, self.expected_query)
+
+    @mock.patch('galley.queries.make_request_to_galley')
+    def test_get_recipe_nutrition_data_successful(self, mock_retrieval_method):
+        def recipe(ID):
+            return ({
+                'id': ID,
+                'externalName': f'Test Recipe {ID}',
+                'notes': f'Some notes about recipe {ID}.',
+                'description': f'Details about recipe {ID}.',
+                'categoryValues': [
+                    {
+                        'name': 'vegan',
+                        'category': {
+                            'itemType': 'recipe',
+                            'name': 'protein'
+                        }
+                    },
+                    {
+                        'name': 'TS48',
+                        'category': {
+                            'itemType': 'recipe',
+                            'name': 'meal container'
+                        }
+                    },
+                    {
+                        'name': 'Dinner',
+                        'category': {
+                            'itemType': 'recipe',
+                            'name': 'meal type'
+                        }
+                    },
+                    {
+                        'name': 'true',
+                        'category': {
+                            'itemType': 'recipe',
+                            'name': 'is perishable'
+                        }
+                    }
+                ],
+                'reconciledNutritionals': {
+                    'addedSugarG': 0,
+                    'calciumMg': 111.98919574121712,
+                    'calciumPercentRDI': 0.086,
+                    'caloriesKCal': 432.85693190562375,
+                    'carbsG': 36.45962786638635,
+                    'carbsPercentDRV': 0.133,
+                    'cholesterolMg': 0,
+                    'cholesterolPercentDRV': None,
+                    'copperMg': 0.5571680986811711,
+                    'copperPercentRDI': 0.619,
+                    'fiberG': 8.935359363694342,
+                    'fiberPercentDRV': 0.319,
+                    'folateMcg': 66.74783312756712,
+                    'folatePercentRDI': 0.167,
+                    'ironMg': 7.189047392673014,
+                    'ironPercentRDI': 0.399,
+                    'magnesiumMg': 129.71436209264868,
+                    'magnesiumPercentRDI': 0.309,
+                    'manganeseMg': 1.5268803227284646,
+                    'manganesePercentRDI': 0.664,
+                    'niacinMg': 2.591144920835429,
+                    'niacinPercentRDI': 0.162,
+                    'pantothenicAcidMg': 0.4216704338299461,
+                    'phosphorusMg': 296.94409573351317,
+                    'phosphorusPercentRDI': 0.238,
+                    'potassiumMg': 358.1749624292856,
+                    'potassiumPercentRDI': 0.076,
+                    'proteinG': 9.484336690248725,
+                    'proteinPercentRDI': 0.19,
+                    'riboflavinMg': 0.25357865086256715,
+                    'riboflavinPercentRDI': 0.195,
+                    'saturatedFatG': 4.504105090278564,
+                    'seleniumMcg': 25.00140713878487,
+                    'seleniumPercentRDI': 0.455,
+                    'sodiumMg': 259.10792677825793,
+                    'sodiumPercentDRV': 0.113,
+                    'sugarG': 11.64282088688695,
+                    'sugarPercentDRV': None,
+                    'thiaminMg': 0.22938643609988163,
+                    'thiaminPercentRDI': 0.191,
+                    'totalFatG': 29.331998228140108,
+                    'totalFatPercentDRV': 0.376,
+                    'transFatG': 0.013683867180513159,
+                    'vitaminAMcg': 1.3704756299447372,
+                    'vitaminAPercentRDI': 0.002,
+                    'vitaminB12Mcg': 0,
+                    'vitaminB12PercentRDI': None,
+                    'vitaminB6Mg': 0.18718518681601845,
+                    'vitaminB6PercentRDI': 0.11,
+                    'vitaminCMg': 6.507446518274343,
+                    'vitaminCPercentRDI': 0.072,
+                    'vitaminDMcg': 0,
+                    'vitaminDPercentRDI': None,
+                    'vitaminEMg': 9.111428556325356,
+                    'vitaminEPercentRDI': 0.607,
+                    'vitaminKMcg': 0.9909650409871054,
+                    'vitaminKPercentRDI': 0.008,
+                    'zincMg': 1.961309534232711,
+                    'zincPercentRDI': 0.178
+                }
+            }) if ID is not '2' else []
+
+        def response(*recipes):
+            return ({
+                'data': {
+                    'viewer': {
+                        'recipes': [r for r in recipes if r]
+                    }
+                }
+            })
+
+        mock_retrieval_method.side_effect = [
+            response(recipe('1')),
+            response(recipe('1'), recipe('3'), recipe('4')),
+            response(recipe('2'), recipe('4')),
+            response(recipe('2')),
+        ]
+
+        # test one valid input id
+        result1 = get_recipe_nutrition_data(['1'])
+        self.assertEqual(result1, [recipe('1')])
+
+        # test multiple valid input ids
+        result2 = get_recipe_nutrition_data(['1', '3', '4'])
+        self.assertEqual(result2, [recipe('1'), recipe('3'), recipe('4')])
+
+        # test one valid input id and one invalid input id
+        result3 = get_recipe_nutrition_data(['2', '4'])
+        self.assertEqual(result3, [recipe('4')])
+
+        # test one invalid input id
+        result4 = get_recipe_nutrition_data(['2'])
+        self.assertEqual(result4, [])
+
+    @mock.patch('galley.queries.make_request_to_galley')
+    def test_get_recipe_nutrition_data_validation_failure(self, mock_retrieval_method):
+        mock_retrieval_method.return_value = {
+            'data': {
+                'viewer': {
+                    'test': 'test'
+                }
+            }
+        }
+
+        result = get_recipe_nutrition_data(['1'])
+        self.assertEqual(result, None)
+
+    @mock.patch('galley.queries.make_request_to_galley')
+    def test_nutrition_data_null(self, mock_retrieval_method):
+        mock_retrieval_method.return_value = None
+        result = get_recipe_nutrition_data(['2'])
+        self.assertEqual(result, None)
+
+
+class TestQueryWeekMenuData(TestCase):
+    def setUp(self) -> None:
+        self.expected_query = '''query {
+            viewer {
+            menus(where: {date: ["2021-10-04"]}) {
+            id
+            name
+            date
+            location {
+            name
+            }
+            categoryValues {
+            id
+            name
+            category {
+            id
+            name
+            itemType
+            }
+            }
+            menuItems {
+            recipeId
+            categoryValues {
+            id
+            name
+            category {
+            id
+            name
+            itemType
             }
             }
             recipe {
@@ -291,6 +486,128 @@ class TestRecipesDataQuery(TestCase):
         query_str = bytes(query).decode('utf-8')
         self.assertEqual(query_str, self.expected_query)
 
+    def test_week_menu_data_query(self):
+        query_operation = Operation(Query)
+        query_operation.viewer().menus(where=MenuFilterInput(date=["2021-10-04"])).__fields__(
+            'id', 'name', 'date', 'location', 'categoryValues', 'menuItems'
+        )
+        query_operation.viewer.menus.menuItems.__fields__('recipeId', 'categoryValues', 'recipe')
+        query_operation.viewer.menus.menuItems.recipe.__fields__('externalName', 'recipeItems')
+        query_operation.viewer.menus.menuItems.recipe.recipeItems.__fields__('subRecipeId', 'preparations')
+        query_operation.viewer.menus.menuItems.recipe.recipeItems.preparations.__fields__('name')
+        query_str = query_operation.__to_graphql__(auto_select_depth=3)
+        self.assertEqual(query_str.replace(' ', ''), self.expected_query.replace(' ', ''))
+
+    @mock.patch('galley.queries.make_request_to_galley')
+    def test_get_week_menu_data_successful(self, mock_retrieval_method):
+        def menus(date):
+            return ({
+                'name': f"{date} 1_2_3",
+                'id': 'MENU123ABC',
+                'date': f"{date}",
+                'location': {
+                    'name': 'Vacaville'
+                },
+                'categoryValues': [
+                    {
+                        'id': '1',
+                        'name': 'production',
+                        'category': {
+                            'id': '1',
+                            'name': 'menu type',
+                            'itemType': 'menu'
+                        }
+                    },
+                ],
+                'menuItems': [
+                    {
+                        'recipeId': 'RECIPE1ABC',
+                        'categoryValues': [{
+                            'name': 'dv1',
+                            'category': {
+                                'itemType': 'menuItem',
+                                'name': 'menu item type'
+                            }
+                        }],
+                        'recipe': {
+                            'externalName': 'Test Recipe Name 1',
+                            'recipeItems': [{
+                                'preparations': [
+                                    {'name':  'standalone'}
+                                ],
+                                'subRecipeId': 'SUBRECIPEID456'
+                            }]
+                        },
+                    },
+                    {
+                        'recipeId': 'RECIPE2DEF',
+                        'categoryValues': [{
+                            'name': 'dv2',
+                            'category': {
+                                'itemType': 'menuItem',
+                                'name': 'menu item type'
+                            }
+                        }],
+                        'recipe': {
+                            'externalName': 'Test Recipe Name 2',
+                            'recipeItems': [{
+                                'preparations': [
+                                    {'name':  'standalone'}
+                                ],
+                                'subRecipeId': 'SUBRECIPEID789'
+                            }]
+                        },
+                    },
+                ]
+            }) if date != '2021-12-05' else []
+
+        def response(*menus):
+            return ({
+                'data': {
+                    'viewer': {
+                        'menus': [m for m in menus if m]
+                    }
+                }
+            })
+
+        mock_retrieval_method.side_effect = [
+            response(menus('2021-11-14')),
+            response(menus('2021-11-21'), menus('2021-11-21'),
+                     menus('2021-11-28')),
+            response(menus('2021-11-28'), menus('2021-12-05')),
+            response(menus('2021-12-05')),
+        ]
+
+        # one valid menu name
+        result1 = get_week_menu_data(['2021-11-14'])
+        self.assertEqual(result1, [menus('2021-11-14')])
+
+        # multiple valid menu names
+        result2 = get_week_menu_data(['2021-11-21', '2021-11-21',
+                                      '2021-11-28'])
+        self.assertEqual(result2, [menus('2021-11-21'), menus('2021-11-21'),
+                                   menus('2021-11-28')])
+
+        # one valid menu name and one invalid menu name
+        result3 = get_week_menu_data(['2021-11-28', '2021-12-05'])
+        self.assertEqual(result3, [menus('2021-11-28')])
+
+        # one invalid menu name
+        result4 = get_week_menu_data(['2021-12-05'])
+        self.assertEqual(result4, [])
+
+    @mock.patch('galley.queries.make_request_to_galley')
+    def test_get_week_menu_data_validation_failure(self, mock_retrieval_method):
+        mock_retrieval_method.return_value = {
+            'data': {
+                'viewer': {
+                    'test': 'test'
+                }
+            }
+        }
+
+        with self.assertRaises(ValueError):
+            get_week_menu_data(['YYYY-MM-DD'])
 
 class TestQueryGetRawRecipesData(TestCase):
     @mock.patch('galley.queries.make_request_to_galley')


### PR DESCRIPTION
## Description

https://linear.app/thistle/issue/ENG-821/set-up-caching-for-menu-data

Please include a summary of the change. List any dependencies that are required for this pull request.
- Changes menu query to take list of dates instead of names
- added filtering based on location and menu type for menu data
- added menu category enum to hold id values
- expanded category and category values fields to return ids
- adjusted existing tests to reflect the above

## Test Plan
Please describe tests that you ran to verify your changes and include relevant details for tests configuration.
- check automated tests
- to test method in python console,`from galley.queries import get_raw_menu_data` then pass a list of dates, can also be filtered based on menu type and location
- to test filtering on menu type duplicate a menu and then change tag menu type in galley to development.

## Versioning
Please update the project version in setup.py
