### PR TITLE
(ENG-870) add menu item id to menu data retrieval and formatting functions

### DIFF
--- a/galley/formatted_queries.py
+++ b/galley/formatted_queries.py
@@ -168,6 +168,7 @@ def get_formatted_menu_data(dates: List[str],
             recipe_items = menu_item.get('recipe', {}).get('recipeItems', [])
 
             formatted_menu['menuItems'].append({
+                'id': menu_item.get('id'),
                 'itemCode': next((cv.get('name') for cv in menu_item['categoryValues']), None),
                 'recipeId': menu_item.get('recipeId'),
                 'standaloneRecipeId': get_standalone(recipe_items)

--- a/galley/queries.py
+++ b/galley/queries.py
@@ -79,12 +79,9 @@ def get_menu_query(dates: List[str]) -> Optional[List[Dict]]:
     query.viewer.menus(where=MenuFilterInput(date=dates)).__fields__(
         'id', 'name', 'date', 'location', 'categoryValues', 'menuItems'
     )
-    query.viewer.menus.menuItems.__fields__('recipeId', 'categoryValues',
-                                            'recipe')
-    query.viewer.menus.menuItems.recipe.__fields__('externalName',
-                                                   'recipeItems')
-    query.viewer.menus.menuItems.recipe.recipeItems.__fields__('subRecipeId',
-                                                               'preparations')
+    query.viewer.menus.menuItems.__fields__('id', 'recipeId', 'categoryValues', 'recipe')
+    query.viewer.menus.menuItems.recipe.__fields__('externalName', 'recipeItems')
+    query.viewer.menus.menuItems.recipe.recipeItems.__fields__('subRecipeId', 'preparations')
     query.viewer.menus.menuItems.recipe.recipeItems.preparations.__fields__('id', 'name')
     return query
 

--- a/galley/types.py
+++ b/galley/types.py
@@ -161,6 +161,7 @@ class UnitInput(Input):
 
 
 class MenuItem(Type):
+    id = str
     recipeId = str
     categoryValues = Field(CategoryValue)
     recipe = Field(Recipe)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # are dependencies that are required on remote installs, not local development.
 setup(
     name='galley_sdk',
-    version='0.14.0',
+    version='0.15.0',
     packages=['galley'],
     install_requires=['sgqlc==14.0', 'backoff==1.11.1']
 )

--- a/tests/mock_responses/mock_menu_data.py
+++ b/tests/mock_responses/mock_menu_data.py
@@ -20,6 +20,7 @@ def mock_menu(date, location_name="Vacaville", menu_type="production"):
         }],
         'menuItems': [
             {
+                'id': 'MENUITEM1ABC',
                 'recipeId': 'RECIPE1ABC',
                 'categoryValues': [{
                     'name': 'dv1',
@@ -42,6 +43,7 @@ def mock_menu(date, location_name="Vacaville", menu_type="production"):
                 },
             },
             {
+                'id': 'MENUITEM2DEF',
                 'recipeId': 'RECIPE2DEF',
                 'categoryValues': [{
                     'name': 'dv2',
@@ -64,6 +66,7 @@ def mock_menu(date, location_name="Vacaville", menu_type="production"):
                 },
             },
             {
+                'id': 'MENUITEM3GHI',
                 'recipeId': 'RECIPE3GHI',
                 'categoryValues': [{
                     'name': 'lm2',

--- a/tests/test_formatted_queries.py
+++ b/tests/test_formatted_queries.py
@@ -144,14 +144,17 @@ class TestGetFormattedMenuData(TestCase):
                 'location': 'Vacaville',
                 'categoryMenuType': 'production',
                 'menuItems': [{
+                    'id': 'MENUITEM1ABC',
                     'itemCode': 'dv1',
                     'recipeId': 'RECIPE1ABC',
                     'standaloneRecipeId': 'SUBRECIPEID456'
                 }, {
+                    'id': 'MENUITEM2DEF',
                     'itemCode': 'dv2',
                     'recipeId': 'RECIPE2DEF',
                     'standaloneRecipeId': None
                 }, {
+                    'id': 'MENUITEM3GHI',
                     'itemCode': 'lm2',
                     'recipeId': 'RECIPE3GHI',
                     'standaloneRecipeId': 'SUBRECIPEID321'

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -107,6 +107,7 @@ class TestQueryWeekMenuData(TestCase):
             }
             }
             menuItems {
+            id
             recipeId
             categoryValues {
             id


### PR DESCRIPTION
## Description
This adds another attribute, menu item id, to the data that gets retrieved from Galley and returned by get_formatted_menu_data. We will be using menu item id within thistle-web to send menu item projections to Galley. Tests and mock data are updated to account for the new attribute.

## Test Plan
Open python interactive within galley-sdk: $ python
`from pprint import pprint` (optional: to apply pretty print format to returned data)
`from galley.formatted_queries import *`

Request formatted menu data for a couple weeks:
`pprint(get_formatted_menu_data(['2022-01-03', '2021-12-27']))`

Validate that for each menu item included in the returned menus, an id is present (can additionally use the Galley playground to validate that the value of the ids matches expectations).
## Versioning
Please update the project version in setup.py -> Done!
