### PR TITLE
Eng 943 add recipe meal slug

### DIFF
--- a/galley/formatted_queries.py
+++ b/galley/formatted_queries.py
@@ -1,12 +1,12 @@
-from typing import Dict, Optional, List
-
-from galley.enums import IngredientCategoryValueEnum, MenuCategoryEnum, MenuItemCategoryEnum, \
-                         PreparationEnum, IngredientCategoryTagTypeEnum, RecipeCategoryTagTypeEnum
-from galley.queries import get_raw_recipes_data, get_raw_menu_data
-
 import logging
+from typing import Dict, List, Optional
 
-from galley.types import Nutrition
+from galley.enums import (IngredientCategoryTagTypeEnum,
+                          IngredientCategoryValueEnum, MenuCategoryEnum,
+                          MenuItemCategoryEnum, PreparationEnum,
+                          RecipeCategoryTagTypeEnum)
+from galley.queries import get_raw_menu_data, get_raw_recipes_data
+
 logger = logging.getLogger(__name__)
 
 

--- a/galley/formatted_queries.py
+++ b/galley/formatted_queries.py
@@ -195,6 +195,12 @@ def get_standalone(recipe_items: List[Dict]) -> Optional[str]:
             return recipe_item.get('subRecipeId')
     return None
 
+def get_meal_slug(menu_item: Dict) -> Optional[str]:
+    categories = menu_item['recipe'].get('categoryValues', [])
+    for category in categories:
+        if category.get('category', {}).get('id', '') == RecipeCategoryTagTypeEnum.BASE_MEAL_SLUG_TAG.value:
+            return category['name']
+
 
 # DATA TRANSFORMATION FUNCTIONS
 
@@ -245,6 +251,7 @@ def get_formatted_menu_data(dates: List[str],
             formatted_menu['menuItems'].append({
                 'id': menu_item.get('id'),
                 'itemCode': itemCode,
+                'mealSlug': get_meal_slug(menu_item),
                 'recipeId': menu_item.get('recipeId'),
                 'standaloneRecipeId': get_standalone(recipe_items)
             })

--- a/galley/formatted_queries.py
+++ b/galley/formatted_queries.py
@@ -200,6 +200,7 @@ def get_meal_slug(menu_item: Dict) -> Optional[str]:
     for category in categories:
         if category.get('category', {}).get('id', '') == RecipeCategoryTagTypeEnum.BASE_MEAL_SLUG_TAG.value:
             return category['name']
+    return None
 
 
 # DATA TRANSFORMATION FUNCTIONS

--- a/galley/queries.py
+++ b/galley/queries.py
@@ -1,12 +1,14 @@
-from typing import Any, Dict, Optional, List
+import logging
+from typing import Any, Dict, List, Optional
+
 from sgqlc.operation import Operation
-from sgqlc.types import Field, Type, ArgDict
+from sgqlc.types import ArgDict, Field, Type
 
 from galley.common import make_request_to_galley, validate_response_data
 from galley.enums import MenuCategoryEnum
-from galley.types import Recipe, Menu, FilterInput, MenuFilterInput, RecipeConnection, \
-    RecipeConnectionFilter, PaginationOptions
-import logging
+from galley.types import (FilterInput, Menu, MenuFilterInput,
+                          PaginationOptions, Recipe, RecipeConnection,
+                          RecipeConnectionFilter)
 
 logger = logging.getLogger(__name__)
 
@@ -15,9 +17,9 @@ DEFAULT_PAGE_SIZE = 25
 
 class Viewer(Type):
     recipeConnection = Field(
-        RecipeConnection, 
+        RecipeConnection,
         args=(ArgDict({
-            'filters': RecipeConnectionFilter, 
+            'filters': RecipeConnectionFilter,
             'paginationOptions': PaginationOptions
         }))
     )
@@ -63,7 +65,7 @@ def get_recipe_data() -> Optional[List[Dict]]:
 def recipe_connection_query(recipe_ids: List[str], page_size: int = DEFAULT_PAGE_SIZE, start_index: int = 0) -> Optional[Operation]:
     query = Operation(Query)
     query.viewer.recipeConnection(
-        filters=RecipeConnectionFilter(id=recipe_ids), 
+        filters=RecipeConnectionFilter(id=recipe_ids),
         paginationOptions=PaginationOptions(first=page_size, startIndex=start_index)
     )
     query.viewer.recipeConnection.edges()
@@ -98,7 +100,7 @@ def get_raw_recipes_data(recipe_ids: List[str]) -> Optional[List[Dict]]:
     start_index = 0
 
     raw_recipes_data = []
-    
+
     if recipe_ids is None:
         return []
 
@@ -111,18 +113,18 @@ def get_raw_recipes_data(recipe_ids: List[str]) -> Optional[List[Dict]]:
             return None
 
         edges = validated_data.get('edges', [])
-        
+
         for edge in edges:
             recipe = edge.get('node', {})
             if recipe:
                 raw_recipes_data.append(recipe)
-        
+
         page_info = validated_data.get('pageInfo', {})
         start_index = page_info.get('endIndex')
         has_next_page = page_info.get('hasNextPage', False)
-    
+
     return raw_recipes_data
-    
+
 
 def get_menu_query(dates: List[str]) -> Optional[List[Dict]]:
     query = Operation(Query)

--- a/galley/queries.py
+++ b/galley/queries.py
@@ -130,7 +130,7 @@ def get_menu_query(dates: List[str]) -> Optional[List[Dict]]:
         'id', 'name', 'date', 'location', 'categoryValues', 'menuItems'
     )
     query.viewer.menus.menuItems.__fields__('id', 'recipeId', 'categoryValues', 'recipe')
