### PR TITLE
(ENG-1077) handle non-sellable menu items

### DIFF
--- a/galley/queries.py
+++ b/galley/queries.py
@@ -151,7 +151,7 @@ def get_menu_query(dates: List[str]) -> Operation:
         'id', 'name', 'date', 'location', 'categoryValues', 'menuItems'
     )
     query.viewer.menus.menuItems.__fields__('id', 'recipeId', 'categoryValues', 'recipe')
-    query.viewer.menus.menuItems.recipe.__fields__('externalName', 'name', 'recipeItems', 'categoryValues', 'media')
+    query.viewer.menus.menuItems.recipe.__fields__('externalName', 'name', 'recipeItems', 'categoryValues', 'media', 'isDish')
     query.viewer.menus.menuItems.recipe.media.__fields__('altText', 'caption', 'sourceUrl')
     query.viewer.menus.menuItems.recipe.recipeItems.__fields__('subRecipeId', 'preparations')
     query.viewer.menus.menuItems.recipe.recipeItems.preparations.__fields__('id', 'name')

--- a/galley/types.py
+++ b/galley/types.py
@@ -164,6 +164,7 @@ class Recipe(Type):
     categoryValues = Field(CategoryValue)
     recipeItems = Field(RecipeItem)
     media = Field(RecipeMedia)
+    isDish = bool
 
 
 class DietaryFlag(Type):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # are dependencies that are required on remote installs, not local development.
 setup(
     name='galley_sdk',
-    version='0.25.1',
+    version='0.26.0',
     packages=['galley'],
     install_requires=['sgqlc==14.0', 'backoff==1.11.1']
 )

--- a/tests/mock_responses/mock_menu_data.py
+++ b/tests/mock_responses/mock_menu_data.py
@@ -77,6 +77,7 @@ def mock_menu(date, location_name="Vacaville", menu_type="production"):
                          'id': 'Y2F0ZWdvcnlWYWx1ZToxNDQ4OQ==',
                          'name': 'vegan'}
                     ],
+                    'isDish': True,
                     'recipeItems': [{
                         'preparations': [
                             {
@@ -148,6 +149,7 @@ def mock_menu(date, location_name="Vacaville", menu_type="production"):
                             'id': 'Y2F0ZWdvcnlWYWx1ZToxNDQ4OQ==',
                             'name': 'vegan'}
                     ],
+                    'isDish': True,
                     'recipeItems': [{
                         'preparations': [
                             {
@@ -217,6 +219,7 @@ def mock_menu(date, location_name="Vacaville", menu_type="production"):
                             'id': 'Y2F0ZWdvcnlWYWx1ZToxNDQ4OQ==',
                             'name': 'meat'}
                     ],
+                    'isDish': True,
                     'recipeItems': [{
                         'preparations': [
                             {
@@ -228,6 +231,27 @@ def mock_menu(date, location_name="Vacaville", menu_type="production"):
                             }
                         ],
                         'subRecipeId': 'SUBRECIPEID321'
+                    }],
+                },
+            },
+            {
+                'id': 'MENUITEM4JKL',
+                'recipeId': 'RECIPE4JKL',
+                'categoryValues': [{
+                    'name': 'non-sellable soup',
+                    'category': {
+                        'id': MenuItemCategoryEnum.PRODUCT_CODE.value,
+                        'itemType': 'menuItem',
+                        'name': 'product_code'
+                    }
+                }],
+                'recipe': {
+                    'externalName': 'Test Recipe Name 4',
+                    'categoryValues': [],
+                    'isDish': False,
+                    'recipeItems': [{
+                        'preparations': [],
+                        'subRecipeId': None
                     }],
                 },
             }

--- a/tests/mock_responses/mock_recipes_data.py
+++ b/tests/mock_responses/mock_recipes_data.py
@@ -90,6 +90,7 @@ def mock_recipe_base(id):
                 'storageKey': f'Thistle/Media/1uTFWcWhTIGBpybJ1axc_lifestyle{id}.jpg'
             },
         ],
+        'isDish': True,
         'recipeItems': mock_recipe_items.mock_data,
         'reconciledNutritionals': mock_nutrition_data.mock_data,
         'dietaryFlagsWithUsages': []

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -95,6 +95,7 @@ class TestQueryWeekMenuData(TestCase):
             caption
             sourceUrl
             }
+            isDish
             }
             }
             }


### PR DESCRIPTION
## Description
This adds support for filtering non-sellable menu items from the menu data retrieved from Galley. An optional parameter, onlySellableMenuItems, is added to get_formatted_menu_data() so that callers can exclude non-sellable menu items from the returned menus, if desired. Tests and mock data are updated accordingly.

## Test Plan
To test, open the python shell and pull a menu that has at least one non-sellable item on it (I used the [2022-03-07 1_2_3](https://staging-app.galleysolutions.com/menus/bWVudToxNDU1MzI1) menu for testing, which currently has one non-sellable item). Compare the menu_items returned when the new optional parameter is not set vs set, you should see the non-sellable menu item(s) be filtered out as expected.

For example:
`from galley.formatted_queries import *`
`menu = get_formatted_menu_data(['2022-03-07'])`
`len(menu[0]['menuItems'])` -> 44
`menu = get_formatted_menu_data(['2022-03-07'], onlySellableMenuItems=True)`
`len(menu[0]['menuItems'])` -> 43

## Versioning
Please update the project version in setup.py -> DONE
