### PR TITLE
(ENG-990) Pull photos for recipe and return lifestylePhotoUrl

### DIFF
--- a/galley/enums.py
+++ b/galley/enums.py
@@ -47,3 +47,8 @@ class RecipeCategoryTagTypeEnum(Enum):
     BASE_MEAL_SLUG_TAG = 'Y2F0ZWdvcnk6MjYyMA=='
     BASE_MEAL_TAG = 'Y2F0ZWdvcnk6MjU4OQ=='
 
+class RecipeMediaEnum(Enum):
+    """
+    Enum for RecipeMedia. <field name>: <field value>
+    """
+    LIFESTYLE_CAPTION = 'lifestyle'

--- a/galley/formatted_queries.py
+++ b/galley/formatted_queries.py
@@ -115,6 +115,7 @@ class FormattedRecipe:
         self.externalName = get_external_name(recipe_data)
         self.notes = recipe_data.get('notes')
         self.description = recipe_data.get('description')
+        self.lifestylePhotoUrl = get_lifestyle_photo(recipe_data.get('media', []))
         self.nutrition = recipe_data.get('reconciledNutritionals', {})
         self.recipe_category_values = recipe_data.get('categoryValues', [])
         self.recipe_tags = get_recipe_category_tags(self.recipe_category_values)
@@ -132,6 +133,7 @@ class FormattedRecipe:
             'description': self.description,
             'nutrition': self.nutrition,
             'ingredients': ingredients_from_recipe_items(recipe_items=self.recipe_items),
+            'lifestylePhotoUrl': self.lifestylePhotoUrl,
             **self.formatted_recipe_tree_components_data,
             **self.recipe_tags
         }
@@ -278,6 +280,13 @@ def get_meal_slug(menu_item: Dict) -> Optional[str]:
     for category in categories:
         if category.get('category', {}).get('id', '') == RecipeCategoryTagTypeEnum.BASE_MEAL_SLUG_TAG.value:
             return category['name']
+    return None
+
+
+def get_lifestyle_photo(media: List) -> Optional[str]:
+    for photo in media:
+        if photo.get('caption', '') == 'lifestyle' and photo.get('sourceUrl', None):
+            return photo.get('sourceUrl')
     return None
 
 

--- a/galley/formatted_queries.py
+++ b/galley/formatted_queries.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Optional
 from galley.enums import (IngredientCategoryTagTypeEnum,
                           IngredientCategoryValueEnum, MenuCategoryEnum,
                           MenuItemCategoryEnum, PreparationEnum,
-                          RecipeCategoryTagTypeEnum)
+                          RecipeCategoryTagTypeEnum, RecipeMediaEnum)
 from galley.queries import get_raw_menu_data, get_raw_recipes_data
 
 logger = logging.getLogger(__name__)
@@ -115,7 +115,7 @@ class FormattedRecipe:
         self.externalName = get_external_name(recipe_data)
         self.notes = recipe_data.get('notes')
         self.description = recipe_data.get('description')
-        self.lifestylePhotoUrl = get_lifestyle_photo(recipe_data.get('media', []))
+        self.lifestylePhotoUrl = get_lifestyle_photo_url(recipe_data.get('media', []))
         self.nutrition = recipe_data.get('reconciledNutritionals', {})
         self.recipe_category_values = recipe_data.get('categoryValues', [])
         self.recipe_tags = get_recipe_category_tags(self.recipe_category_values)
@@ -283,9 +283,9 @@ def get_meal_slug(menu_item: Dict) -> Optional[str]:
     return None
 
 
-def get_lifestyle_photo(media: List) -> Optional[str]:
+def get_lifestyle_photo_url(media: List) -> Optional[str]:
     for photo in media:
-        if photo.get('caption', '') == 'lifestyle' and photo.get('sourceUrl', None):
+        if photo.get('caption', '') == RecipeMediaEnum.LIFESTYLE_CAPTION.value and photo.get('sourceUrl', None):
             return photo.get('sourceUrl')
     return None
 

