### PR TITLE
(ENG-1010) remove proof-of-concept code

### DIFF
--- a/galley/mutations.py
+++ b/galley/mutations.py
@@ -2,37 +2,13 @@ from sgqlc.operation import Operation
 from sgqlc.types import Field, Type
 
 from galley.common import make_request_to_galley, validate_response_data
-from galley.types import (BulkMenusInput, InstructionInput, MenuInput,
-                          MenuItemInput, MenuPayload, RecipeInstructionInput,
-                          RecipeInstructionPayload, UnitInput)
+from galley.types import (BulkMenusInput, MenuInput, MenuItemInput, MenuPayload, UnitInput)
 
 
 # This is graphql root for mutating data according to sgqlc lib. So this class name has to be Mutation.
 class Mutation(Type):
-    createRecipeInstruction = Field(RecipeInstructionPayload, args={'input': RecipeInstructionInput})
     bulkUpsertMenus = Field(MenuPayload, args={'input': BulkMenusInput})
 
-
-# RECIPE MUTATIONS
-
-def add_recipe_instruction(recipe_id, instruction, position=None):
-    mutation = Operation(Mutation)
-    vars = {'recipeId': recipe_id, 'text': instruction}
-
-    if position is not None:
-        mutation.createRecipeInstruction(input=RecipeInstructionInput(
-            recipeId=recipe_id,
-            recipeInstruction=InstructionInput(text=instruction, position=position)
-        )).recipeInstruction().__fields__('recipeId', 'text', 'position')
-        vars.setdefault('position', position)
-    else:
-        mutation.createRecipeInstruction(input=RecipeInstructionInput(
-            recipeId=recipe_id,
-            recipeInstruction=InstructionInput(text=instruction)
-        )).recipeInstruction().__fields__('recipeId', 'text', 'position')
-
-    raw_data = make_request_to_galley(op=mutation, variables=vars)
-    return validate_response_data(raw_data, 'createRecipeInstruction', 'recipeInstruction')
 
 # MENU MUTATIONS
 UNIT_NAME_WHITELIST = ['each']

--- a/galley/queries.py
+++ b/galley/queries.py
@@ -51,17 +51,6 @@ class Query(Type):
 
 # RECIPE QUERIES
 
-def get_recipe_data() -> Optional[List[Dict]]:
-    # Initiate a query
-    query = Operation(Query)
-    # Call sub-type you need to build the query.
-    query.viewer.recipes.__fields__(
-        'id', 'externalName', 'instructions', 'notes', 'description'
-    )
-    # pass query as an argument to make_request_to_galley function.
-    raw_data = make_request_to_galley(op=query)
-    return validate_response_data(raw_data, 'recipes')
-
 def recipe_connection_query(recipe_ids: List[str], page_size: int = DEFAULT_PAGE_SIZE, start_index: int = 0) -> Optional[Operation]:
     query = Operation(Query)
     query.viewer.recipeConnection(

--- a/galley/types.py
+++ b/galley/types.py
@@ -196,27 +196,6 @@ class RecipeConnection(Connection):
     totalCount = int
 
 
-class RecipeInstruction(Type):
-    id = str
-    text = str
-    position = int
-    recipeId = str
-
-
-class InstructionInput(Input):
-    text = str
-    position = int
-
-
-class RecipeInstructionInput(Input):
-    recipeId = str
-    recipeInstruction = InstructionInput
-
-
-class RecipeInstructionPayload(Type):
-    recipeInstruction = Field(RecipeInstruction)
-
-
 class Location(Type):
     name = str
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # are dependencies that are required on remote installs, not local development.
 setup(
     name='galley_sdk',
-    version='0.23.0',
+    version='0.23.1',
     packages=['galley'],
     install_requires=['sgqlc==14.0', 'backoff==1.11.1']
 )

--- a/tests/test_mutations.py
+++ b/tests/test_mutations.py
@@ -1,81 +1,15 @@
 from unittest import mock, TestCase
 from sgqlc.operation import Operation
 
-from galley.mutations import Mutation, add_recipe_instruction, upsert_menu_data, build_upsert_mutation_query
+from galley.mutations import Mutation, upsert_menu_data, build_upsert_mutation_query
 from galley.types import (
     MenuInput,
-    Menu,
-    RecipeInstructionInput,
-    InstructionInput
+    Menu
 )
 import logging
 
 logger = logging.getLogger(__name__)
 
-
-class TestCreateRecipeInstructionMethod(TestCase):
-    def setUp(self) -> None:
-        self.galley_graphql_mutation_str = '''mutation {
-            createRecipeInstruction(input: {recipeId: "cmVjaXBlOjE2NDgzMw", recipeInstruction: {text: "Add salt"}}) {
-            recipeInstruction {
-            recipeId
-            text
-            position
-            }
-            }
-            }'''.replace(' '*12, '')
-
-        self.payload = {
-            'recipeId': 'ABCDE123',
-            'text': 'Test instruction text.',
-            'position': 10
-        }
-
-        self.data = {
-            'data': {
-                'createRecipeInstruction': {
-                    'recipeInstruction': self.payload
-                }
-            }
-        }
-
-    def test_add_recipe_instruction_mutation(self):
-        mutation_operation = Operation(Mutation)
-        mutation_operation.createRecipeInstruction(input=RecipeInstructionInput(
-            recipeId="cmVjaXBlOjE2NDgzMw",
-            recipeInstruction=InstructionInput(text="Add salt")
-        )).recipeInstruction().__fields__('recipeId', 'text', 'position')
-        mutation_str = bytes(mutation_operation).decode('utf-8')
-        self.assertEqual(mutation_str, self.galley_graphql_mutation_str)
-
-    def test_add_recipe_instruction_failure(self):
-        mutation_operation = Operation(Mutation)
-        mutation_str = bytes(mutation_operation).decode('utf-8')
-        self.assertNotEqual(mutation_str, self.galley_graphql_mutation_str)
-
-    @mock.patch('galley.mutations.make_request_to_galley')
-    def test_add_recipe_instruction_with_step_successful(self, mock_mr):
-        mock_mr.return_value = self.data
-        result = add_recipe_instruction('ABCDE123', 'Test instruction text.', 10)
-        self.assertEqual(result, self.payload)
-
-    @mock.patch('galley.mutations.make_request_to_galley')
-    def test_add_recipe_instruction_without_step_successful(self, mock_mr):
-        mock_mr.return_value = self.data
-        result = add_recipe_instruction('ABCDE123', 'Test instruction text.')
-        self.assertEqual(result, self.payload)
-
-    @mock.patch('galley.mutations.make_request_to_galley')
-    def test_add_recipe_instruction_validation_failure(self, mock_mr):
-        mock_mr.return_value = {
-            'data': {
-                'createRecipeInstruction': {
-                    'test': 'test'
-                }
-            }
-        }
-        result = add_recipe_instruction('ABCDE123', 'Test instruction text.')
-        self.assertEqual(result, None)
 
 class TestUpsertMenuData(TestCase):
     def setUp(self) -> None:

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -2,8 +2,7 @@ import logging
 from unittest import TestCase, mock
 
 from galley.queries import (Query, get_menu_query, get_raw_menu_data,
-                            get_raw_recipes_data, get_recipe_data,
-                            recipe_connection_query)
+                            get_raw_recipes_data, recipe_connection_query)
 from sgqlc.operation import Operation
 
 from tests.mock_responses import mock_recipes_data
