### PR TITLE
(ENG-873) retrieve highlight tags from Galley

### DIFF
--- a/galley/enums.py
+++ b/galley/enums.py
@@ -48,6 +48,8 @@ class RecipeCategoryTagTypeEnum(Enum):
     PROTEIN_ADDON_TAG = 'Y2F0ZWdvcnk6MjU4MQ=='
     BASE_MEAL_SLUG_TAG = 'Y2F0ZWdvcnk6MjYyMA=='
     BASE_MEAL_TAG = 'Y2F0ZWdvcnk6MjU4OQ=='
+    HIGHLIGHT_ONE_TAG = 'Y2F0ZWdvcnk6MjU3OA=='
+    HIGHLIGHT_TWO_TAG = 'Y2F0ZWdvcnk6MzA0OQ=='
 
 class RecipeMediaEnum(Enum):
     """

--- a/galley/formatted_queries.py
+++ b/galley/formatted_queries.py
@@ -217,6 +217,8 @@ def get_recipe_category_tags(
         RecipeCategoryTagTypeEnum.PROTEIN_ADDON_TAG.value: 'proteinAddOn',
         RecipeCategoryTagTypeEnum.BASE_MEAL_SLUG_TAG.value: 'baseMealSlug',
         RecipeCategoryTagTypeEnum.BASE_MEAL_TAG.value: 'baseMeal',
+        RecipeCategoryTagTypeEnum.HIGHLIGHT_ONE_TAG.value: 'highlightOne',
+        RecipeCategoryTagTypeEnum.HIGHLIGHT_TWO_TAG.value: 'highlightTwo',
     }
 
     for recipe_category_value in recipe_category_values:
@@ -226,7 +228,23 @@ def get_recipe_category_tags(
 
         if label and recipe_category_value_name:
             recipe_tags.setdefault(label, recipe_category_value_name)
-    return recipe_tags
+
+    return format_highlight_tags(recipe_tags)
+
+def format_highlight_tags(
+    recipe_tags: Dict
+) -> Optional[Dict]:
+    highlight_tag_values = []
+    new_recipe_tags = dict(recipe_tags)
+
+    for key, value in new_recipe_tags.items():
+        if key in ('highlightOne', 'highlightTwo'):
+            highlight_tag_values.append(value)
+
+    new_recipe_tags.pop('highlightOne', None)
+    new_recipe_tags.pop('highlightTwo', None)
+    new_recipe_tags.setdefault('highlightTags', highlight_tag_values)
+    return new_recipe_tags
 
 
 def format_recipe_tree_components_data(

--- a/galley/formatted_queries.py
+++ b/galley/formatted_queries.py
@@ -208,7 +208,7 @@ def get_recipe_allergens(recipe_dietry_flags: List[Dict]) -> Dict:
 
 def get_recipe_category_tags(
     recipe_category_values: List[Dict]
-) -> Optional[Dict]:
+) -> Dict:
     recipe_tags: Dict = {}
     recipe_tag_labels: Dict = {
         RecipeCategoryTagTypeEnum.PROTEIN_TYPE_TAG.value: 'proteinType',
@@ -229,22 +229,23 @@ def get_recipe_category_tags(
         if label and recipe_category_value_name:
             recipe_tags.setdefault(label, recipe_category_value_name)
 
-    return format_highlight_tags(recipe_tags)
+    recipe_tags = format_highlight_tags(recipe_tags)
+    return recipe_tags
+
 
 def format_highlight_tags(
     recipe_tags: Dict
-) -> Optional[Dict]:
+) -> Dict:
     highlight_tag_values = []
-    new_recipe_tags = dict(recipe_tags)
 
-    for key, value in new_recipe_tags.items():
+    for key, value in recipe_tags.items():
         if key in ('highlightOne', 'highlightTwo'):
             highlight_tag_values.append(value)
 
-    new_recipe_tags.pop('highlightOne', None)
-    new_recipe_tags.pop('highlightTwo', None)
-    new_recipe_tags.setdefault('highlightTags', highlight_tag_values)
-    return new_recipe_tags
+    recipe_tags.pop('highlightOne', None)
+    recipe_tags.pop('highlightTwo', None)
+    recipe_tags.setdefault('highlightTags', highlight_tag_values)
+    return recipe_tags
 
 
 def format_recipe_tree_components_data(

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # are dependencies that are required on remote installs, not local development.
 setup(
     name='galley_sdk',
-    version='0.28.0',
+    version='0.29.0',
     packages=['galley'],
     install_requires=['sgqlc==14.0', 'backoff==1.11.1']
 )

--- a/tests/mock_responses/mock_recipe_category_values.py
+++ b/tests/mock_responses/mock_recipe_category_values.py
@@ -1,0 +1,77 @@
+from galley.enums import RecipeCategoryTagTypeEnum
+
+
+mock_data_all_categories = [
+    {
+        'name': 'vegan',
+        'category': {
+            'id': RecipeCategoryTagTypeEnum.PROTEIN_TYPE_TAG.value,
+            'itemType': 'recipe',
+            'name': 'protein type'
+        }
+    },
+    {
+        'name': 'ts48',
+        'category': {
+            'id': RecipeCategoryTagTypeEnum.MEAL_CONTAINER_TAG.value,
+            'itemType': 'recipe',
+            'name': 'meal container'
+        }
+    },
+    {
+        'name': 'dinner',
+        'category': {
+            'id': RecipeCategoryTagTypeEnum.MEAL_TYPE_TAG.value,
+            'itemType': 'recipe',
+            'name': 'meal type'
+        }
+    },
+    {
+        'name': 'true',
+        'category': {
+            'id': "",
+            'itemType': 'recipe',
+            'name': 'is perishable'
+        }
+    },
+    {
+        'name': 'high-protein-legume',
+        'category': {
+            'id': RecipeCategoryTagTypeEnum.PROTEIN_ADDON_TAG.value,
+            'itemType': 'recipe',
+            'name': 'protein addon'
+        }
+    },
+    {
+        'name': 'base-salad',
+        'category': {
+            'id': RecipeCategoryTagTypeEnum.BASE_MEAL_SLUG_TAG.value,
+            'itemType': 'recipe',
+            'name': 'base meal slug'
+        }
+    },
+    {
+        'name': 'Base Salad Name',
+        'category': {
+            'id': RecipeCategoryTagTypeEnum.BASE_MEAL_TAG.value,
+            'itemType': 'recipe',
+            'name': 'base meal'
+        }
+    },
+    {
+        'name': 'new',
+        'category': {
+            'id': RecipeCategoryTagTypeEnum.HIGHLIGHT_ONE_TAG.value,
+            'itemType': 'recipe',
+            'name': 'highlight_1'
+        }
+    },
+    {
+        'name': 'spicy',
+        'category': {
+            'id': RecipeCategoryTagTypeEnum.HIGHLIGHT_TWO_TAG.value,
+            'itemType': 'recipe',
+            'name': 'highlight_2'
+        }
+    },
+]

--- a/tests/mock_responses/mock_recipes_data.py
+++ b/tests/mock_responses/mock_recipes_data.py
@@ -1,5 +1,8 @@
 from galley.types import PageInfoType
-from tests.mock_responses import mock_nutrition_data, mock_recipe_items, mock_recipe_tree_components
+from tests.mock_responses import (mock_nutrition_data,
+                                  mock_recipe_items,
+                                  mock_recipe_tree_components,
+                                  mock_recipe_category_values)
 from galley.enums import RecipeCategoryTagTypeEnum
 
 
@@ -9,80 +12,7 @@ def mock_recipe_base(id):
         'externalName': f'Test Recipe {id}',
         'notes': f'Some notes about recipe {id}',
         'description': f'Details about recipe {id}',
-        'categoryValues': [
-            {
-                'name': 'vegan',
-                'category': {
-                    'id': RecipeCategoryTagTypeEnum.PROTEIN_TYPE_TAG.value,
-                    'itemType': 'recipe',
-                    'name': 'protein type'
-                }
-            },
-            {
-                'name': 'ts48',
-                'category': {
-                    'id': RecipeCategoryTagTypeEnum.MEAL_CONTAINER_TAG.value,
-                    'itemType': 'recipe',
-                    'name': 'meal container'
-                }
-            },
-            {
-                'name': 'dinner',
-                'category': {
-                    'id': RecipeCategoryTagTypeEnum.MEAL_TYPE_TAG.value,
-                    'itemType': 'recipe',
-                    'name': 'meal type'
-                }
-            },
-            {
-                'name': 'true',
-                'category': {
-                    'id': "",
-                    'itemType': 'recipe',
-                    'name': 'is perishable'
-                }
-            },
-            {
-                'name': 'high-protein-legume',
-                'category': {
-                    'id': RecipeCategoryTagTypeEnum.PROTEIN_ADDON_TAG.value,
-                    'itemType': 'recipe',
-                    'name': 'protein addon'
-                }
-            },
-            {
-                'name': 'base-salad',
-                'category': {
-                    'id': RecipeCategoryTagTypeEnum.BASE_MEAL_SLUG_TAG.value,
-                    'itemType': 'recipe',
-                    'name': 'base meal slug'
-                }
-            },
-            {
-                'name': 'Base Salad Name',
-                'category': {
-                    'id': RecipeCategoryTagTypeEnum.BASE_MEAL_TAG.value,
-                    'itemType': 'recipe',
-                    'name': 'base meal'
-                }
-            },
-            {
-                'name': 'new',
-                'category': {
-                    'id': RecipeCategoryTagTypeEnum.HIGHLIGHT_ONE_TAG.value,
-                    'itemType': 'recipe',
-                    'name': 'highlight_1'
-                }
-            },
-            {
-                'name': 'spicy',
-                'category': {
-                    'id': RecipeCategoryTagTypeEnum.HIGHLIGHT_TWO_TAG.value,
-                    'itemType': 'recipe',
-                    'name': 'highlight_2'
-                }
-            },
-        ],
+        'categoryValues': mock_recipe_category_values.mock_data_all_categories,
         'media': [
             {
                 'altText': 'None.jpg',

--- a/tests/mock_responses/mock_recipes_data.py
+++ b/tests/mock_responses/mock_recipes_data.py
@@ -65,7 +65,23 @@ def mock_recipe_base(id):
                     'itemType': 'recipe',
                     'name': 'base meal'
                 }
-            }
+            },
+            {
+                'name': 'new',
+                'category': {
+                    'id': RecipeCategoryTagTypeEnum.HIGHLIGHT_ONE_TAG.value,
+                    'itemType': 'recipe',
+                    'name': 'highlight_1'
+                }
+            },
+            {
+                'name': 'spicy',
+                'category': {
+                    'id': RecipeCategoryTagTypeEnum.HIGHLIGHT_TWO_TAG.value,
+                    'itemType': 'recipe',
+                    'name': 'highlight_2'
+                }
+            },
         ],
         'media': [
             {

--- a/tests/test_formatted_queries.py
+++ b/tests/test_formatted_queries.py
@@ -428,6 +428,7 @@ class TestGetFormattedRecipesData(TestCase):
                 'proteinAddOn': 'high-protein-legume',
                 'baseMealSlug': 'base-salad',
                 'baseMeal': 'Base Salad Name',
+                'highlightTags': ['new', 'spicy'],
                 'ingredients': [
                     'Unique 1',
                     'Duplicate 1',
@@ -463,6 +464,7 @@ class TestGetFormattedRecipesData(TestCase):
                 'proteinAddOn': 'high-protein-legume',
                 'baseMealSlug': 'base-salad',
                 'baseMeal': 'Base Salad Name',
+                'highlightTags': ['new', 'spicy'],
                 'ingredients': [
                     'Unique 1',
                     'Duplicate 1',
@@ -560,6 +562,7 @@ class TestGetFormattedRecipesData(TestCase):
                 'proteinAddOn': 'high-protein-legume',
                 'baseMealSlug': 'base-salad',
                 'baseMeal': 'Base Salad Name',
+                'highlightTags': ['new', 'spicy'],
                 'ingredients': [
                     'Unique 1',
                     'Duplicate 1',
@@ -621,6 +624,7 @@ class TestGetFormattedRecipesData(TestCase):
                 'proteinAddOn': 'high-protein-legume',
                 'baseMealSlug': 'base-salad',
                 'baseMeal': 'Base Salad Name',
+                'highlightTags': ['new', 'spicy'],
                 'ingredients': [
                     'Unique 1',
                     'Duplicate 1',

--- a/tests/test_formatted_queries.py
+++ b/tests/test_formatted_queries.py
@@ -1,14 +1,18 @@
 from unittest import TestCase, mock
+from galley.enums import RecipeCategoryTagTypeEnum
 
 from galley.formatted_queries import (format_recipe_tree_components_data,
+                                      get_recipe_category_tags,
                                       get_formatted_menu_data,
                                       get_formatted_recipes_data,
                                       ingredients_from_recipe_items,
                                       calculate_servings,
                                       calculate_serving_size_weight)
 
-from tests.mock_responses import (mock_nutrition_data, mock_recipe_items,
+from tests.mock_responses import (mock_nutrition_data,
+                                  mock_recipe_items,
                                   mock_recipe_tree_components,
+                                  mock_recipe_category_values,
                                   mock_recipes_data)
 from tests.mock_responses.mock_menu_data import mock_menu
 
@@ -408,6 +412,58 @@ class TestFormattedRecipeTreeComponents(TestCase):
             'hasStandalone': True
         }
         self.assertEqual(result, expected)
+
+
+class TestGetRecipeCategoryTags(TestCase):
+
+    def test_get_recipe_category_tags_with_all_tags_populated(self):
+        recipe_category_values = mock_recipe_category_values.mock_data_all_categories
+        expected_result = {
+            'proteinType': 'vegan',
+            'mealContainer': 'ts48',
+            'mealType': 'dinner',
+            'proteinAddOn': 'high-protein-legume',
+            'baseMealSlug': 'base-salad',
+            'baseMeal': 'Base Salad Name',
+            'highlightTags': ['new', 'spicy'],
+        }
+
+        result = get_recipe_category_tags(recipe_category_values)
+        self.assertEqual(result, expected_result)
+
+    def test_get_recipe_category_tags_with_no_tags_populated(self):
+        recipe_category_values = []
+        expected_result = {
+            'highlightTags': []
+        }
+
+        result = get_recipe_category_tags(recipe_category_values)
+        self.assertEqual(result, expected_result)
+
+    def test_get_recipe_category_tags_with_just_one_highlight_tag(self):
+        recipe_category_values = mock_recipe_category_values.mock_data_all_categories
+        # mock data contains two highlight tags- remove one of them
+        recipe_category_values.pop(recipe_category_values.index({
+            'name': 'spicy',
+            'category': {
+                'id': RecipeCategoryTagTypeEnum.HIGHLIGHT_TWO_TAG.value,
+                'itemType': 'recipe',
+                'name': 'highlight_2'
+            }
+        }))
+        expected_result = {
+            'proteinType': 'vegan',
+            'mealContainer': 'ts48',
+            'mealType': 'dinner',
+            'proteinAddOn': 'high-protein-legume',
+            'baseMealSlug': 'base-salad',
+            'baseMeal': 'Base Salad Name',
+            'highlightTags': ['new'],
+        }
+
+        result = get_recipe_category_tags(recipe_category_values)
+        self.assertEqual(result, expected_result)
+
 
 class TestGetFormattedRecipesData(TestCase):
 


### PR DESCRIPTION
## Description
This adds a new field, "highlight_tags", to the response provided by get_formatted_recipes_data(). The highlight_tags field is an array of string values representing what has been assigned to the recipe for the highlight_1 and highlight_2 categories. If no highlight tags have been applied to the recipe, the highlight_tags field is expected to be an empty array.

## Test Plan
To manually test that the new "highlight_tags" field is behaving as expected, I updated recipe tags as necessary (as there aren't many tags already applied to recipes) and then went into the python shell and pulled recipe data for those recipes: 
`python`
`from pprint import pprint` (optional)
`from galley.formatted_queries import *`

`pprint(get_formatted_recipes_data(['cmVjaXBlOjE2NzEwOQ==']))` -> [Gado Gado Salad with Tofu](https://staging-app.galleysolutions.com/recipes/cmVjaXBlOjE2NzEwOQ==?userLocationId=bG9jYXRpb246MTkyOA%3D%3D) (2 tags)

`pprint(get_formatted_recipes_data(['cmVjaXBlOjE5MDE2Mw==']))` -> [Cherry Mint Pistachio Salad](https://staging-app.galleysolutions.com/recipes/cmVjaXBlOjE5MDE2Mw==?userLocationId=bG9jYXRpb246MTkyOA%3D%3D) (1 tag)

`pprint(get_formatted_recipes_data(['cmVjaXBlOjE4OTMzMw==']))` -> [Jollof Rice Bowl with Pea Protein Crumbles](https://staging-app.galleysolutions.com/recipes/cmVjaXBlOjE4OTMzMw==?userLocationId=bG9jYXRpb246MTkyOA%3D%3D) (no tags) 

## Versioning
- [x ] Please update the project version in setup.py
