### PR TITLE
(ENG-891) Add baseMealSlug and proteinAddOn tags to recipe data retrieval

### DIFF
--- a/galley/enums.py
+++ b/galley/enums.py
@@ -15,7 +15,6 @@ class PreparationEnum(Enum):
     STANDALONE = 'cHJlcGFyYXRpb246MjgzMzQ='
     TWO_OUNCE_RAM = 'cHJlcGFyYXRpb246MjgxMTU='
     THREE_OUNCE_RAM = 'cHJlcGFyYXRpb246MjgxMTQ='
-    PROTEIN_ADDON = 'cHJlcGFyYXRpb246Mjg1NDM='
 
 
 class IngredientCategoryValueEnum(Enum):

--- a/galley/enums.py
+++ b/galley/enums.py
@@ -1,5 +1,6 @@
 from enum import Enum
 
+
 class MenuCategoryEnum(Enum):
     """
     Enum for categories, for item type menu <category name>: <category id>
@@ -14,15 +15,30 @@ class PreparationEnum(Enum):
     STANDALONE = 'cHJlcGFyYXRpb246MjgzMzQ='
     TWO_OUNCE_RAM = 'cHJlcGFyYXRpb246MjgxMTU='
     THREE_OUNCE_RAM = 'cHJlcGFyYXRpb246MjgxMTQ='
+    PROTEIN_ADDON = 'cHJlcGFyYXRpb246Mjg1NDM='
 
 
-class IngredientCategoryEnum(Enum):
+class IngredientCategoryValueEnum(Enum):
     """
-    Enum for Ingredient Categories. <category name>: <category id>
+    Enum for Ingredient CategoryValues. <categoryValue name>: <categoryValue id>
     """
-    FOOD_PACKAGE = "Y2F0ZWdvcnlWYWx1ZToxNDAxNQ=="
+    FOOD_PACKAGE = 'Y2F0ZWdvcnlWYWx1ZToxNDAxNQ=='
 
-class TagTypeEnum(Enum):
+
+class IngredientCategoryTagTypeEnum(Enum):
     """
