### PR TITLE
(ENG-818) adding weight to recipe details

### DIFF
--- a/galley/formatted_queries.py
+++ b/galley/formatted_queries.py
@@ -90,12 +90,12 @@ class FormattedRecipe:
 def ingredients_from_recipe_items(recipe_items: List[Dict]) -> Optional[List]:
     ingredients: List[str] = []
 
-    for recipe_item in recipe_items:
-        ingredient = recipe_item.get('ingredient')
-        sub_recipe = recipe_item.get('subRecipe')
+    for recipeItem in recipe_items:
+        ingredient = recipeItem.get('ingredient')
+        sub_recipe = recipeItem.get('subRecipe')
         recipe_item = RecipeItem(
             ingredient=ingredient if ingredient else None,
-            preparations=recipe_item.get('preparations', [])
+            preparations=recipeItem.get('preparations', [])
         )
 
         # Top Level Ingredient

--- a/galley/formatted_queries.py
+++ b/galley/formatted_queries.py
@@ -65,11 +65,11 @@ class FormattedRecipe:
             'mealContainer': self.mealContainer,
             'mealType': self.mealType,
             'ingredients': ingredients_from_recipe_items(recipe_items=self.recipe_items),
-            'totalWeight': weight_from_recipe_tree_components(recipe_tree_components=self.recipe_tree_components)
+            'weight': weight_from_recipe_tree_components(recipe_tree_components=self.recipe_tree_components)
         }
 
 
-def weight_from_recipe_tree_components(recipe_tree_components: List[Dict]) -> int:
+def weight_from_recipe_tree_components(recipe_tree_components: List[Dict]) -> float:
     total_weight = 0
     for recipe_tree_component in recipe_tree_components:
         recipe_item_dict = recipe_tree_component.get('recipeItem', {})
@@ -79,10 +79,11 @@ def weight_from_recipe_tree_components(recipe_tree_components: List[Dict]) -> in
                 ingredient=recipe_item_dict.get('ingredient', {}),
                 quantity_unit_values=recipe_tree_component.get('quantityUnitValues', [])
             )
+
             if recipe_item.is_standalone() or recipe_item.is_packaging():
                 continue
             total_weight += recipe_item.mass() if recipe_item.mass() else 0
-    return total_weight
+    return round(total_weight, 2)
 
 
 def ingredients_from_recipe_items(recipe_items: List[Dict]) -> Optional[List]:

--- a/galley/queries.py
+++ b/galley/queries.py
@@ -21,7 +21,7 @@ class MenuCategoryEnum(Enum):
 class Viewer(Type):
     recipes = Field(Recipe, args=(ArgDict({'where': FilterInput})))
     recipe = Field(Recipe, args=(ArgDict({'id': str})))
-    menus = Field(Menu, args=(ArgDict({'where': FilterInput})))
+    menus = Field(Menu, args=(ArgDict({'where': MenuFilterInput})))
 
 
 # This is graphql root for querying data according to sgqlc lib. So this class name has to be Query.

--- a/galley/queries.py
+++ b/galley/queries.py
@@ -10,8 +10,6 @@ from enum import Enum
 
 logger = logging.getLogger(__name__)
 
-FOOD_PACKAGING = 'food pkg'
-STANDALONE = 'standalone'
 
 class MenuCategoryEnum(Enum):
     """
@@ -19,10 +17,11 @@ class MenuCategoryEnum(Enum):
     """
     MENU_TYPE = 'Y2F0ZWdvcnk6MjQ2NQ=='
 
+
 class Viewer(Type):
     recipes = Field(Recipe, args=(ArgDict({'where': FilterInput})))
-    recipe = Field(Recipe, args={'id': str})
-    menus = Field(Menu, args=(ArgDict({'where': MenuFilterInput})))
+    recipe = Field(Recipe, args=(ArgDict({'id': str})))
+    menus = Field(Menu, args=(ArgDict({'where': FilterInput})))
 
 
 # This is graphql root for querying data according to sgqlc lib. So this class name has to be Query.
@@ -68,6 +67,13 @@ def recipes_data_query(recipe_ids: List[str]) -> Optional[Operation]:
     query.viewer.recipes.recipeItems.__fields__('ingredient', 'subRecipe', 'preparations')
     query.viewer.recipes.recipeItems.ingredient.__fields__('externalName', 'categoryValues')
     query.viewer.recipes.recipeItems.ingredient.categoryValues.__fields__('name')
