### PR TITLE
Eng 882

### DIFF
--- a/galley/enums.py
+++ b/galley/enums.py
@@ -14,3 +14,10 @@ class PreparationEnum(Enum):
     STANDALONE = 'cHJlcGFyYXRpb246MjgzMzQ='
     TWO_OUNCE_RAM = 'cHJlcGFyYXRpb246MjgxMTU='
     THREE_OUNCE_RAM = 'cHJlcGFyYXRpb246MjgxMTQ='
+
+
+class IngredientCategoryEnum(Enum):
+    """
+    Enum for Ingredient Categories. <category name>: <category id>
+    """
+    FOOD_PACKAGE = "Y2F0ZWdvcnlWYWx1ZToxNDAxNQ=="

--- a/galley/enums.py
+++ b/galley/enums.py
@@ -1,0 +1,16 @@
+from enum import Enum
+
+class MenuCategoryEnum(Enum):
+    """
+    Enum for categories, for item type menu <category name>: <category id>
+    """
+    MENU_TYPE = 'Y2F0ZWdvcnk6MjQ2NQ=='
+
+
+class PreparationEnum(Enum):
+    """
+    Enum for preparations.  <preparation name>: <preparation id>
+    """
+    STANDALONE = 'cHJlcGFyYXRpb246MjgzMzQ='
+    TWO_OUNCE_RAM = 'cHJlcGFyYXRpb246MjgxMTU='
+    THREE_OUNCE_RAM = 'cHJlcGFyYXRpb246MjgxMTQ='