+    Enum for category tag types at ingredient (itemType) level. <category name>: <category id>
     """
-    CATEGORY_TAG_TYPE = "Y2F0ZWdvcnk6MjQyMA=="
+    ACCOUNTING_TAG = 'Y2F0ZWdvcnk6MjQyMA=='
+
+
+class RecipeCategoryTagTypeEnum(Enum):
+    """
+    Enum for category tag types at recipe (itemType) level. <category name>: <category id>
+    """
+    PROTEIN_TYPE_TAG = 'Y2F0ZWdvcnk6MjUwOA=='
+    MEAL_TYPE_TAG = 'Y2F0ZWdvcnk6MjQyMg=='
+    MEAL_CONTAINER_TAG = 'Y2F0ZWdvcnk6MjU2Nw=='
+    PROTEIN_ADDON_TAG = 'Y2F0ZWdvcnk6MjU4MQ=='
+    BASE_MEAL_SLUG_TAG = 'Y2F0ZWdvcnk6MjYyMA=='
+

--- a/galley/formatted_queries.py
+++ b/galley/formatted_queries.py
@@ -1,6 +1,6 @@
-from typing import Dict, Optional, List
+from typing import Dict, Optional, List, Set
 
-from galley.enums import IngredientCategoryEnum, MenuCategoryEnum, PreparationEnum, TagTypeEnum
+from galley.enums import IngredientCategoryValueEnum, MenuCategoryEnum, PreparationEnum, IngredientCategoryTagTypeEnum, RecipeCategoryTagTypeEnum
 from galley.pagination import paginate_results
 from galley.queries import get_raw_recipes_data, get_raw_menu_data
 
@@ -16,8 +16,8 @@ class RecipeItem:
 
     def is_packaging(self):
         return any(
-            cat_val.get('id') == IngredientCategoryEnum.FOOD_PACKAGE.value and
-            cat_val.get('category', {}).get('id') == TagTypeEnum.CATEGORY_TAG_TYPE.value for cat_val in self.category_values
+            cat_val.get('id') == IngredientCategoryValueEnum.FOOD_PACKAGE.value and
+            cat_val.get('category', {}).get('id') == IngredientCategoryTagTypeEnum.ACCOUNTING_TAG.value for cat_val in self.category_values
         )
 
     def mass(self):
@@ -30,44 +30,45 @@ class RecipeItem:
 
 
 class FormattedRecipe:
-    mealContainer = None
-    mealType = None
-    proteinType = None
-
     def __init__(self, recipe_data):
         self.galleyId = recipe_data.get('id')
         self.externalName = recipe_data.get('externalName')
         self.notes = recipe_data.get('notes')
         self.description = recipe_data.get('description')
         self.nutrition = recipe_data.get('reconciledNutritionals', {})
-
         self.recipe_category_values = recipe_data.get('categoryValues', [])
-        for recipe_category_value in self.recipe_category_values:
-            category_name = recipe_category_value.get('category', {}).get('name')
-            category_value = recipe_category_value.get('name')
-            if category_name == 'protein type':
-                self.proteinType = category_value
-            elif category_name == 'meal type':
-                self.mealType = category_value
-            elif category_name == 'meal container':
-                self.mealContainer = category_value
-
+        self.recipe_tags = get_recipe_category_tags(self.recipe_category_values)
         self.recipe_items = recipe_data.get('recipeItems', [])
         self.recipe_tree_components = recipe_data.get('recipeTreeComponents', [])
 
+
     def to_dict(self):
-        return {
+        recipe_data = {
             'id': self.galleyId,
             'externalName': self.externalName,
             'notes': self.notes,
             'description': self.description,
             'nutrition': self.nutrition,
-            'proteinType': self.proteinType,
-            'mealContainer': self.mealContainer,
-            'mealType': self.mealType,
             'ingredients': ingredients_from_recipe_items(recipe_items=self.recipe_items),
             'weight': weight_from_recipe_tree_components(recipe_tree_components=self.recipe_tree_components)
         }
+        return {**recipe_data, **self.recipe_tags}
+
+
+def get_recipe_category_tags(category_values: List[Dict]) -> Optional[Dict]:
+    recipe_tags: Dict = {}
+    recipe_tags_enum: Set = {tag.value for tag in RecipeCategoryTagTypeEnum}
+
+    for category_value in category_values:
+        if category_value.get('category', {}).get('id') in recipe_tags_enum:
+            category_name = category_value.get('category', {}).get('name')
+            category_value = category_value.get('name')
+
+            if category_name and category_value:
+                _tag = category_name.lower().split()
+                tag = _tag[0] + ''.join(t.title() for t in _tag[1:])
+                recipe_tags.setdefault(tag, category_value)
+    return recipe_tags
 
 
 def weight_from_recipe_tree_components(recipe_tree_components: List[Dict]) -> float:
@@ -110,13 +111,12 @@ def ingredients_from_recipe_items(recipe_items: List[Dict]) -> Optional[List]:
                 for i in sub_recipe.get('allIngredients'):
                     if i not in ingredients:
                         ingredients.append(i)
-
     return ingredients
 
 
 # Returns the subRecipeId if any 'standalone' item exists within recipeItems, else returns None
 # It is assumed that there is a max of ONE standalone item within the list of recipeItems, if any.
-def get_standalone(recipe_items):
+def get_standalone(recipe_items: List[Dict]) -> Optional[str]:
     for recipe_item in recipe_items:
         preparations = recipe_item.get('preparations', [])
         is_standalone = any(prep['id'] == PreparationEnum.STANDALONE.value for prep in preparations)

--- a/galley/formatted_queries.py
+++ b/galley/formatted_queries.py
@@ -57,17 +57,21 @@ class FormattedRecipe:
 
 def get_recipe_category_tags(recipe_category_values: List[Dict]) -> Optional[Dict]:
     recipe_tags: Dict = {}
-    recipe_tags_enum: Set = {tag.value for tag in RecipeCategoryTagTypeEnum}
+    recipe_tag_labels: Dict = {
+        RecipeCategoryTagTypeEnum.PROTEIN_TYPE_TAG.value: 'proteinType',
+        RecipeCategoryTagTypeEnum.MEAL_TYPE_TAG.value: 'mealType',
+        RecipeCategoryTagTypeEnum.MEAL_CONTAINER_TAG.value: 'mealContainer',
+        RecipeCategoryTagTypeEnum.PROTEIN_ADDON_TAG.value: 'proteinAddOn',
+        RecipeCategoryTagTypeEnum.BASE_MEAL_SLUG_TAG.value: 'baseMealSlug',
+    }
 
     for recipe_category_value in recipe_category_values:
-        if recipe_category_value.get('category', {}).get('id') in recipe_tags_enum:
-            category_name = recipe_category_value.get('category', {}).get('name')
-            category_value = recipe_category_value.get('name')
+        tag_id = recipe_category_value.get('category', {}).get('id')
+        label = recipe_tag_labels.get(tag_id)
+        recipe_category_value_name = recipe_category_value.get('name')
 
-            if category_name and category_value:
-                _tag = category_name.lower().split()
-                tag = _tag[0] + ''.join(t.title() for t in _tag[1:])
-                recipe_tags.setdefault(tag, category_value)
+        if label and recipe_category_value_name:
+            recipe_tags.setdefault(label, recipe_category_value_name)
     return recipe_tags
 
 

--- a/galley/formatted_queries.py
+++ b/galley/formatted_queries.py
@@ -55,14 +55,14 @@ class FormattedRecipe:
         return {**recipe_data, **self.recipe_tags}
 
 
-def get_recipe_category_tags(category_values: List[Dict]) -> Optional[Dict]:
+def get_recipe_category_tags(recipe_category_values: List[Dict]) -> Optional[Dict]:
     recipe_tags: Dict = {}
     recipe_tags_enum: Set = {tag.value for tag in RecipeCategoryTagTypeEnum}
 
-    for category_value in category_values:
-        if category_value.get('category', {}).get('id') in recipe_tags_enum:
-            category_name = category_value.get('category', {}).get('name')
-            category_value = category_value.get('name')
+    for recipe_category_value in recipe_category_values:
+        if recipe_category_value.get('category', {}).get('id') in recipe_tags_enum:
+            category_name = recipe_category_value.get('category', {}).get('name')
+            category_value = recipe_category_value.get('name')
 
             if category_name and category_value:
                 _tag = category_name.lower().split()

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # are dependencies that are required on remote installs, not local development.
 setup(
     name='galley_sdk',
-    version='0.15.0',
+    version='0.16.0',
     packages=['galley'],
     install_requires=['sgqlc==14.0', 'backoff==1.11.1']
 )

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # are dependencies that are required on remote installs, not local development.
 setup(
     name='galley_sdk',
-    version='0.14.0',
+    version='0.15.0',
     packages=['galley'],
     install_requires=['sgqlc==14.0', 'backoff==1.11.1']
 )

--- a/tests/mock_responses/mock_recipes_data.py
+++ b/tests/mock_responses/mock_recipes_data.py
@@ -38,6 +38,22 @@ def mock_recipe(id):
                     'itemType': 'recipe',
                     'name': 'is perishable'
                 }
+            },
+            {
+                'name': 'high-protein-legume',
+                'category': {
+                    'id': "Y2F0ZWdvcnk6MjU4MQ==",
+                    'itemType': 'recipe',
+                    'name': 'protein addon'
+                }
+            },
+            {
+                'name': 'base-salad',
+                'category': {
+                    'id': "Y2F0ZWdvcnk6MjYyMA==",
+                    'itemType': 'recipe',
+                    'name': 'base meal slug'
+                }
             }
         ],
         'recipeItems': mock_recipe_items.mock_data,

--- a/tests/mock_responses/mock_recipes_data.py
+++ b/tests/mock_responses/mock_recipes_data.py
@@ -1,4 +1,5 @@
 from tests.mock_responses import mock_nutrition_data, mock_recipe_items, mock_recipe_tree_components
+from galley.enums import RecipeCategoryTagTypeEnum
 
 def mock_recipe(id):
     return ({
@@ -10,7 +11,7 @@ def mock_recipe(id):
             {
                 'name': 'vegan',
                 'category': {
-                    'id': "Y2F0ZWdvcnk6MjUwOA==",
+                    'id': RecipeCategoryTagTypeEnum.PROTEIN_TYPE_TAG.value,
                     'itemType': 'recipe',
                     'name': 'protein type'
                 }
@@ -18,7 +19,7 @@ def mock_recipe(id):
             {
                 'name': 'ts48',
                 'category': {
-                    'id': "Y2F0ZWdvcnk6MjU2Nw==",
+                    'id': RecipeCategoryTagTypeEnum.MEAL_CONTAINER_TAG.value,
                     'itemType': 'recipe',
                     'name': 'meal container'
                 }
@@ -26,7 +27,7 @@ def mock_recipe(id):
             {
                 'name': 'dinner',
                 'category': {
-                    'id': "Y2F0ZWdvcnk6MjQyMg==",
+                    'id': RecipeCategoryTagTypeEnum.MEAL_TYPE_TAG.value,
                     'itemType': 'recipe',
                     'name': 'meal type'
                 }
@@ -42,7 +43,7 @@ def mock_recipe(id):
             {
                 'name': 'high-protein-legume',
                 'category': {
-                    'id': "Y2F0ZWdvcnk6MjU4MQ==",
+                    'id': RecipeCategoryTagTypeEnum.PROTEIN_ADDON_TAG.value,
                     'itemType': 'recipe',
                     'name': 'protein addon'
                 }
@@ -50,7 +51,7 @@ def mock_recipe(id):
             {
                 'name': 'base-salad',
                 'category': {
-                    'id': "Y2F0ZWdvcnk6MjYyMA==",
+                    'id': RecipeCategoryTagTypeEnum.BASE_MEAL_SLUG_TAG.value,
                     'itemType': 'recipe',
                     'name': 'base meal slug'
                 }

--- a/tests/test_formatted_queries.py
+++ b/tests/test_formatted_queries.py
@@ -57,6 +57,8 @@ class TestGetFormattedRecipesData(TestCase):
                 'proteinType': 'vegan',
                 'mealContainer': 'ts48',
                 'mealType': 'dinner',
+                'proteinAddon': 'high-protein-legume',
+                'baseMealSlug': 'base-salad',
                 'ingredients': [
                     'Unique 1',
                     'Duplicate 1',
@@ -76,6 +78,8 @@ class TestGetFormattedRecipesData(TestCase):
                 'proteinType': 'vegan',
                 'mealContainer': 'ts48',
                 'mealType': 'dinner',
+                'proteinAddon': 'high-protein-legume',
+                'baseMealSlug': 'base-salad',
                 'ingredients': [
                     'Unique 1',
                     'Duplicate 1',

--- a/tests/test_formatted_queries.py
+++ b/tests/test_formatted_queries.py
@@ -57,7 +57,7 @@ class TestGetFormattedRecipesData(TestCase):
                 'proteinType': 'vegan',
                 'mealContainer': 'ts48',
                 'mealType': 'dinner',
-                'proteinAddon': 'high-protein-legume',
+                'proteinAddOn': 'high-protein-legume',
                 'baseMealSlug': 'base-salad',
                 'ingredients': [
                     'Unique 1',
@@ -78,7 +78,7 @@ class TestGetFormattedRecipesData(TestCase):
                 'proteinType': 'vegan',
                 'mealContainer': 'ts48',
                 'mealType': 'dinner',
-                'proteinAddon': 'high-protein-legume',
+                'proteinAddOn': 'high-protein-legume',
                 'baseMealSlug': 'base-salad',
                 'ingredients': [
                     'Unique 1',


### PR DESCRIPTION
## Description
The focus of this PR is to add two more recipe-level category tag values, `baseMealSlug` and `proteinAddOn`, to the return value of `get_formatted_recipes_data()` for label printing purposes. This PR also ensures that `baseMealSlug`, `proteinAddOn`, and all other existing recipe-level category tags are identified via their id--`categoryId`. Automated tests have been updated to confirm the expected behavior(s).

## Test Plan
Open python interactive within galley-sdk: `$ python`
`>>> from pprint import pprint` (optional: to apply pretty print format to returned data)
`>>> from galley.formatted_queries import *`
 `>>> pprint(get_formatted_recipes_data(['cmVjaXBlOjE4Mzk4NA==']))`

> **Expectation:** A return value **similar** to:
> ```python3
> [{'baseMealSlug': 'persephone-salad',
>   'description': None,
>   'externalName': None,
>   'id': 'cmVjaXBlOjE4Mzk4NA==',
>   'ingredients': [ ... ],
>   'mealContainer': 'ts48'
>   'mealType': 'lunch',
>   'notes': None,
>   'nutrition': { ... },
>   'proteinAddOn': 'garbanzo-beans',
>   'proteinType': 'vegan',
>   'weight': 113.4}]
>```

## Run Automated Unittests
Exit python interactive and stay within the galley-sdk directory to run tests:
`(galley-env) $ python3 -m unittest tests/test_formatted_queries.py`
**[OPTIONAL SANITY CHECK]** `(galley-env) $ python -m unittest tests/test_*.py`

## Versioning
v0.15.1 --> v0.16.0
