### PR TITLE
(maint) itemCode referenced before assignment fix

### DIFF
--- a/galley/formatted_queries.py
+++ b/galley/formatted_queries.py
@@ -235,7 +235,7 @@ def get_formatted_menu_data(dates: List[str],
         menu_items = menu.get('menuItems', [])
         for menu_item in menu_items:
             recipe_items = menu_item.get('recipe', {}).get('recipeItems', [])
-
+            itemCode = ''
             categoryValues = menu_item['categoryValues']
             for categoryValue in categoryValues:
                 if (categoryValue['category']['id'] ==

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # are dependencies that are required on remote installs, not local development.
 setup(
     name='galley_sdk',
-    version='0.19.0',
+    version='0.19.2',
     packages=['galley'],
     install_requires=['sgqlc==14.0', 'backoff==1.11.1']
 )

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # are dependencies that are required on remote installs, not local development.
 setup(
     name='galley_sdk',
-    version='0.19.2',
+    version='0.21.1',
     packages=['galley'],
     install_requires=['sgqlc==14.0', 'backoff==1.11.1']
 )


### PR DESCRIPTION
## Description
in cases where product code is not assigned to a menu item an `UnboundLocalError` is being thrown

## Test Plan
in shell access a menu with a menu item that does not have a product code assigned to it. currently there is one in staging for 10-04-2021

```
from galley.formatted_queries import get_formatted_menu_data
dates = ['2021-10-04']
get_formatted_menu_data(dates=dates)
```

on main, this will generate an `UnboundLocalError` that will go away with this fix

## Versioning
Please update the project version in setup.py
