### PR TITLE
(maint) add hasStandalone and baseMeal fields to formatted recipe data

### DIFF
--- a/galley/enums.py
+++ b/galley/enums.py
@@ -45,4 +45,5 @@ class RecipeCategoryTagTypeEnum(Enum):
     MEAL_CONTAINER_TAG = 'Y2F0ZWdvcnk6MjU2Nw=='
     PROTEIN_ADDON_TAG = 'Y2F0ZWdvcnk6MjU4MQ=='
     BASE_MEAL_SLUG_TAG = 'Y2F0ZWdvcnk6MjYyMA=='
+    BASE_MEAL_TAG = 'Y2F0ZWdvcnk6MjU4OQ=='
 

--- a/galley/formatted_queries.py
+++ b/galley/formatted_queries.py
@@ -87,6 +87,7 @@ def get_recipe_category_tags(recipe_category_values: List[Dict]) -> Optional[Dic
         RecipeCategoryTagTypeEnum.MEAL_CONTAINER_TAG.value: 'mealContainer',
         RecipeCategoryTagTypeEnum.PROTEIN_ADDON_TAG.value: 'proteinAddOn',
         RecipeCategoryTagTypeEnum.BASE_MEAL_SLUG_TAG.value: 'baseMealSlug',
+        RecipeCategoryTagTypeEnum.BASE_MEAL_TAG.value: 'baseMeal',
     }
 
     for recipe_category_value in recipe_category_values:
@@ -153,6 +154,7 @@ def format_recipe_tree_components_data(recipe_tree_components: List[Dict]) -> Di
 
     return {
         'weight': round(total_weight, 2),
+        'hasStandalone': True if standalone_recipe_item else False,
         **standalone_data
     }
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # are dependencies that are required on remote installs, not local development.
 setup(
     name='galley_sdk',
-    version='0.20.0',
+    version='0.21.0',
     packages=['galley'],
     install_requires=['sgqlc==14.0', 'backoff==1.11.1']
 )

--- a/tests/mock_responses/mock_recipes_data.py
+++ b/tests/mock_responses/mock_recipes_data.py
@@ -57,6 +57,14 @@ def mock_recipe_base(id):
                     'itemType': 'recipe',
                     'name': 'base meal slug'
                 }
+            },
+            {
+                'name': 'Base Salad Name',
+                'category': {
+                    'id': RecipeCategoryTagTypeEnum.BASE_MEAL_TAG.value,
+                    'itemType': 'recipe',
+                    'name': 'base meal'
+                }
             }
         ],
         'recipeItems': mock_recipe_items.mock_data,

--- a/tests/test_formatted_queries.py
+++ b/tests/test_formatted_queries.py
@@ -128,7 +128,8 @@ class TestFormattedRecipeTreeComponents(TestCase):
                 "Garlic"
             ],
             'standaloneWeight': 70.87,
-            'weight': 156.49
+            'weight': 156.49,
+            'hasStandalone': True
         }
         self.assertEqual(result, expected)
 
@@ -150,6 +151,7 @@ class TestGetFormattedRecipesData(TestCase):
                 'mealType': 'dinner',
                 'proteinAddOn': 'high-protein-legume',
                 'baseMealSlug': 'base-salad',
+                'baseMeal': 'Base Salad Name',
                 'ingredients': [
                     'Unique 1',
                     'Duplicate 1',
@@ -159,6 +161,7 @@ class TestGetFormattedRecipesData(TestCase):
                     'Unique 4'
                 ],
                 'weight': 829.22,
+                'hasStandalone': False,
                 'standaloneIngredients': None,
                 'standaloneNutrition': None,
                 'standaloneRecipeId': None,
@@ -176,6 +179,7 @@ class TestGetFormattedRecipesData(TestCase):
                 'mealType': 'dinner',
                 'proteinAddOn': 'high-protein-legume',
                 'baseMealSlug': 'base-salad',
+                'baseMeal': 'Base Salad Name',
                 'ingredients': [
                     'Unique 1',
                     'Duplicate 1',
@@ -189,7 +193,8 @@ class TestGetFormattedRecipesData(TestCase):
                 'standaloneRecipeId': None,
                 'standaloneRecipeName': None,
                 'standaloneWeight': None,
-                'weight': 829.22
+                'weight': 829.22,
+                'hasStandalone': False
             }
         ]
 
@@ -240,6 +245,7 @@ class TestGetFormattedRecipesData(TestCase):
         }
         result = get_formatted_recipes_data(['1'])
         formatted_recipe = result[0]
+        self.assertEqual(formatted_recipe['hasStandalone'], True)
         self.assertEqual(formatted_recipe['standaloneRecipeName'], 'Peanut Coconut Sauce')
         self.assertEqual(formatted_recipe['standaloneRecipeId'], 'cmVjaXBlOjE3MDM5NA==')
         self.assertEqual(formatted_recipe['standaloneWeight'], 70.87)


### PR DESCRIPTION
## Description
This adds two new fields to the formatted data returned for each recipe. hasStandalone is a boolean field representing whether the recipe includes a standalone component. This new field will allow us to validate on fields specific to the standalone recipe when expected. baseMeal is a categoryValue (tag) being set on each recipe in Galley that we forgot to include in the formatted data previously. Tests are updated to cover the expected behaviors.

## Test Plan
To test this, retrieve recipe details for a couple recipes (one w/standalone and one without) and ensure that the `hasStandalone` and `baseMeal` fields are returned with the expected values for each recipe.

This example uses the Balinese Gado Gado Salad (with standalone) and Burmese Yellow Curry(no standalone):

`from galley.formatted_queries import *`
`from pprint import pprint`
`pprint(get_formatted_recipes_data(['cmVjaXBlOjE2NzEwOQ==', 'cmVjaXBlOjE3NjQ5Mg==']))`

## Versioning
Please update the project version in setup.py -> DONE