+    query.viewer.recipes.recipeTreeComponents(levels=[1]).__fields__('quantityUnitValues')
+    query.viewer.recipes.recipeTreeComponents.quantityUnitValues.__fields__('unit', 'value')
+    query.viewer.recipes.recipeTreeComponents.quantityUnitValues.unit.__fields__('name')
+    query.viewer.recipes.recipeTreeComponents.recipeItem.__fields__('preparations', 'ingredient')
+    query.viewer.recipes.recipeTreeComponents.recipeItem.preparations.__fields__('name')
+    query.viewer.recipes.recipeTreeComponents.recipeItem.ingredient.__fields__('categoryValues', 'externalName')
+    query.viewer.recipes.recipeTreeComponents.recipeItem.ingredient.categoryValues.__fields__('name')
     return query
 
 

--- a/galley/types.py
+++ b/galley/types.py
@@ -1,4 +1,4 @@
-from sgqlc.types import Field, Type, Input, datetime as d, Enum, ID, list_of
+from sgqlc.types import Field, Type, Input, datetime as d, Enum, ID, list_of, Int, ArgDict
 
 
 class CategoryItemTypeEnum(Enum):
@@ -104,12 +104,27 @@ class RecipeItem(Type):
     preparations = Field(Preparation)
 
 
+class Unit(Type):
+    name = Field(str)
+
+
+class UnitValue(Type):
+    value = float
+    unit = Field(Unit)
+
+
+class RecipeTreeComponent(Type):
+    quantityUnitValues = Field(UnitValue)
+    recipeItem = Field(RecipeItem)
+
+
 class Recipe(Type):
     id = str
     externalName = str
     instructions = str
     notes = str
     description = str
+    recipeTreeComponents = Field(RecipeTreeComponent, args=ArgDict(levels=list_of(Int)))
     reconciledNutritionals = Field(Nutrition)
     categoryValues = Field(CategoryValue)
     recipeItems = Field(RecipeItem)
@@ -137,10 +152,6 @@ class RecipeInstructionPayload(Type):
 
 
 class Location(Type):
-    name = str
-
-
-class Unit(Type):
     name = str
 
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # are dependencies that are required on remote installs, not local development.
 setup(
     name='galley_sdk',
-    version='0.12.0',
+    version='0.13.0',
     packages=['galley'],
     install_requires=['sgqlc==14.0', 'backoff==1.11.1']
 )

