### PR TITLE
(ENG-998) adding recipe fields for menu items

### DIFF
--- a/galley/formatted_queries.py
+++ b/galley/formatted_queries.py
@@ -109,6 +109,7 @@ class RecipeItem:
         else:
             return None
 
+
 class FormattedRecipe:
     def __init__(self, recipe_data):
         self.galleyId = recipe_data.get('id')
@@ -328,7 +329,7 @@ def get_formatted_menu_data(dates: List[str],
 
         menu_items = menu.get('menuItems', [])
         for menu_item in menu_items:
-            recipe_items = menu_item.get('recipe', {}).get('recipeItems', [])
+            formatted_recipe = FormattedRecipe(recipe_data=menu_item.get('recipe', {}))
             itemCode = ''
             categoryValues = menu_item['categoryValues']
             for categoryValue in categoryValues:
@@ -341,7 +342,12 @@ def get_formatted_menu_data(dates: List[str],
                 'itemCode': itemCode,
                 'mealSlug': get_meal_slug(menu_item),
                 'recipeId': menu_item.get('recipeId'),
-                'standaloneRecipeId': get_standalone(recipe_items)
+                'recipeName': formatted_recipe.externalName,
+                'recipeMenuPhotoUrl': formatted_recipe.lifestylePhotoUrl,
+                'recipeMealType': formatted_recipe.recipe_tags.get('mealType', ''),
+                'recipeProteinType': formatted_recipe.recipe_tags.get('proteinType', ''),
+                'standaloneRecipeId': get_standalone(formatted_recipe.recipe_items),
+                'baseMeal': formatted_recipe.recipe_tags.get('baseMeal', ''),
             })
 
         formatted_menus.append(formatted_menu)

--- a/galley/types.py
+++ b/galley/types.py
@@ -146,6 +146,12 @@ class RecipeTreeComponent(Type):
     recipeItem = Field(RecipeItem)
 
 
+class RecipeMedia(Type):
+    altText = str
+    caption = str
+    sourceUrl = str
+
+
 class Recipe(Type):
     id = str
     name = str
@@ -157,12 +163,7 @@ class Recipe(Type):
     reconciledNutritionals = Field(Nutrition)
     categoryValues = Field(CategoryValue)
     recipeItems = Field(RecipeItem)
-
-
-class RecipeMedia(Type):
-    altText = str
-    caption = str
-    sourceUrl = str
+    media = Field(RecipeMedia)
 
 
 class RecipeNode(Node):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # are dependencies that are required on remote installs, not local development.
 setup(
     name='galley_sdk',
-    version='0.23.1',
+    version='0.24.0',
     packages=['galley'],
     install_requires=['sgqlc==14.0', 'backoff==1.11.1']
 )

