### PR TITLE
(maint) adjust recipe connection query to pull back standalone nutrition from correct source

### DIFF
--- a/galley/queries.py
+++ b/galley/queries.py
@@ -79,13 +79,13 @@ def recipe_connection_query(recipe_ids: List[str], page_size: int = DEFAULT_PAGE
     query.viewer.recipeConnection.edges.node.recipeTreeComponents.quantityUnitValues.__fields__('unit', 'value')
     query.viewer.recipeConnection.edges.node.recipeTreeComponents.quantityUnitValues.unit.__fields__('id', 'name')
     query.viewer.recipeConnection.edges.node.recipeTreeComponents.recipeItem.__fields__(
-        'preparations', 'ingredient', 'subRecipe', 'subRecipeId', 'quantity', 'unit', 'reconciledNutritionals'
+        'preparations', 'ingredient', 'subRecipe', 'subRecipeId', 'quantity', 'unit'
     )
     query.viewer.recipeConnection.edges.node.recipeTreeComponents.recipeItem.preparations.__fields__('id', 'name')
     query.viewer.recipeConnection.edges.node.recipeTreeComponents.recipeItem.ingredient.__fields__('categoryValues', 'externalName')
     query.viewer.recipeConnection.edges.node.recipeTreeComponents.recipeItem.ingredient.categoryValues.__fields__('id', 'name', 'category')
     query.viewer.recipeConnection.edges.node.recipeTreeComponents.recipeItem.subRecipe.__fields__(
-        'id', 'allIngredients', 'externalName', 'name'
+        'id', 'allIngredients', 'externalName', 'name', 'reconciledNutritionals'
     )
     query.viewer.recipeConnection.edges.node.recipeTreeComponents.recipeItem.unit.__fields__('id', 'name')
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # are dependencies that are required on remote installs, not local development.
 setup(
     name='galley_sdk',
-    version='0.19.0',
+    version='0.19.1',
     packages=['galley'],
     install_requires=['sgqlc==14.0', 'backoff==1.11.1']
 )

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -430,13 +430,6 @@ class TestRecipeConnectionQuery(TestCase):
             allIngredients
             externalName
             name
-            }
-            subRecipeId
-            quantity
-            unit {
-            id
-            name
-            }
             reconciledNutritionals {
             addedSugarG
             calciumMg
@@ -497,6 +490,13 @@ class TestRecipeConnectionQuery(TestCase):
             vitaminKPercentRDI
             zincMg
             zincPercentRDI
+            }
+            }
+            subRecipeId
+            quantity
+            unit {
+            id
+            name
             }
             }
             }


### PR DESCRIPTION
## Description
We recently changed the way we're managing standalone recipes in Galley and updated the related handling in get_formatted_recipes_data() to access standaloneNutrition according to the new recipe structure (with the value of standaloneNutrition being pulled from subrecipe.reconciledNutritionals instead of recipeItem.reconciledNutritionals). While this work was in-flight, an unrelated PR merged that updated the way we query recipe data to use graphQL pagination via recipe_connection_query. These changes passed each other like ships in the night, such that get_formatted_recipes_data() was trying to access data no longer being pulled in by recipe_connection_query(). This fix updates recipe_connection_query to pull in subrecipe.reconciledNutritionals instead of recipeItem.reconciledNutritionals, so that the expected data is returned by get_formatted_recipes_data() for standaloneNutrition.

## Test Plan
To test this fix, you'll need to work with a parent recipe that 1) includes a standalone component, and 2) whose standalone component has had its nutrition contribution % set to 0% (like this[ Balinese Gado Gado Salad recipe](https://staging-app.galleysolutions.com/recipes/cmVjaXBlOjE2NzEwOQ==/?userLocationId=bG9jYXRpb246MTkyOA%3D%3D), for example)

Enter the python shell and test retrieving recipe data on the main branch vs. this branch. On the main branch you'll see a None value for standaloneNutrition, on this branch you'll see the expected nutritional values.

`from galley.formatted_queries import *`
`from pprint import pprint`
`pprint(get_formatted_recipes_data(['cmVjaXBlOjE2NzEwOQ==']))`

## Versioning
Please update the project version in setup.py -> DONE