--- a/tests/mock_responses/mock_recipe_tree_components.py
+++ b/tests/mock_responses/mock_recipe_tree_components.py
@@ -1,0 +1,412 @@
+mock_data = [
+    {
+        'quantityUnitValues': [
+            {
+                'unit': {
+                    'name': 'g'
+                },
+                'value': 276.40785022499995
+            },
+            {
+                'unit': {
+                    'name': 'kg'
+                },
+                'value': 0.276407850225
+            },
+            {
+                'unit': {
+                    'name': 'oz'
+                },
+                'value': 9.75
+            },
+            {
+                'unit': {
+                    'name': 'lb'
+                },
+                'value': 0.6093749994626232
+            },
+            {
+                'unit': {
+                    'name': 'each'
+                },
+                'value': 1
+            }
+        ],
+        'recipeItem': {
+            'ingredient': None,
+            'preparations': []
+        }
+    },
+    {
+        'quantityUnitValues': [
+            {
+                'unit': {
+                    'name': 'g'
+                },
+                'value': 276.40785022499995
+            },
+            {
+                'unit': {
+                    'name': 'kg'
+                },
+                'value': 0.276407850225
+            },
+            {
+                'unit': {
+                    'name': 'oz'
+                },
+                'value': 9.75
+            },
+            {
+                'unit': {
+                    'name': 'lb'
+                },
+                'value': 0.6093749994626232
+            },
+            {
+                'unit': {
+                    'name': 'each'
+                },
+                'value': 1
+            }
+        ],
+        'recipeItem': {
+            'ingredient': None,
+            'preparations': []
+        }
+    },
+    {
+        'quantityUnitValues': [
+            {
+                'unit': {
+                    'name': 'g'
+                },
+                'value': 276.40785022499995
+            },
+            {
+                'unit': {
+                    'name': 'kg'
+                },
+                'value': 0.276407850225
+            },
+            {
+                'unit': {
+                    'name': 'oz'
+                },
+                'value': 9.75
+            },
+            {
+                'unit': {
+                    'name': 'lb'
+                },
+                'value': 0.6093749994626232
+            },
+            {
+                'unit': {
+                    'name': 'each'
+                },
+                'value': 1
+            }
+        ],
+        'recipeItem': {
+            'ingredient': None,
+            'preparations': [
+                {
+                    'name': '2 oz RAM'
+                },
+                {   'name': 'standalone'
+                }
+            ]
+        }
+    },
+    {
+        'quantityUnitValues': [
+            {
+                'unit': {
+                    'name': 'g'
+                },
+                'value': 276.40785022499995
+            },
+            {
+                'unit': {
+                    'name': 'kg'
+                },
+                'value': 0.276407850225
+            },
+            {
+                'unit': {
+                    'name': 'oz'
+                },
+                'value': 9.75
+            },
+            {
+                'unit': {
+                    'name': 'lb'
+                },
+                'value': 0.6093749994626232
+            },
+            {
+                'unit': {
+                    'name': 'each'
+                },
+                'value': 1
+            }
+        ],
+        'recipeItem': {
+            'ingredient': None,
+            'preparations': []
+        }
+    },
+    {
+        'quantityUnitValues': [
+            {
+                'unit': {
+                    'name': 'g'
+                },
+                'value': 276.40785022499995
+            },
+            {
+                'unit': {
+                    'name': 'kg'
+                },
+                'value': 0.276407850225
+            },
+            {
+                'unit': {
+                    'name': 'oz'
+                },
+                'value': 9.75
+            },
+            {
+                'unit': {
+                    'name': 'lb'
+                },
+                'value': 0.6093749994626232
+            },
+            {
+                'unit': {
+                    'name': 'each'
+                },
+                'value': 1
+            }
+        ],
+        'recipeItem': {
+            'ingredient': {
+                'categoryValues': [
+                    {
+                        'name': 'food pkg'
+                    }
+                ],
+                'externalName': '48 oz Meal Boxes'
+            },    
+            'preparations': []
+        }
+    },
+    {
+        'quantityUnitValues': [],
+        'recipeItem': {
+            'ingredient': None, 
+            'preparations': []
+        }
+    }
+]  
+
+mock_data_no_pkg_no_standalone = [
+    {
+        'quantityUnitValues': [
+            {
+                'unit': {
+                    'name': 'g'
+                },
+                'value': 276.40785022499995
+            },
+            {
+                'unit': {
+                    'name': 'kg'
+                },
+                'value': 0.276407850225
+            },
+            {
+                'unit': {
+                    'name': 'oz'
+                },
+                'value': 9.75
+            },
+            {
+                'unit': {
+                    'name': 'lb'
+                },
+                'value': 0.6093749994626232
+            },
+            {
+                'unit': {
+                    'name': 'each'
+                },
+                'value': 1
+            }
+        ],
+        'recipeItem': {
+            'ingredient': None,
+            'preparations': []
+        }
+    },
+    {
+        'quantityUnitValues': [
+            {
+                'unit': {
+                    'name': 'g'
+                },
+                'value': 276.40785022499995
+            },
+            {
+                'unit': {
+                    'name': 'kg'
+                },
+                'value': 0.276407850225
+            },
+            {
+                'unit': {
+                    'name': 'oz'
+                },
+                'value': 9.75
+            },
+            {
+                'unit': {
+                    'name': 'lb'
+                },
+                'value': 0.6093749994626232
+            },
+            {
+                'unit': {
+                    'name': 'each'
+                },
+                'value': 1
+            }
+        ],
+        'recipeItem': {
+            'ingredient': None,
+            'preparations': []
+        }
+    },
+    {
+        'quantityUnitValues': [
+            {
+                'unit': {
+                    'name': 'g'
+                },
+                'value': 276.40785022499995
+            },
+            {
+                'unit': {
+                    'name': 'kg'
+                },
+                'value': 0.276407850225
+            },
+            {
+                'unit': {
+                    'name': 'oz'
+                },
+                'value': 9.75
+            },
+            {
+                'unit': {
+                    'name': 'lb'
+                },
+                'value': 0.6093749994626232
+            },
+            {
+                'unit': {
+                    'name': 'each'
+                },
+                'value': 1
+            }
+        ],
+        'recipeItem': {
+            'ingredient': None,
+            'preparations': []
+        }
+    },
+    {
+        'quantityUnitValues': [
+            {
+                'unit': {
+                    'name': 'g'
+                },
+                'value': 276.40785022499995
+            },
+            {
+                'unit': {
+                    'name': 'kg'
+                },
+                'value': 0.276407850225
+            },
+            {
+                'unit': {
+                    'name': 'oz'
+                },
+                'value': 9.75
+            },
+            {
+                'unit': {
+                    'name': 'lb'
+                },
+                'value': 0.6093749994626232
+            },
+            {
+                'unit': {
+                    'name': 'each'
+                },
+                'value': 1
+            }
+        ],
+        'recipeItem': {
+            'ingredient': None,
+            'preparations': []
+        }
+    },
+    {
+        'quantityUnitValues': [
+            {
+                'unit': {
+                    'name': 'g'
+                },
+                'value': 276.40785022499995
+            },
+            {
+                'unit': {
+                    'name': 'kg'
+                },
+                'value': 0.276407850225
+            },
+            {
+                'unit': {
+                    'name': 'oz'
+                },
+                'value': 9.75
+            },
+            {
+                'unit': {
+                    'name': 'lb'
+                },
+                'value': 0.6093749994626232
+            },
+            {
+                'unit': {
+                    'name': 'each'
+                },
+                'value': 1
+            }
+        ],
+        'recipeItem': {
+            'ingredient': None,  
+            'preparations': []
+        }
+    },
+    {
+        'quantityUnitValues': [],
+        'recipeItem': {
+            'ingredient': None, 
+            'preparations': []
+        }
+    }
+]              