--- a/galley/queries.py
+++ b/galley/queries.py
@@ -73,8 +73,9 @@ def recipe_connection_query(recipe_ids: List[str], page_size: int = DEFAULT_PAGE
     query.viewer.recipeConnection.totalCount
 
     query.viewer.recipeConnection.edges.node.__fields__(
-        'id', 'externalName', 'name', 'notes', 'description', 'categoryValues', 'reconciledNutritionals', 'recipeItems'
+        'id', 'externalName', 'name', 'notes', 'description', 'media', 'categoryValues', 'reconciledNutritionals', 'recipeItems',
     )
+    query.viewer.recipeConnection.edges.node.media.__fields__('altText', 'caption', 'sourceUrl')
     query.viewer.recipeConnection.edges.node.recipeItems.__fields__('ingredient', 'subRecipe', 'preparations')
     query.viewer.recipeConnection.edges.node.recipeItems.ingredient.__fields__('externalName', 'categoryValues')
     query.viewer.recipeConnection.edges.node.recipeTreeComponents(levels=[1]).__fields__('id', 'quantityUnitValues', 'recipeItem')

--- a/galley/types.py
+++ b/galley/types.py
@@ -159,6 +159,12 @@ class Recipe(Type):
     recipeItems = Field(RecipeItem)
 
 
+class RecipeMedia(Type):
+    altText = str
+    caption = str
+    sourceUrl = str
+
+
 class RecipeNode(Node):
     id = str
     name = str
@@ -170,6 +176,7 @@ class RecipeNode(Node):
     reconciledNutritionals = Field(Nutrition)
     categoryValues = Field(CategoryValue)
     recipeItems = Field(RecipeItem)
+    media = Field(RecipeMedia)
 
 
 class RecipeEdge(Type):
@@ -187,7 +194,7 @@ class RecipeConnection(Connection):
     edges = list_of(RecipeEdge)
     pageInfo = Field(PageInfoType)
     totalCount = int
-    
+
 
 class RecipeInstruction(Type):
     id = str
@@ -250,6 +257,7 @@ class MenuInput(Input):
     id = str
     recipeId = str
     menuItems = Field(list_of(MenuItemInput))
+
 
 class BulkMenusInput(Input):
     menus = Field(list_of(MenuInput))

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # are dependencies that are required on remote installs, not local development.
 setup(
     name='galley_sdk',
-    version='0.22.0',
+    version='0.23.0',
     packages=['galley'],
     install_requires=['sgqlc==14.0', 'backoff==1.11.1']
 )

--- a/tests/mock_responses/mock_recipes_data.py
+++ b/tests/mock_responses/mock_recipes_data.py
@@ -67,6 +67,29 @@ def mock_recipe_base(id):
                 }
             }
         ],
+        'media': [
+            {
+                'altText': 'None.jpg',
+                'caption': None,
+                'sourceUrl': 'https://cdn.filestackcontent.com/HaCZIYLBRfWmeMtErKSU',
+                'mediaId': 'bWVkaWE6OTEwNA==',
+                'storageKey': 'Thistle/Media/ujTTMJETR1eV9LJMJTJo_None.jpg'
+            },
+            {
+                'altText': 'Plating.jpg',
+                'caption': 'Plating Photo',
+                'sourceUrl': 'https://cdn.filestackcontent.com/rVVEymFAQv4m0LTYz3IV',
+                'mediaId': 'bWVkaWE6TEOwNQ==',
+                'storageKey': 'Thistle/Media/TnLOVsiTG61I5W1VFwqw_.jpg'
+            },
+            {
+                'altText': f'lifestyle{id}.jpg',
+                'caption': 'lifestyle',
+                'sourceUrl': f'https://cdn.filestackcontent.com/LIFESTYLE{id}',
+                'mediaId': 'bWVkaWE6OTEwNA==',
+                'storageKey': f'Thistle/Media/1uTFWcWhTIGBpybJ1axc_lifestyle{id}.jpg'
+            },
+        ],
         'recipeItems': mock_recipe_items.mock_data,
         'reconciledNutritionals': mock_nutrition_data.mock_data
 })
@@ -86,9 +109,9 @@ def mock_recipe_with_standalone_recipe_item(id):
     })
 
 