--- a/galley/enums.py
+++ b/galley/enums.py
@@ -21,3 +21,8 @@ class IngredientCategoryEnum(Enum):
     Enum for Ingredient Categories. <category name>: <category id>
     """
     FOOD_PACKAGE = "Y2F0ZWdvcnlWYWx1ZToxNDAxNQ=="
+
+class TagTypeEnum(Enum):
+    """
+    """
+    CATEGORY_TAG_TYPE = "Y2F0ZWdvcnk6MjQyMA=="

--- a/galley/formatted_queries.py
+++ b/galley/formatted_queries.py
@@ -1,10 +1,8 @@
 from typing import Dict, Optional, List
 
-from galley.enums import MenuCategoryEnum, PreparationEnum
+from galley.enums import IngredientCategoryEnum, MenuCategoryEnum, PreparationEnum
 from galley.pagination import paginate_results
 from galley.queries import get_raw_recipes_data, get_raw_menu_data
-
-FOOD_PACKAGING = 'food pkg'
 
 
 class RecipeItem:
@@ -18,7 +16,7 @@ class RecipeItem:
 
     # TODO: on staging/prod I was unable to find a listed category of "food pkg" is this still relevant?
     def is_packaging(self):
-        return any(cat_val.get('name') == FOOD_PACKAGING for cat_val in self.category_values)
+        return any(cat_val.get('id') == IngredientCategoryEnum.FOOD_PACKAGE.value for cat_val in self.category_values)
 
     def mass(self):
         if self.quantity_unit_values is None:

--- a/galley/formatted_queries.py
+++ b/galley/formatted_queries.py
@@ -1,6 +1,6 @@
 from typing import Dict, Optional, List
 
-from galley.enums import IngredientCategoryEnum, MenuCategoryEnum, PreparationEnum
+from galley.enums import IngredientCategoryEnum, MenuCategoryEnum, PreparationEnum, TagTypeEnum
 from galley.pagination import paginate_results
 from galley.queries import get_raw_recipes_data, get_raw_menu_data
 
@@ -14,9 +14,11 @@ class RecipeItem:
     def is_standalone(self):
         return any(prep.get('id') == PreparationEnum.STANDALONE.value for prep in self.preparations)
 
-    # TODO: on staging/prod I was unable to find a listed category of "food pkg" is this still relevant?
     def is_packaging(self):
-        return any(cat_val.get('id') == IngredientCategoryEnum.FOOD_PACKAGE.value for cat_val in self.category_values)
+        return any(
+            cat_val.get('id') == IngredientCategoryEnum.FOOD_PACKAGE.value and
+            cat_val.get('category', {}).get('id') == TagTypeEnum.CATEGORY_TAG_TYPE.value for cat_val in self.category_values
+        )
 
     def mass(self):
         if self.quantity_unit_values is None:

--- a/galley/formatted_queries.py
+++ b/galley/formatted_queries.py
@@ -1,10 +1,10 @@
 from typing import Dict, Optional, List
 
-from galley.queries import MenuCategoryEnum, get_raw_recipes_data, get_raw_menu_data
+from galley.enums import MenuCategoryEnum, PreparationEnum
 from galley.pagination import paginate_results
+from galley.queries import get_raw_recipes_data, get_raw_menu_data
 
 FOOD_PACKAGING = 'food pkg'
-STANDALONE = 'standalone'
 
 
 class RecipeItem:
@@ -14,8 +14,9 @@ class RecipeItem:
         self.quantity_unit_values = quantity_unit_values
 
     def is_standalone(self):
-        return any(prep.get('name') == STANDALONE for prep in self.preparations)
+        return any(prep.get('id') == PreparationEnum.STANDALONE.value for prep in self.preparations)
 
+    # TODO: on staging/prod I was unable to find a listed category of "food pkg" is this still relevant?
     def is_packaging(self):
         return any(cat_val.get('name') == FOOD_PACKAGING for cat_val in self.category_values)
 
@@ -118,7 +119,7 @@ def ingredients_from_recipe_items(recipe_items: List[Dict]) -> Optional[List]:
 def get_standalone(recipe_items):
     for recipe_item in recipe_items:
         preparations = recipe_item.get('preparations', [])
-        is_standalone = any(prep['name'] == STANDALONE for prep in preparations)
+        is_standalone = any(prep['id'] == PreparationEnum.STANDALONE.value for prep in preparations)
 
         if is_standalone:
             return recipe_item.get('subRecipeId')

--- a/galley/queries.py
+++ b/galley/queries.py
@@ -58,14 +58,13 @@ def recipes_data_query(recipe_ids: List[str]) -> Optional[Operation]:
     )
     query.viewer.recipes.recipeItems.__fields__('ingredient', 'subRecipe', 'preparations')
     query.viewer.recipes.recipeItems.ingredient.__fields__('externalName', 'categoryValues')
-    query.viewer.recipes.recipeItems.ingredient.categoryValues.__fields__('id', 'name')
     query.viewer.recipes.recipeTreeComponents(levels=[1]).__fields__('quantityUnitValues')
     query.viewer.recipes.recipeTreeComponents.quantityUnitValues.__fields__('unit', 'value')
     query.viewer.recipes.recipeTreeComponents.quantityUnitValues.unit.__fields__('name')
     query.viewer.recipes.recipeTreeComponents.recipeItem.__fields__('preparations', 'ingredient')
     query.viewer.recipes.recipeTreeComponents.recipeItem.preparations.__fields__('id', 'name')
     query.viewer.recipes.recipeTreeComponents.recipeItem.ingredient.__fields__('categoryValues', 'externalName')
-    query.viewer.recipes.recipeTreeComponents.recipeItem.ingredient.categoryValues.__fields__('id', 'name')
+    query.viewer.recipes.recipeTreeComponents.recipeItem.ingredient.categoryValues.__fields__('id', 'name', 'category')
     return query
 
 
@@ -86,7 +85,7 @@ def get_menu_query(dates: List[str]) -> Optional[List[Dict]]:
                                                    'recipeItems')
     query.viewer.menus.menuItems.recipe.recipeItems.__fields__('subRecipeId',
                                                                'preparations')
-    query.viewer.menus.menuItems.recipe.recipeItems.preparations.__fields__('id','name')
+    query.viewer.menus.menuItems.recipe.recipeItems.preparations.__fields__('id', 'name')
     return query
 
 

--- a/galley/queries.py
+++ b/galley/queries.py
@@ -3,19 +3,11 @@ from sgqlc.operation import Operation
 from sgqlc.types import Field, Type, ArgDict
 
 from galley.common import make_request_to_galley, validate_response_data
+from galley.enums import MenuCategoryEnum
 from galley.types import Recipe, Menu, FilterInput, MenuFilterInput
 import logging
 
-from enum import Enum
-
 logger = logging.getLogger(__name__)
-
-
-class MenuCategoryEnum(Enum):
-    """
-    Enum for categories, for item type menu <category name>: <category id>
-    """
-    MENU_TYPE = 'Y2F0ZWdvcnk6MjQ2NQ=='
 
 
 class Viewer(Type):
@@ -66,14 +58,14 @@ def recipes_data_query(recipe_ids: List[str]) -> Optional[Operation]:
     )
     query.viewer.recipes.recipeItems.__fields__('ingredient', 'subRecipe', 'preparations')
     query.viewer.recipes.recipeItems.ingredient.__fields__('externalName', 'categoryValues')
-    query.viewer.recipes.recipeItems.ingredient.categoryValues.__fields__('name')
+    query.viewer.recipes.recipeItems.ingredient.categoryValues.__fields__('id', 'name')
     query.viewer.recipes.recipeTreeComponents(levels=[1]).__fields__('quantityUnitValues')
     query.viewer.recipes.recipeTreeComponents.quantityUnitValues.__fields__('unit', 'value')
     query.viewer.recipes.recipeTreeComponents.quantityUnitValues.unit.__fields__('name')
     query.viewer.recipes.recipeTreeComponents.recipeItem.__fields__('preparations', 'ingredient')
-    query.viewer.recipes.recipeTreeComponents.recipeItem.preparations.__fields__('name')
+    query.viewer.recipes.recipeTreeComponents.recipeItem.preparations.__fields__('id', 'name')
     query.viewer.recipes.recipeTreeComponents.recipeItem.ingredient.__fields__('categoryValues', 'externalName')
-    query.viewer.recipes.recipeTreeComponents.recipeItem.ingredient.categoryValues.__fields__('name')
+    query.viewer.recipes.recipeTreeComponents.recipeItem.ingredient.categoryValues.__fields__('id', 'name')
     return query
 
 
@@ -94,8 +86,7 @@ def get_menu_query(dates: List[str]) -> Optional[List[Dict]]:
                                                    'recipeItems')
     query.viewer.menus.menuItems.recipe.recipeItems.__fields__('subRecipeId',
                                                                'preparations')
-    query.viewer.menus.menuItems.recipe.recipeItems.preparations\
-                                                   .__fields__('name')
+    query.viewer.menus.menuItems.recipe.recipeItems.preparations.__fields__('id','name')
     return query
 
 
@@ -126,8 +117,8 @@ def get_raw_menu_data(dates: List[str],
             if menu['location']['name'] == location_name:
                 categoryValues = menu['categoryValues']
                 for categoryValue in categoryValues:
-                    if (categoryValue['category']['id'] == MenuCategoryEnum.
-                       MENU_TYPE.value and categoryValue['name'] == menu_type):
+                    if (categoryValue['category']['id'] == MenuCategoryEnum.MENU_TYPE.value and \
+                        categoryValue['name'] == menu_type):
                         response.append(menu)
                     else:
                         continue

--- a/galley/types.py
+++ b/galley/types.py
@@ -94,6 +94,7 @@ class SubRecipe(Type):
 
 
 class Preparation(Type):
+    id = Field(ID)
     name = str
 
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # are dependencies that are required on remote installs, not local development.
 setup(
     name='galley_sdk',
-    version='0.13.0',
+    version='0.14.0',
     packages=['galley'],
     install_requires=['sgqlc==14.0', 'backoff==1.11.1']
 )

--- a/tests/mock_responses/mock_menu_data.py
+++ b/tests/mock_responses/mock_menu_data.py
@@ -1,4 +1,4 @@
-from galley.queries import MenuCategoryEnum
+from galley.enums import MenuCategoryEnum, PreparationEnum
 
 
 def mock_menu(date, location_name="Vacaville", menu_type="production"):
@@ -32,7 +32,10 @@ def mock_menu(date, location_name="Vacaville", menu_type="production"):
                     'externalName': 'Test Recipe Name 1',
                     'recipeItems': [{
                         'preparations': [
-                            {'name':  'standalone'}
+                            {
+                                'id': PreparationEnum.STANDALONE.value,
+                                'name':  'standalone'
+                            }
                         ],
                         'subRecipeId': 'SUBRECIPEID456'
                     }]
@@ -51,7 +54,10 @@ def mock_menu(date, location_name="Vacaville", menu_type="production"):
                     'externalName': 'Test Recipe Name 2',
                     'recipeItems': [{
                         'preparations': [
-                            {'name':  '2 oz RAM'}
+                            {
+                                'id': PreparationEnum.TWO_OUNCE_RAM.value,
+                                'name':  '2 oz RAM'
+                            }
                         ],
                         'subRecipeId': 'SUBRECIPEID789'
                     }]
@@ -70,8 +76,13 @@ def mock_menu(date, location_name="Vacaville", menu_type="production"):
                     'externalName': 'Test Recipe Name 3',
                     'recipeItems': [{
                         'preparations': [
-                            {'name':  '3 oz RAM'},
-                            {'name': 'standalone'}
+                            {
+                                'id': PreparationEnum.THREE_OUNCE_RAM.value,
+                                'name':  '3.25 oz RAM'},
+                            {
+                                'id': PreparationEnum.STANDALONE.value,
+                                'name': 'standalone'
+                            }
                         ],
                         'subRecipeId': 'SUBRECIPEID321'
                     }]

--- a/tests/mock_responses/mock_recipe_items.py
+++ b/tests/mock_responses/mock_recipe_items.py
@@ -46,21 +46,21 @@ mock_data = [
     },
     {
         'ingredient': {
-        'externalName': 'Unique 4',
-        'categoryValues': [
-            {
-                'name': 'send to plate',
-                'category': {
-                    'itemType': 'ingredient'
+            'externalName': 'Unique 4',
+            'categoryValues': [
+                {
+                    'name': 'send to plate',
+                    'category': {
+                        'itemType': 'ingredient'
+                    }
+                },
+                {
+                    'name': None,           # Test empty categoryValue['name']
+                    'category': {
+                        'itemType': None    # Test empty category['itemType']
+                    }
                 }
-            },
-            {
-                'name': None,           # Test empty categoryValue['name']
-                'category': {
-                    'itemType': None    # Test empty category['itemType']
-                }
-            }
-        ]
+            ]
         },
         'subRecipe': None,
         'preparations': [
@@ -71,16 +71,18 @@ mock_data = [
     },
     {
         'ingredient': {
-        'externalName': '32 oz Meal Boxes',
-        'categoryValues': [
-            {
-                'id': 'Y2F0ZWdvcnlWYWx1ZToxNDAxNQ==',
-                'name': 'food pkg',
-                'category': {
-                    'itemType': 'ingredient'
+            'externalName': '32 oz Meal Boxes',
+            'categoryValues': [
+                {
+                    'id': 'Y2F0ZWdvcnlWYWx1ZToxNDAxNQ==',
+                    'name': 'food pkg',
+                    'category': {
+                        'id': "Y2F0ZWdvcnk6MjQyMA==",
+                        'name': "category",
+                        'itemType': 'ingredient'
+                    }
                 }
-            }
-        ]
+            ]
         },
         'subRecipe': None,
         'preparations': []

--- a/tests/mock_responses/mock_recipe_items.py
+++ b/tests/mock_responses/mock_recipe_items.py
@@ -74,10 +74,11 @@ mock_data = [
         'externalName': '32 oz Meal Boxes',
         'categoryValues': [
             {
-            'name': 'food pkg',
-            'category': {
-                'itemType': 'ingredient'
-            }
+                'id': 'Y2F0ZWdvcnlWYWx1ZToxNDAxNQ==',
+                'name': 'food pkg',
+                'category': {
+                    'itemType': 'ingredient'
+                }
             }
         ]
         },

--- a/tests/mock_responses/mock_recipe_items.py
+++ b/tests/mock_responses/mock_recipe_items.py
@@ -1,3 +1,6 @@
+from galley.enums import PreparationEnum
+
+
 mock_data = [
     {
         'ingredient': None,
@@ -36,6 +39,7 @@ mock_data = [
                 'name': '2 oz RAM'
             },
             {
+                'id': PreparationEnum.STANDALONE.value,
                 'name': 'standalone'
             }
         ]

--- a/tests/mock_responses/mock_recipe_tree_components.py
+++ b/tests/mock_responses/mock_recipe_tree_components.py
@@ -1,3 +1,6 @@
+from galley.enums import PreparationEnum
+
+
 mock_data = [
     {
         'quantityUnitValues': [
@@ -114,7 +117,9 @@ mock_data = [
                 {
                     'name': '2 oz RAM'
                 },
-                {   'name': 'standalone'
+                {
+                    'id': PreparationEnum.STANDALONE.value,
+                    'name': 'standalone'
                 }
             ]
         }
@@ -198,18 +203,18 @@ mock_data = [
                     }
                 ],
                 'externalName': '48 oz Meal Boxes'
-            },    
+            },
             'preparations': []
         }
     },
     {
         'quantityUnitValues': [],
         'recipeItem': {
-            'ingredient': None, 
+            'ingredient': None,
             'preparations': []
         }
     }
-]  
+]
 
 mock_data_no_pkg_no_standalone = [
     {
@@ -398,15 +403,15 @@ mock_data_no_pkg_no_standalone = [
             }
         ],
         'recipeItem': {
-            'ingredient': None,  
+            'ingredient': None,
             'preparations': []
         }
     },
     {
         'quantityUnitValues': [],
         'recipeItem': {
-            'ingredient': None, 
+            'ingredient': None,
             'preparations': []
         }
     }
-]              
+]

--- a/tests/mock_responses/mock_recipe_tree_components.py
+++ b/tests/mock_responses/mock_recipe_tree_components.py
@@ -200,7 +200,12 @@ mock_data = [
                 'categoryValues': [
                     {
                         'id': 'Y2F0ZWdvcnlWYWx1ZToxNDAxNQ==',
-                        'name': 'food pkg'
+                        'name': 'food pkg',
+                        'category': {
+                            'id': "Y2F0ZWdvcnk6MjQyMA==",
+                            'name': "category",
+                            'itemType': 'ingredient'
+                        }
                     }
                 ],
                 'externalName': '48 oz Meal Boxes'

--- a/tests/mock_responses/mock_recipe_tree_components.py
+++ b/tests/mock_responses/mock_recipe_tree_components.py
@@ -199,6 +199,7 @@ mock_data = [
             'ingredient': {
                 'categoryValues': [
                     {
+                        'id': 'Y2F0ZWdvcnlWYWx1ZToxNDAxNQ==',
                         'name': 'food pkg'
                     }
                 ],

--- a/tests/mock_responses/mock_recipes_data.py
+++ b/tests/mock_responses/mock_recipes_data.py
@@ -10,6 +10,7 @@ def mock_recipe(id):
             {
                 'name': 'vegan',
                 'category': {
+                    'id': "Y2F0ZWdvcnk6MjUwOA==",
                     'itemType': 'recipe',
                     'name': 'protein type'
                 }
@@ -17,6 +18,7 @@ def mock_recipe(id):
             {
                 'name': 'ts48',
                 'category': {
+                    'id': "Y2F0ZWdvcnk6MjU2Nw==",
                     'itemType': 'recipe',
                     'name': 'meal container'
                 }
@@ -24,6 +26,7 @@ def mock_recipe(id):
             {
                 'name': 'dinner',
                 'category': {
+                    'id': "Y2F0ZWdvcnk6MjQyMg==",
                     'itemType': 'recipe',
                     'name': 'meal type'
                 }
@@ -31,12 +34,13 @@ def mock_recipe(id):
             {
                 'name': 'true',
                 'category': {
+                    'id': "",
                     'itemType': 'recipe',
                     'name': 'is perishable'
                 }
             }
         ],
-        'recipeItems': mock_recipe_items.mock_data,        
+        'recipeItems': mock_recipe_items.mock_data,
         'reconciledNutritionals': mock_nutrition_data.mock_data,
         'recipeTreeComponents': mock_recipe_tree_components.mock_data
     })

--- a/tests/test_formatted_queries.py
+++ b/tests/test_formatted_queries.py
@@ -192,7 +192,7 @@ class TestGetFormattedMenuData(TestCase):
         mock_retrieval_method.return_value = None
         result = get_formatted_menu_data([])
         self.assertEqual(result, None)
-    
+
     @mock.patch('galley.formatted_queries.get_raw_menu_data')
     def test_get_formatted_menu_data_args_defaults(self, mock_grmd):
         dates = ['2021-11-14', '2021-10-04']

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -122,6 +122,7 @@ class TestQueryWeekMenuData(TestCase):
             recipeItems {
             subRecipeId
             preparations {
+            id
             name
             }
             }
@@ -193,7 +194,7 @@ class TestQueryWeekMenuData(TestCase):
         mock_retrieval_method.return_value = None
         result = get_raw_menu_data([], 'Vacaville', 'production')
         self.assertEqual(result, [])
-    
+
     @mock.patch('galley.queries.make_request_to_galley')
     def test_get_raw_menu_data_filters_by_location(self, mock_retrieval_method):
         mock_retrieval_method.return_value = {
@@ -312,6 +313,7 @@ class TestRecipesDataQuery(TestCase):
             ingredient {
             externalName
             categoryValues {
+            id
             name
             }
             }
@@ -319,6 +321,7 @@ class TestRecipesDataQuery(TestCase):
             allIngredients
             }
             preparations {
+            id
             name
             }
             }
@@ -331,10 +334,12 @@ class TestRecipesDataQuery(TestCase):
             }
             recipeItem {
             preparations {
+            id
             name
             }
             ingredient {
             categoryValues {
+            id
             name
             }
             externalName

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -315,6 +315,11 @@ class TestRecipesDataQuery(TestCase):
             categoryValues {
             id
             name
+            category {
+            id
+            name
+            itemType
+            }
             }
             }
             subRecipe {
@@ -341,6 +346,11 @@ class TestRecipesDataQuery(TestCase):
             categoryValues {
             id
             name
+            category {
+            id
+            name
+            itemType
+            }
             }
             externalName
             }


### PR DESCRIPTION
## Description
Update lookups for Category and Preparations to take place by ID not by name.  The primary location where a name lookup for preparations were taking place was with the is_standalone() and is_packaging check for RecipeItem.

This branch also updates any queries that look for preparations to return the preparation's ids in addition to name, same goes for ingredient categories.

## Test Plan
I'm not 100% of all the places that needed to be updated as a part of this work.  I have updated all the existing tests which check STANDALONE and is_packaging to ensure that they now pass.  There is no net new functionality to go along with these lookups, so theoretically if the tests pass everything is still working as expected.

## Versioning
[X] Please update the project version in setup.py