--- a/tests/mock_responses/mock_recipes_data.py
+++ b/tests/mock_responses/mock_recipes_data.py
@@ -37,5 +37,6 @@ def mock_recipe(id):
             }
         ],
         'recipeItems': mock_recipe_items.mock_data,        
-        'reconciledNutritionals': mock_nutrition_data.mock_data                
+        'reconciledNutritionals': mock_nutrition_data.mock_data,
+        'recipeTreeComponents': []
     })

--- a/tests/mock_responses/mock_recipes_data.py
+++ b/tests/mock_responses/mock_recipes_data.py
@@ -1,4 +1,4 @@
-from tests.mock_responses import mock_nutrition_data, mock_recipe_items
+from tests.mock_responses import mock_nutrition_data, mock_recipe_items, mock_recipe_tree_components
 
 def mock_recipe(id):
     return ({
@@ -38,5 +38,5 @@ def mock_recipe(id):
         ],
         'recipeItems': mock_recipe_items.mock_data,        
         'reconciledNutritionals': mock_nutrition_data.mock_data,
-        'recipeTreeComponents': []
+        'recipeTreeComponents': mock_recipe_tree_components.mock_data
     })

--- a/tests/test_formatted_queries.py
+++ b/tests/test_formatted_queries.py
@@ -32,7 +32,6 @@ class TestIngredientsFromRecipeItems(TestCase):
 class TestGetFormattedRecipesData(TestCase):
     @mock.patch('galley.queries.make_request_to_galley')
     def test_get_formatted_recipes_data_successful(self, mock_retrieval_method):
-        self.maxDiff = None
         expected_result = [
             {
                 'id': '1',

--- a/tests/test_formatted_queries.py
+++ b/tests/test_formatted_queries.py
@@ -32,6 +32,7 @@ class TestIngredientsFromRecipeItems(TestCase):
 class TestGetFormattedRecipesData(TestCase):
     @mock.patch('galley.queries.make_request_to_galley')
     def test_get_formatted_recipes_data_successful(self, mock_retrieval_method):
+        self.maxDiff = None
         expected_result = [
             {
                 'id': '1',
@@ -50,6 +51,7 @@ class TestGetFormattedRecipesData(TestCase):
                     'Unique 2',
                     'Unique 4'
                 ],
+                'totalWeight': 0
             },
             {
                 'id': '2',
@@ -68,6 +70,7 @@ class TestGetFormattedRecipesData(TestCase):
                     'Unique 2',
                     'Unique 4'
                 ],
+                'totalWeight': 0
             }
         ]
 