--- a/tests/mock_responses/mock_menu_data.py
+++ b/tests/mock_responses/mock_menu_data.py
@@ -32,6 +32,51 @@ def mock_menu(date, location_name="Vacaville", menu_type="production"):
                 }],
                 'recipe': {
                     'externalName': 'Test Recipe Name 1',
+                    'categoryValues': [
+                        {'category': {
+                            'id': RecipeCategoryTagTypeEnum.PROTEIN_ADDON_TAG.value,
+                            'itemType': 'recipe',
+                            'name': 'protein addon'
+                        },
+                         'id': 'Y2F0ZWdvcnlWYWx1ZToxNjIxMA==',
+                         'name': 'chipotle pulled pork'
+                        },
+                        {'category': {
+                            'id': RecipeCategoryTagTypeEnum.BASE_MEAL_TAG.value,
+                            'itemType': 'recipe',
+                            'name': 'base meal'
+                        },
+                         'id': 'Y2F0ZWdvcnlWYWx1ZToxNjYzMQ==',
+                         'name': ''},
+                        {'category': {
+                            'id': RecipeCategoryTagTypeEnum.BASE_MEAL_SLUG_TAG.value,
+                            'itemType': 'recipe',
+                            'name': 'base meal slug'
+                        },
+                         'id': 'Y2F0ZWdvcnlWYWx1ZToxNTcwNA==',
+                         'name': 'test-recipe-name-1'},
+                        {'category': {
+                            'id': RecipeCategoryTagTypeEnum.MEAL_CONTAINER_TAG.value,
+                            'itemType': 'recipe',
+                            'name': 'meal container'
+                        },
+                         'id': 'Y2F0ZWdvcnlWYWx1ZToxNTExNg==',
+                         'name': 'ts32'},
+                        {'category': {
+                            'id': RecipeCategoryTagTypeEnum.MEAL_TYPE_TAG.value,
+                            'itemType': 'recipe',
+                            'name': 'meal type'
+                        },
+                         'id': 'Y2F0ZWdvcnlWYWx1ZToxNDYzMQ==',
+                         'name': 'dinner'},
+                        {'category': {
+                            'id': RecipeCategoryTagTypeEnum.PROTEIN_TYPE_TAG.value,
+                            'itemType': 'recipe',
+                            'name': 'protein type'
+                        },
+                         'id': 'Y2F0ZWdvcnlWYWx1ZToxNDQ4OQ==',
+                         'name': 'vegan'}
+                    ],
                     'recipeItems': [{
                         'preparations': [
                             {
@@ -46,16 +91,63 @@ def mock_menu(date, location_name="Vacaville", menu_type="production"):
             {
                 'id': 'MENUITEM2DEF',
                 'recipeId': 'RECIPE2DEF',
-                'categoryValues': [{
-                    'name': 'dv2',
-                    'category': {
-                        'id': MenuItemCategoryEnum.PRODUCT_CODE.value,
-                        'itemType': 'menuItem',
-                        'name': 'product_code'
+                'categoryValues': [
+                    {
+                        'name': 'dv2',
+                        'category': {
+                            'id': MenuItemCategoryEnum.PRODUCT_CODE.value,
+                            'itemType': 'menuItem',
+                            'name': 'product_code'
+                        }
                     }
-                }],
+                ],
                 'recipe': {
                     'externalName': 'Test Recipe Name 2',
+                    'categoryValues': [
+                        {'category': {
+                            'id': RecipeCategoryTagTypeEnum.PROTEIN_ADDON_TAG.value,
+                            'itemType': 'recipe',
+                            'name': 'protein addon'
+                        },
+                            'id': 'Y2F0ZWdvcnlWYWx1ZToxNjIxMA==',
+                            'name': 'chipotle pulled pork'
+                        },
+                        {'category': {
+                            'id': RecipeCategoryTagTypeEnum.BASE_MEAL_TAG.value,
+                            'itemType': 'recipe',
+                            'name': 'base meal'
+                        },
+                            'id': 'Y2F0ZWdvcnlWYWx1ZToxNjYzMQ==',
+                            'name': ''},
+                        {'category': {
+                            'id': RecipeCategoryTagTypeEnum.BASE_MEAL_SLUG_TAG.value,
+                            'itemType': 'recipe',
+                            'name': 'base meal slug'
+                        },
+                            'id': 'Y2F0ZWdvcnlWYWx1ZToxNTcwNA==',
+                            'name': 'test-recipe-name-2'},
+                        {'category': {
+                            'id': RecipeCategoryTagTypeEnum.MEAL_CONTAINER_TAG.value,
+                            'itemType': 'recipe',
+                            'name': 'meal container'
+                        },
+                            'id': 'Y2F0ZWdvcnlWYWx1ZToxNTExNg==',
+                            'name': 'ts32'},
+                        {'category': {
+                            'id': RecipeCategoryTagTypeEnum.MEAL_TYPE_TAG.value,
+                            'itemType': 'recipe',
+                            'name': 'meal type'
+                        },
+                            'id': 'Y2F0ZWdvcnlWYWx1ZToxNDYzMQ==',
+                            'name': 'dinner'},
+                        {'category': {
+                            'id': RecipeCategoryTagTypeEnum.PROTEIN_TYPE_TAG.value,
+                            'itemType': 'recipe',
+                            'name': 'protein type'
+                        },
+                            'id': 'Y2F0ZWdvcnlWYWx1ZToxNDQ4OQ==',
+                            'name': 'vegan'}
+                    ],
                     'recipeItems': [{
                         'preparations': [
                             {
@@ -80,6 +172,51 @@ def mock_menu(date, location_name="Vacaville", menu_type="production"):
                 }],
                 'recipe': {
                     'externalName': 'Test Recipe Name 3',
+                    'categoryValues': [
+                        {'category': {
+                            'id': RecipeCategoryTagTypeEnum.PROTEIN_ADDON_TAG.value,
+                            'itemType': 'recipe',
+                            'name': 'protein addon'
+                        },
+                            'id': 'Y2F0ZWdvcnlWYWx1ZToxNjIxMA==',
+                            'name': 'chipotle pulled pork'
+                        },
+                        {'category': {
+                            'id': RecipeCategoryTagTypeEnum.BASE_MEAL_TAG.value,
+                            'itemType': 'recipe',
+                            'name': 'base meal'
+                        },
+                            'id': 'Y2F0ZWdvcnlWYWx1ZToxNjYzMQ==',
+                            'name': ''},
+                        {'category': {
+                            'id': RecipeCategoryTagTypeEnum.BASE_MEAL_SLUG_TAG.value,
+                            'itemType': 'recipe',
+                            'name': 'base meal slug'
+                        },
+                            'id': 'uniqueCatvalueId',
+                            'name': 'test-recipe-name-3'},
+                        {'category': {
+                            'id': RecipeCategoryTagTypeEnum.MEAL_CONTAINER_TAG.value,
+                            'itemType': 'recipe',
+                            'name': 'meal container'
+                        },
+                            'id': 'Y2F0ZWdvcnlWYWx1ZToxNTExNg==',
+                            'name': 'ts32'},
+                        {'category': {
+                            'id': RecipeCategoryTagTypeEnum.MEAL_TYPE_TAG.value,
+                            'itemType': 'recipe',
+                            'name': 'meal type'
+                        },
+                            'id': 'Y2F0ZWdvcnlWYWx1ZToxNDYzMQ==',
+                            'name': 'lunch'},
+                        {'category': {
+                            'id': RecipeCategoryTagTypeEnum.PROTEIN_TYPE_TAG.value,
+                            'itemType': 'recipe',
+                            'name': 'protein type'
+                        },
+                            'id': 'Y2F0ZWdvcnlWYWx1ZToxNDQ4OQ==',
+                            'name': 'meat'}
+                    ],
                     'recipeItems': [{
                         'preparations': [
                             {
@@ -92,15 +229,6 @@ def mock_menu(date, location_name="Vacaville", menu_type="production"):
                         ],
                         'subRecipeId': 'SUBRECIPEID321'
                     }],
-                    'categoryValues': [{
-                        'id': 'uniqueCatvalueId',
-                        'name': 'test-recipe-name-3',
-                        'category': {
-                            'id': RecipeCategoryTagTypeEnum.BASE_MEAL_SLUG_TAG.value,
-                            'name': 'base meal slug',
-                            'itemType': 'recipe'
-                        }
-                    }]
                 },
             }
         ]

--- a/tests/test_formatted_queries.py
+++ b/tests/test_formatted_queries.py
@@ -131,7 +131,6 @@ class TestFormattedRecipeTreeComponents(TestCase):
         self.assertEqual(result['weight'], 0)
 
     def test_format_recipe_tree_components_data_with_more_than_one_serving_of_standalone_component(self):
-        self.maxDiff = None
         result = format_recipe_tree_components_data(
             mock_recipe_tree_components.mock_recipe_tree_components_data_with_multiple_servings_of_standalone)
         expected = {
@@ -217,7 +216,6 @@ class TestFormattedRecipeTreeComponents(TestCase):
         self.assertEqual(result, expected)
 
     def test_format_recipe_tree_components_data_with_one_serving_of_standalone_component(self):
-        self.maxDiff = None
         result = format_recipe_tree_components_data(
             mock_recipe_tree_components.mock_recipe_tree_components_data_with_one_serving_of_standalone)
         expected = {
@@ -303,7 +301,6 @@ class TestFormattedRecipeTreeComponents(TestCase):
         self.assertEqual(result, expected)
 
     def test_format_recipe_tree_components_data_with_standalone_missing_nutritionals_quantity_data(self):
-        self.maxDiff = None
         result = format_recipe_tree_components_data(
             mock_recipe_tree_components.mock_recipe_tree_components_data_with_standalone_missing_nutritionals_quantity_data)
         expected = {
@@ -392,7 +389,6 @@ class TestGetFormattedRecipesData(TestCase):
 
     @mock.patch('galley.queries.make_request_to_galley')
     def test_get_formatted_recipes_data_successful(self, mock_retrieval_method):
-        self.maxDiff = None
         expected_result = [
             {
                 'id': '1',
@@ -496,7 +492,6 @@ class TestGetFormattedRecipesData(TestCase):
 
     @mock.patch('galley.queries.make_request_to_galley')
     def test_get_formatted_recipes_data_with_standalone(self, mock_retrieval_method):
-        self.maxDiff = None
         mock_retrieval_method.return_value = {
             'data': {
                 'viewer': {
@@ -528,7 +523,6 @@ class TestGetFormattedMenuData(TestCase):
 
     @mock.patch('galley.queries.make_request_to_galley')
     def test_get_formatted_menu_data_successful(self, mock_retrieval_method):
-        self.maxDiff = None
         mock_retrieval_method.side_effect = [
             self.response(mock_menu('2021-11-14')),
             self.response(mock_menu('2021-11-21'), mock_menu('2021-11-21'),

--- a/tests/test_formatted_queries.py
+++ b/tests/test_formatted_queries.py
@@ -13,6 +13,50 @@ from tests.mock_responses import (mock_nutrition_data, mock_recipe_items,
 from tests.mock_responses.mock_menu_data import mock_menu
 
 
+def formatted_menu(date):
+    return ({
+        'name': f"{date} 1_2_3",
+        'id': 'MENU123ABC',
+        'date': f"{date}",
+        'location': 'Vacaville',
+        'categoryMenuType': 'production',
+        'menuItems': [{
+            'baseMeal': '',
+            'id': 'MENUITEM1ABC',
+            'itemCode': 'dv1',
+            'mealSlug': 'test-recipe-name-1',
+            'recipeId': 'RECIPE1ABC',
+            'recipeMealType': 'dinner',
+            'recipeMenuPhotoUrl': None,
+            'recipeName': 'Test Recipe Name 1',
+            'recipeProteinType': 'vegan',
+            'standaloneRecipeId': 'SUBRECIPEID456'
+        }, {
+            'baseMeal': '',
+            'id': 'MENUITEM2DEF',
+            'itemCode': 'dv2',
+            'mealSlug': 'test-recipe-name-2',
+            'recipeId': 'RECIPE2DEF',
+            'recipeMealType': 'dinner',
+            'recipeMenuPhotoUrl': None,
+            'recipeName': 'Test Recipe Name 2',
+            'recipeProteinType': 'vegan',
+            'standaloneRecipeId': None
+        }, {
+            'baseMeal': '',
+            'id': 'MENUITEM3GHI',
+            'itemCode': 'lm2',
+            'mealSlug': 'test-recipe-name-3',
+            'recipeId': 'RECIPE3GHI',
+            'recipeMealType': 'lunch',
+            'recipeMenuPhotoUrl': None,
+            'recipeName': 'Test Recipe Name 3',
+            'recipeProteinType': 'meat',
+            'standaloneRecipeId': 'SUBRECIPEID321'
+        }]
+    })
+
+
 class TestIngredientsFromRecipeItems(TestCase):
     def test_ingredients_from_recipes_successful(self):
         expected_result = [
@@ -482,36 +526,9 @@ class TestGetFormattedMenuData(TestCase):
             }
         })
 
-    def formatted_menu(self, date):
-        return ({
-            'name': f"{date} 1_2_3",
-            'id': 'MENU123ABC',
-            'date': f"{date}",
-            'location': 'Vacaville',
-            'categoryMenuType': 'production',
-            'menuItems': [{
-                'id': 'MENUITEM1ABC',
-                'itemCode': 'dv1',
-                'mealSlug': None,
-                'recipeId': 'RECIPE1ABC',
-                'standaloneRecipeId': 'SUBRECIPEID456'
-            }, {
-                'id': 'MENUITEM2DEF',
-                'itemCode': 'dv2',
-                'mealSlug': None,
-                'recipeId': 'RECIPE2DEF',
-                'standaloneRecipeId': None
-            }, {
-                'id': 'MENUITEM3GHI',
-                'itemCode': 'lm2',
-                'mealSlug': 'test-recipe-name-3',
-                'recipeId': 'RECIPE3GHI',
-                'standaloneRecipeId': 'SUBRECIPEID321'
-            }]
-        })
-
     @mock.patch('galley.queries.make_request_to_galley')
     def test_get_formatted_menu_data_successful(self, mock_retrieval_method):
+        self.maxDiff = None
         mock_retrieval_method.side_effect = [
             self.response(mock_menu('2021-11-14')),
             self.response(mock_menu('2021-11-21'), mock_menu('2021-11-21'),
@@ -522,18 +539,18 @@ class TestGetFormattedMenuData(TestCase):
 
         # one valid menu name
         result1 = get_formatted_menu_data(['2021-11-14'])
-        self.assertEqual(result1, [self.formatted_menu('2021-11-14')])
+        self.assertEqual(result1, [formatted_menu('2021-11-14')])
 
         # multiple valid menu names
         result2 = get_formatted_menu_data(['2021-11-21', '2021-11-21',
                                            '2021-11-28'])
-        self.assertEqual(result2, [self.formatted_menu('2021-11-21'),
-                                   self.formatted_menu('2021-11-21'),
-                                   self.formatted_menu('2021-11-28')])
+        self.assertEqual(result2, [formatted_menu('2021-11-21'),
+                                   formatted_menu('2021-11-21'),
+                                   formatted_menu('2021-11-28')])
 
         # one valid menu name and one invalid menu name
         result3 = get_formatted_menu_data(['2021-11-28', '2021-12-05'])
-        self.assertEqual(result3, [self.formatted_menu('2021-11-28')])
+        self.assertEqual(result3, [formatted_menu('2021-11-28')])
 
         # one invalid menu name
         result4 = get_formatted_menu_data(['2021-12-05'])

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -494,7 +494,6 @@ class TestRecipeConnectionQuery(TestCase):
             }'''.replace(' '*12, '')
 
     def test_recipe_connection_query(self):
-        self.maxDiff = None;
         query = recipe_connection_query(
             recipe_ids=["cmVjaXBlOjE2NzEwOQ==", "cmVjaXBlOjE2OTEyMg==", "cmVjaXBlOjE2NTY5MA=="],
             page_size=2,

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -89,6 +89,11 @@ class TestQueryWeekMenuData(TestCase):
             itemType
             }
             }
+            media{
+            altText
+            caption
+            sourceUrl
+            }
             }
             }
             }


### PR DESCRIPTION
## Description
adding new fields for formatted menu items:

recipeName
recipeMenuPhotoUrl
recipeMealType
recipeProteinType
baseMeal


## Test Plan
in shell, use the following to look for presence of new fields
```
>>> from galley.formatted_queries import get_formatted_menu_data
>>> import pprint
>>> pp = pprint.PrettyPrinter()
>>> pp.pprint(get_formatted_menu_data(['2022-01-31']))
```
## Versioning
Please update the project version in setup.py