@@ -38,53 +37,6 @@ class TestQueryRecipes(TestCase):
         query_operation = Operation(Query)
         query_str = bytes(query_operation).decode('utf-8')
         self.assertNotEqual(query_str, self.expected_query)
-
-    @mock.patch('galley.queries.make_request_to_galley')
-    def test_get_recipe_data_successful(self, mock_retrieval_method):
-        recipes = [
-            {
-                'id': '10000',
-                'externalName': 'test recipe 1',
-                'instructions': 'testing',
-                'notes': 'testing notes',
-                'description': 'test'
-            },
-            {
-                'id': '10000',
-                'externalName': 'test recipe 2',
-                'instructions': None,
-                'notes': None,
-                'description': None
-            }
-        ]
-
-        mock_retrieval_method.return_value = {
-            'data': {
-                'viewer': {
-                    'recipes': recipes
-                }
-            }
-        }
-        result = get_recipe_data()
-        self.assertEqual(result, recipes)
-
-    @mock.patch('galley.queries.make_request_to_galley')
-    def test_get_recipe_data_validation_failure(self, mock_retrieval_method):
-        mock_retrieval_method.return_value = {
-            'data': {
-                'viewer': {
-                    'test': 'test'
-                }
-            }
-        }
-        result = get_recipe_data()
-        self.assertEqual(result, None)
-
-    @mock.patch('galley.queries.make_request_to_galley')
-    def test_recipe_data_null(self, mock_retrieval_method):
-        mock_retrieval_method.return_value = None
-        result = get_recipe_data()
-        self.assertEqual(result, None)
 
 
 class TestQueryWeekMenuData(TestCase):


### PR DESCRIPTION
## Description
This removes the POC query and mutation we added while we were setting up galley-sdk and learning how to use the sgqlc tooling. The query, get_recipe_data(), and mutation, add_recipe_instruction(), are not being used and we have no plans to use them in the future. Related tests and Typing entries are also removed.

## Test Plan
I checked that these deletions do not impact our primary query/mutation functions, via entering the python shell and:
- For the query:
     `from pprint import pprint`
     `from galley.formatted_queries import *`
     `pprint(get_formatted_recipes_data(['cmVjaXBlOjE4NzI3Mw==']))`

- For the mutation (example pointed at [this menu in Galley](https://staging-app.galleysolutions.com/menus/bWVudTo5NjYwOTQ=))
     `from galley.mutations import *`
     `payload = [{"menu_id": "bWVudTo5NjYwOTQ=", "menu_items": [{"id": "bWVudUl0ZW06MzcxNjE1NDY=", "volume": 20, "unit_name": "each"}]}]`
     `upsert_menu_data(payload)`

## Versioning
Please update the project version in setup.py -> DONE!