--- a/tests/test_formatted_queries.py
+++ b/tests/test_formatted_queries.py
@@ -1,9 +1,9 @@
 from unittest import mock, TestCase
 
 from galley.formatted_queries import get_formatted_recipes_data, ingredients_from_recipe_items, \
-    get_formatted_menu_data
+    get_formatted_menu_data, weight_from_recipe_tree_components
 
-from tests.mock_responses import mock_nutrition_data, mock_recipes_data, mock_recipe_items
+from tests.mock_responses import mock_nutrition_data, mock_recipes_data, mock_recipe_items, mock_recipe_tree_components
 from tests.mock_responses.mock_menu_data import mock_menu
 
 
@@ -28,6 +28,21 @@ class TestIngredientsFromRecipeItems(TestCase):
         result = ingredients_from_recipe_items([])
         self.assertEqual(result, [])
 
+class TestWeightFromRecipeTreeComponents(TestCase):
+    def test_weight_from_recipe_tree_components_with_pkg_and_standalone(self):
+        expected_result = 829.22
+        result = weight_from_recipe_tree_components(mock_recipe_tree_components.mock_data)
+        self.assertEqual(result, expected_result)
+
+    def test_weight_from_recipe_tree_components_successful_no_pkg_no_standalone(self):
+        expected_result = 1382.04
+        result = weight_from_recipe_tree_components(mock_recipe_tree_components.mock_data_no_pkg_no_standalone)
+        self.assertEqual(result, expected_result)
+
+    def test_weight_from_recipe_tree_components_empty(self):
+        result = weight_from_recipe_tree_components([])
+        self.assertEqual(result, 0)
+
 
 class TestGetFormattedRecipesData(TestCase):
     @mock.patch('galley.queries.make_request_to_galley')
@@ -50,7 +65,7 @@ class TestGetFormattedRecipesData(TestCase):
                     'Unique 2',
                     'Unique 4'
                 ],
-                'totalWeight': 0
+                'weight': 829.22
             },
             {
                 'id': '2',
@@ -69,7 +84,7 @@ class TestGetFormattedRecipesData(TestCase):
                     'Unique 2',
                     'Unique 4'
                 ],
-                'totalWeight': 0
+                'weight': 829.22
             }
         ]
 

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -322,6 +322,25 @@ class TestRecipesDataQuery(TestCase):
             name
             }
             }
+            recipeTreeComponents(levels: [1]) {
+            quantityUnitValues {
+            unit {
+            name
+            }
+            value
+            }
+            recipeItem {
+            preparations {
+            name
+            }
+            ingredient {
+            categoryValues {
+            name
+            }
+            externalName
+            }
+            }
+            }
             }
             }
             }'''.replace(' '*12, '')


### PR DESCRIPTION
## Description
adds `totalWeight` as output to formatted recipes from `get_formatted_recipes_data`

## Test Plan
automated tests passing...

manual test:
```
>>> import pprint; import galley
>>> from galley.formatted_queries import *
>>> result=get_formatted_recipes_data(['cmVjaXBlOjE4MjEzOA=='])
>>> pp = pprint.PrettyPrinter()
>>> pp.pprint(result)
[{'description': None,
  'externalName': None,
  'id': 'cmVjaXBlOjE4MjEzOA==',
...
                'zincPercentRDI': 0.321},
  'proteinType': 'vegan',
  'totalWeight': 389.80594262499994}]
```

note that if you comment out skipping standalone and packaging items

```
            if recipeItem:
                recipe_item = RecipeItem(
                    preparations=recipeItem.get('preparations', []),
                    ingredient=ingredient if ingredient else None,
                    quantity_unit_values=recipe_tree_component.get('quantityUnitValues', [])
                )
                #if recipe_item.is_standalone() or recipe_item.is_packaging():
                #    continue
                total_weight += recipe_item.mass() if recipe_item.mass() else 0
```

and then total weight is...

```
'totalWeight': 521.347758158523}]
```

which matches what we see for this recipe in galley dashboard https://staging-app.galleysolutions.com/recipes/cmVjaXBlOjE4MjEzOA==/?userLocationId=bG9jYXRpb246MTkyOA%3D%3D

```
521.347758158523 g = 1.1493750614864244  lb
Galley Dashboard has TOTAL WEIGHT: 1.149 lb for this recipe
```

## Versioning
Please update the project version in setup.py
