### PR TITLE
(ENG-998) add name to menu item recipe

### DIFF
--- a/galley/queries.py
+++ b/galley/queries.py
@@ -151,7 +151,7 @@ def get_menu_query(dates: List[str]) -> Operation:
         'id', 'name', 'date', 'location', 'categoryValues', 'menuItems'
     )
     query.viewer.menus.menuItems.__fields__('id', 'recipeId', 'categoryValues', 'recipe')
-    query.viewer.menus.menuItems.recipe.__fields__('externalName', 'recipeItems', 'categoryValues', 'media')
+    query.viewer.menus.menuItems.recipe.__fields__('externalName', 'name', 'recipeItems', 'categoryValues', 'media')
     query.viewer.menus.menuItems.recipe.media.__fields__('altText', 'caption', 'sourceUrl')
     query.viewer.menus.menuItems.recipe.recipeItems.__fields__('subRecipeId', 'preparations')
     query.viewer.menus.menuItems.recipe.recipeItems.preparations.__fields__('id', 'name')

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # are dependencies that are required on remote installs, not local development.
 setup(
     name='galley_sdk',
-    version='0.25.0',
+    version='0.25.1',
     packages=['galley'],
     install_requires=['sgqlc==14.0', 'backoff==1.11.1']
 )

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -73,6 +73,7 @@ class TestQueryWeekMenuData(TestCase):
             }
             recipe {
             externalName
+            name
             recipeItems {
             subRecipeId
             preparations {


### PR DESCRIPTION
## Description
in 0.24.0, we pulled only `externalName` for menu item recipes, but many recipes have only a `name`, so adding that to the query

## Test Plan
Compared to `main`, reviewer can see in shell that this adds `recipeName` value for many menu items with this command
```
>>> from galley.formatted_queries import get_formatted_menu_data
>>> import pprint
>>> pp = pprint.PrettyPrinter()
>>> pp.pprint(get_formatted_menu_data(['2022-01-31']))

## Versioning
Please update the project version in setup.py
