### PR TITLE
(ENG-870) fix bug with menu item category values

### DIFF
--- a/galley/enums.py
+++ b/galley/enums.py
@@ -6,6 +6,11 @@ class MenuCategoryEnum(Enum):
     """
     MENU_TYPE = 'Y2F0ZWdvcnk6MjQ2NQ=='
 
+class MenuItemCategoryEnum(Enum):
+    """
+    Enum for categories, for item type menu item <category name>: <category id>
+    """
+    PRODUCT_CODE = 'Y2F0ZWdvcnk6MjQ2Nw=='
 
 class PreparationEnum(Enum):
     """

--- a/galley/formatted_queries.py
+++ b/galley/formatted_queries.py
@@ -1,6 +1,6 @@
 from typing import Dict, Optional, List
 
-from galley.enums import IngredientCategoryEnum, MenuCategoryEnum, PreparationEnum, TagTypeEnum
+from galley.enums import IngredientCategoryEnum, MenuCategoryEnum, MenuItemCategoryEnum, PreparationEnum, TagTypeEnum
 from galley.pagination import paginate_results
 from galley.queries import get_raw_recipes_data, get_raw_menu_data
 
@@ -167,9 +167,15 @@ def get_formatted_menu_data(dates: List[str],
         for menu_item in menu_items:
             recipe_items = menu_item.get('recipe', {}).get('recipeItems', [])
 
+            categoryValues = menu_item['categoryValues']
+            for categoryValue in categoryValues:
+                if (categoryValue['category']['id'] ==
+                        MenuItemCategoryEnum.PRODUCT_CODE.value):
+                    itemCode = categoryValue['name']
+
             formatted_menu['menuItems'].append({
                 'id': menu_item.get('id'),
-                'itemCode': next((cv.get('name') for cv in menu_item['categoryValues']), None),
+                'itemCode': itemCode,
                 'recipeId': menu_item.get('recipeId'),
                 'standaloneRecipeId': get_standalone(recipe_items)
             })

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # are dependencies that are required on remote installs, not local development.
 setup(
     name='galley_sdk',
-    version='0.15.0',
+    version='0.15.1',
     packages=['galley'],
     install_requires=['sgqlc==14.0', 'backoff==1.11.1']
 )

--- a/tests/mock_responses/mock_menu_data.py
+++ b/tests/mock_responses/mock_menu_data.py
@@ -1,4 +1,4 @@
-from galley.enums import MenuCategoryEnum, PreparationEnum
+from galley.enums import MenuCategoryEnum, MenuItemCategoryEnum, PreparationEnum
 
 
 def mock_menu(date, location_name="Vacaville", menu_type="production"):
@@ -25,6 +25,7 @@ def mock_menu(date, location_name="Vacaville", menu_type="production"):
                 'categoryValues': [{
                     'name': 'dv1',
                     'category': {
+                        'id': MenuItemCategoryEnum.PRODUCT_CODE.value,
                         'itemType': 'menuItem',
                         'name': 'product_code'
                     }
@@ -48,6 +49,7 @@ def mock_menu(date, location_name="Vacaville", menu_type="production"):
                 'categoryValues': [{
                     'name': 'dv2',
                     'category': {
+                        'id': MenuItemCategoryEnum.PRODUCT_CODE.value,
                         'itemType': 'menuItem',
                         'name': 'product_code'
                     }
@@ -71,6 +73,7 @@ def mock_menu(date, location_name="Vacaville", menu_type="production"):
                 'categoryValues': [{
                     'name': 'lm2',
                     'category': {
+                        'id': MenuItemCategoryEnum.PRODUCT_CODE.value,
                         'itemType': 'menuItem',
                         'name': 'product_code'
                     }


### PR DESCRIPTION
## Description
This fixes a bug where the data returned for the itemCode attribute on menuItems was fluctuating between the product_code and bag_label_header category values. The new behavior ensures that only product_code category value is returned. Tests and fixtures are updated to account for the changes.
## Test Plan
Open python interactive within galley-sdk: 
`$ python`
`from pprint import pprint` (optional: to apply pretty print format to returned data)
`from galley.formatted_queries import *`

Request formatted menu data for a couple weeks:
`pprint(get_formatted_menu_data(['2022-01-03', '2021-12-27']))`

Validate that for each menu item included in the returned menus, the itemCode attribute matches what you see in the product_code column for that menu in the Galley UX.
## Versioning
Please update the project version in setup.py -> Done!