-    query.viewer.menus.menuItems.recipe.__fields__('externalName', 'recipeItems')
+    query.viewer.menus.menuItems.recipe.__fields__('externalName', 'recipeItems', 'categoryValues')
     query.viewer.menus.menuItems.recipe.recipeItems.__fields__('subRecipeId', 'preparations')
     query.viewer.menus.menuItems.recipe.recipeItems.preparations.__fields__('id', 'name')
     return query

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # are dependencies that are required on remote installs, not local development.
 setup(
     name='galley_sdk',
-    version='0.19.0',
+    version='0.20.0',
     packages=['galley'],
     install_requires=['sgqlc==14.0', 'backoff==1.11.1']
 )

--- a/tests/mock_responses/mock_menu_data.py
+++ b/tests/mock_responses/mock_menu_data.py
@@ -1,4 +1,4 @@
-from galley.enums import MenuCategoryEnum, MenuItemCategoryEnum, PreparationEnum
+from galley.enums import MenuCategoryEnum, MenuItemCategoryEnum, PreparationEnum, RecipeCategoryTagTypeEnum
 
 
 def mock_menu(date, location_name="Vacaville", menu_type="production"):
@@ -91,6 +91,15 @@ def mock_menu(date, location_name="Vacaville", menu_type="production"):
                             }
                         ],
                         'subRecipeId': 'SUBRECIPEID321'
+                    }],
+                    'categoryValues': [{
+                        'id': 'uniqueCatvalueId',
+                        'name': 'test-recipe-name-3',
+                        'category': {
+                            'id': RecipeCategoryTagTypeEnum.BASE_MEAL_SLUG_TAG.value,
+                            'name': 'base meal slug',
+                            'itemType': 'recipe'
+                        }
                     }]
                 },
             }

--- a/tests/test_formatted_queries.py
+++ b/tests/test_formatted_queries.py
@@ -261,16 +261,19 @@ class TestGetFormattedMenuData(TestCase):
             'menuItems': [{
                 'id': 'MENUITEM1ABC',
                 'itemCode': 'dv1',
+                'mealSlug': None,
                 'recipeId': 'RECIPE1ABC',
                 'standaloneRecipeId': 'SUBRECIPEID456'
             }, {
                 'id': 'MENUITEM2DEF',
                 'itemCode': 'dv2',
+                'mealSlug': None,
                 'recipeId': 'RECIPE2DEF',
                 'standaloneRecipeId': None
             }, {
                 'id': 'MENUITEM3GHI',
                 'itemCode': 'lm2',
+                'mealSlug': 'test-recipe-name-3',
                 'recipeId': 'RECIPE3GHI',
                 'standaloneRecipeId': 'SUBRECIPEID321'
             }]