-def mock_page_info(end_index: int = 1, 
-                   has_next_page: bool = False, 
-                   has_previous_page: bool = False, 
+def mock_page_info(end_index: int = 1,
+                   has_next_page: bool = False,
+                   has_previous_page: bool = False,
                    start_index: int = 0):
     return ({
         'endIndex': end_index,
@@ -98,10 +121,10 @@ def mock_page_info(end_index: int = 1,
     })
 
 
-def mock_recipe_connection(ids, 
-                           end_index: int = 1, 
-                           has_next_page: bool = False, 
-                           has_previous_page: bool = False, 
+def mock_recipe_connection(ids,
+                           end_index: int = 1,
+                           has_next_page: bool = False,
+                           has_previous_page: bool = False,
                            start_index: int = 0):
     edges = []
     for id in ids:
@@ -111,7 +134,7 @@ def mock_recipe_connection(ids,
             }
         )
 
-    return ({        
+    return ({
         'edges': edges,
         'pageInfo': mock_page_info(
             end_index=end_index,
@@ -121,10 +144,10 @@ def mock_recipe_connection(ids,
     })
 
 
-def mock_recipe_connection_with_standalone(ids, 
-                           end_index: int = 1, 
-                           has_next_page: bool = False, 
-                           has_previous_page: bool = False, 
+def mock_recipe_connection_with_standalone(ids,
+                           end_index: int = 1,
+                           has_next_page: bool = False,
+                           has_previous_page: bool = False,
                            start_index: int = 0):
     edges = []
     for id in ids:
@@ -134,7 +157,7 @@ def mock_recipe_connection_with_standalone(ids,
             }
         )
 
-    return ({        
+    return ({
         'edges': edges,
         'pageInfo': mock_page_info(
             end_index=end_index,

--- a/tests/test_formatted_queries.py
+++ b/tests/test_formatted_queries.py
@@ -40,12 +40,12 @@ class TestCalculateServings(TestCase):
         expected_result = 2.5
         result = calculate_servings(2.5, 1.0)
         self.assertEqual(result, expected_result)
-        
+
     def test_calculate_servings_returns_None_if_usage_quantity_missing(self):
         expected_result = None
         result = calculate_servings(None, 1.0)
         self.assertEqual(result, expected_result)
-        
+
     def test_calculate_servings_returns_None_if_nutritionals_quantity_missing(self):
         expected_result = None
         result = calculate_servings(2.5, None)
@@ -57,12 +57,12 @@ class TestCalculateServingSizeWeight(TestCase):
         expected_result = 50
         result = calculate_serving_size_weight(100, 2.0)
         self.assertEqual(result, expected_result)
-        
+
     def test_calculate_serving_size_weight_returns_None_if_weight_missing(self):
         expected_result = None
         result = calculate_serving_size_weight(None, 2.0)
         self.assertEqual(result, expected_result)
-        
+
     def test_calculate_serving_size_weight_returns_None_if_number_of_servings_missing(self):
         expected_result = None
         result = calculate_serving_size_weight(100, None)
@@ -171,7 +171,7 @@ class TestFormattedRecipeTreeComponents(TestCase):
             'hasStandalone': True
         }
         self.assertEqual(result, expected)
-        
+
     def test_format_recipe_tree_components_data_with_one_serving_of_standalone_component(self):
         self.maxDiff = None
         result = format_recipe_tree_components_data(
@@ -355,6 +355,7 @@ class TestGetFormattedRecipesData(TestCase):
                 'externalName': 'Test Recipe 1',
                 'notes': 'Some notes about recipe 1',
                 'description': 'Details about recipe 1',
+                'lifestylePhotoUrl': 'https://cdn.filestackcontent.com/LIFESTYLE1',
                 'nutrition': mock_nutrition_data.mock_data,
                 'proteinType': 'vegan',
                 'mealContainer': 'ts48',
@@ -386,6 +387,7 @@ class TestGetFormattedRecipesData(TestCase):
                 'externalName': 'Test Recipe 2',
                 'notes': 'Some notes about recipe 2',
                 'description': 'Details about recipe 2',
+                'lifestylePhotoUrl': 'https://cdn.filestackcontent.com/LIFESTYLE2',
                 'nutrition': mock_nutrition_data.mock_data,
                 'proteinType': 'vegan',
                 'mealContainer': 'ts48',

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -253,6 +253,11 @@ class TestRecipeConnectionQuery(TestCase):
             name
             notes
             description
+            media {
+            altText
+            caption
+            sourceUrl
+            }
             categoryValues {
             id
             name


### PR DESCRIPTION
## Description
Updated galley-sdk to pull a recipe's 'media' attribute (a list of RecipeMedia objects) in recipe_connection_query. Updated get_formatted_recipes_data to search the RecipeMedia objects for an object with the caption 'lifestyle'. It then returns the sourceUrl for this RecipeMedia object as the formatted recipe's lifestylePhotoUrl.

## Test Plan
1. Make sure all tests are passing
2. Test raw query locally in python console (make sure both images show up in the media attribute):
note: The recipe ID provided is a [fake recipe](https://staging-app.galleysolutions.com/recipes/cmVjaXBlOjE5OTgzOA==) I've modified to have two images, one that has the caption 'lifestyle'. This will be overwritten if this PR isn't reviewed before the overnight job replaces staging data.
```
from galley.queries import *
get_raw_recipes_data(recipe_ids=["cmVjaXBlOjE5OTgzOA=="])
```
3. Test formatted data locally (make sure the correct image is returned as the lifestylePhotoUrl:
```
from galley.formatted_queries import *
get_formatted_recipes_data(recipe_ids=["cmVjaXBlOjE5OTgzOA=="])
```

## Versioning

- [x] Please update the project version in setup.py