--- a/tests/test_formatted_queries.py
+++ b/tests/test_formatted_queries.py
@@ -1,9 +1,13 @@
-from unittest import mock, TestCase
+from unittest import TestCase, mock
 
-from galley.formatted_queries import get_formatted_recipes_data, ingredients_from_recipe_items, \
-    get_formatted_menu_data, format_recipe_tree_components_data
+from galley.formatted_queries import (format_recipe_tree_components_data,
+                                      get_formatted_menu_data,
+                                      get_formatted_recipes_data,
+                                      ingredients_from_recipe_items)
 
-from tests.mock_responses import mock_nutrition_data, mock_recipes_data, mock_recipe_items, mock_recipe_tree_components
+from tests.mock_responses import (mock_nutrition_data, mock_recipe_items,
+                                  mock_recipe_tree_components,
+                                  mock_recipes_data)
 from tests.mock_responses.mock_menu_data import mock_menu
 
 
@@ -192,7 +196,7 @@ class TestGetFormattedRecipesData(TestCase):
         mock_retrieval_method.return_value = {
             'data': {
                 'viewer': {
-                    'recipeConnection': mock_recipes_data.mock_recipe_connection(['1', '2'])                    
+                    'recipeConnection': mock_recipes_data.mock_recipe_connection(['1', '2'])
                 }
             }
         }
@@ -229,8 +233,8 @@ class TestGetFormattedRecipesData(TestCase):
         mock_retrieval_method.return_value = {
             'data': {
                 'viewer': {
-                    'recipeConnection': 
-                        mock_recipes_data.mock_recipe_connection_with_standalone(['1'])                    
+                    'recipeConnection':
+                        mock_recipes_data.mock_recipe_connection_with_standalone(['1'])
                 }
             }
         }

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -128,6 +128,15 @@ class TestQueryWeekMenuData(TestCase):
             name
             }
             }
+            categoryValues{
+            id
+            name
+            category{
+            id
+            name
+            itemType
+            }
+            }
             }
             }
             }

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -528,7 +528,7 @@ class TestRecipeConnectionQuery(TestCase):
             start_index=0
         )
         query_str = bytes(query).decode('utf-8')
-        
+
         self.assertEqual(query_str, self.expected_query)
 
 
@@ -596,17 +596,17 @@ class TestQueryGetRawRecipesData(TestCase):
     def test_get_raw_recipes_multiple_pages(self, mock_retrieval_method):
         # Mocking 2 pages with with a 2 recipe limit
         page_1 = mock_recipes_data.mock_recipe_connection(
-            ['1', '2'], 
+            ['1', '2'],
             has_previous_page=False,
-            has_next_page=True, 
+            has_next_page=True,
             start_index=0,
             end_index=2
         )
         page_2 = mock_recipes_data.mock_recipe_connection(
-            ['3'], 
-            has_previous_page=True, 
+            ['3'],
+            has_previous_page=True,
             has_next_page=False,
-            start_index=2, 
+            start_index=2,
             end_index=3
         )
         expected_recipe_data = list(map(mock_recipes_data.mock_recipe, ['1', '2', '3']))
@@ -629,4 +629,3 @@ class TestQueryGetRawRecipesData(TestCase):
         result = get_raw_recipes_data(['1', '2', '3'])
         self.assertEqual(mock_retrieval_method.call_count, 2)
         self.assertEqual(result, expected_recipe_data)
-        


### PR DESCRIPTION
## Description
This branch pulls the base meal slug and includes it in the formatted responses for menu.

## Test Plan
You can check the meal slugs are returned with the formatted queries like so.
```
import galley
from galley.formatted_queries import get_formatted_menu_data
get_formatted_menu_data(['2022-01-03'])
```

## Versioning
[X] Please update the project version in setup.py
