### PR TITLE
(ENG-1204) Pull allergen information into menu ops query

### DIFF
--- a/galley/formatted_queries.py
+++ b/galley/formatted_queries.py
@@ -186,7 +186,9 @@ def get_recipe_allergens(recipe_dietry_flags: List[Dict]) -> Dict:
         DietaryFlagEnum.SMOKED_MEATS.value: 'smoked meats',
         DietaryFlagEnum.BEEF.value: 'beef'
     }
+
     allergens = []
+
     for recipe_dietary_flag in recipe_dietry_flags:
         dietary_flag = recipe_dietary_flag.get('dietaryFlag', None)
         if dietary_flag and 'id' in dietary_flag:
@@ -481,11 +483,11 @@ def get_formatted_ops_menu_data(dates: List[str],
             formatted_recipe = FormattedRecipe(menu_item.get('recipe', {}))
             formatted_menu['menuItems'].append({
                 'id': menu_item.get('id'),
+                'mealCode': get_meal_code(menu_item['categoryValues']),
+                'mealContainer': formatted_recipe.recipe_tags.get('mealContainer', ''),
                 'recipeId': menu_item.get('recipeId'),
                 'recipeName': formatted_recipe.externalName,
                 'recipePhotos': formatted_recipe.files.get('photos', []),
-                'mealCode': get_meal_code(menu_item['categoryValues']),
-                'mealContainer': formatted_recipe.recipe_tags.get('mealContainer', ''),
                 'recipeTreeComponents': formatted_recipe.recipe_tree_components,
                 'totalCount': menu_item.get('volume')
             })

--- a/galley/formatted_queries.py
+++ b/galley/formatted_queries.py
@@ -186,9 +186,7 @@ def get_recipe_allergens(recipe_dietry_flags: List[Dict]) -> Dict:
         DietaryFlagEnum.SMOKED_MEATS.value: 'smoked meats',
         DietaryFlagEnum.BEEF.value: 'beef'
     }
-
     allergens = []
-
     for recipe_dietary_flag in recipe_dietry_flags:
         dietary_flag = recipe_dietary_flag.get('dietaryFlag', None)
         if dietary_flag and 'id' in dietary_flag:

--- a/galley/queries.py
+++ b/galley/queries.py
@@ -154,8 +154,10 @@ def get_ops_menu_query(dates: List[str]) -> Operation:
     query.viewer.menus.menuItems.recipe.recipeTreeComponents.recipeItem.subRecipe.__fields__('id', 'name', 'externalName')
     query.viewer.menus.menuItems.recipe.recipeTreeComponents.recipeItem.subRecipe.recipeTreeComponents(levels=[1]).__fields__('quantityUnitValues')
     query.viewer.menus.menuItems.recipe.recipeTreeComponents.recipeItem.subRecipe.recipeTreeComponents.ingredient.__fields__('id', 'name', 'externalName')
+    query.viewer.menus.menuItems.recipe.recipeTreeComponents.recipeItem.subRecipe.recipeTreeComponents.ingredient.dietaryFlags.__fields__('id', 'name')
     query.viewer.menus.menuItems.recipe.recipeTreeComponents.recipeItem.subRecipe.recipeTreeComponents.recipeItem.preparations.__fields__('id', 'name')
     query.viewer.menus.menuItems.recipe.recipeTreeComponents.recipeItem.subRecipe.recipeTreeComponents.recipeItem.subRecipe.__fields__('id', 'name', 'externalName')
+    query.viewer.menus.menuItems.recipe.recipeTreeComponents.recipeItem.subRecipe.recipeTreeComponents.recipeItem.subRecipe.dietaryFlagsWithUsages.dietaryFlag.__fields__('id', 'name')
     query.viewer.menus.menuItems.recipe.recipeTreeComponents.recipeItem.subRecipe.recipeTreeComponents.recipeItem.subRecipe.recipeInstructions.__fields__('text', 'position')
     return query
 

--- a/galley/queries.py
+++ b/galley/queries.py
@@ -152,6 +152,7 @@ def get_ops_menu_query(dates: List[str]) -> Operation:
     query.viewer.menus.menuItems.recipe.recipeTreeComponents.recipeItem.__fields__('preparations')
     query.viewer.menus.menuItems.recipe.recipeTreeComponents.recipeItem.preparations.__fields__('id', 'name')
     query.viewer.menus.menuItems.recipe.recipeTreeComponents.recipeItem.subRecipe.__fields__('id', 'name', 'externalName')
+    query.viewer.menus.menuItems.recipe.recipeTreeComponents.recipeItem.subRecipe.dietaryFlagsWithUsages.dietaryFlag.__fields__('id', 'name')
     query.viewer.menus.menuItems.recipe.recipeTreeComponents.recipeItem.subRecipe.recipeTreeComponents(levels=[1]).__fields__('quantityUnitValues')
     query.viewer.menus.menuItems.recipe.recipeTreeComponents.recipeItem.subRecipe.recipeTreeComponents.ingredient.__fields__('id', 'name', 'externalName')
     query.viewer.menus.menuItems.recipe.recipeTreeComponents.recipeItem.subRecipe.recipeTreeComponents.ingredient.dietaryFlags.__fields__('id', 'name')

--- a/galley/types.py
+++ b/galley/types.py
@@ -93,6 +93,7 @@ class Ingredient(Type):
     name = str
     externalName = str
     categoryValues = Field(CategoryValue)
+    dietaryFlags = Field('DietaryFlag')
 
 
 class RecipeInstruction(Type):
@@ -127,6 +128,7 @@ class SubRecipe(Type):
     nutritionalsUnit = Field(Unit)
     recipeInstructions = Field(RecipeInstruction)
     recipeTreeComponents = Field(RecipeTreeComponent, args=ArgDict(levels=list_of(Int)))
+    dietaryFlagsWithUsages = Field('DietaryFlagsWithUsages')
 
 
 class RecipeItem(Type):
@@ -154,6 +156,15 @@ class Files(Type):
     photos = Field(EntityMedia)
 
 
+class DietaryFlag(Type):
+    name = str
+    id = str
+
+
+class DietaryFlagsWithUsages(Type):
+    dietaryFlag = Field(DietaryFlag)
+
+
 class Recipe(Type):
     id = str
     name = str
@@ -170,15 +181,7 @@ class Recipe(Type):
     files = Field(Files)
     isDish = bool
     totalYield = float
-
-
-class DietaryFlag(Type):
-    name = str
-    id = str
-
-
-class DietaryFlagsWithUsages(Type):
-    dietaryFlag = Field(DietaryFlag)
+    # dietaryFlagsWithUsages = Field(DietaryFlagsWithUsages)
 
 
 class RecipeNode(Node):

--- a/galley/types.py
+++ b/galley/types.py
@@ -181,7 +181,6 @@ class Recipe(Type):
     files = Field(Files)
     isDish = bool
     totalYield = float
-    # dietaryFlagsWithUsages = Field(DietaryFlagsWithUsages)
 
 
 class RecipeNode(Node):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # are dependencies that are required on remote installs, not local development.
 setup(
     name='galley_sdk',
-    version='0.30.0',
+    version='0.30.1',
     packages=['galley'],
     install_requires=['sgqlc==14.0', 'backoff==1.11.1']
 )

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # are dependencies that are required on remote installs, not local development.
 setup(
     name='galley_sdk',
-    version='0.30.1',
+    version='0.31.1',
     packages=['galley'],
     install_requires=['sgqlc==14.0', 'backoff==1.11.1']
 )

--- a/tests/mock_responses/mock_ops_menu_data.py
+++ b/tests/mock_responses/mock_ops_menu_data.py
@@ -35,6 +35,14 @@ mock_recipeTreeComponents = [
                 'externalName': None,
                 'id': 'cmVjaXBlOjE5MjY1NA==',
                 'name': 'Greek Salad with Crispy Chickpeas BASE',
+                'dietaryFlagsWithUsages': [
+                    {
+                        'dietaryFlag': {
+                            'id': 'ZGlldGFyeUZsYWc6Ng==',
+                            'name': 'soy beans'
+                        }
+                    }
+                ],
                 'recipeTreeComponents': [
                     {
                         'ingredient': None,
@@ -74,6 +82,7 @@ mock_recipeTreeComponents = [
                                 'externalName': None,
                                 'id':'cmVjaXBlOjE4OTcwNA==',
                                 'name': 'Olive Red Pepper & Cucumber Quinoa Pilaf',
+                                'dietaryFlagsWithUsages': [],
                                 'recipeInstructions': [
                                     {
                                         'position': 0,
@@ -117,6 +126,14 @@ mock_recipeTreeComponents = [
                                 'externalName': None,
                                 'id': 'cmVjaXBlOjE3NjQ3Mw==',
                                 'name': 'Tofu Feta',
+                                'dietaryFlagsWithUsages': [
+                                    {
+                                        'dietaryFlag': {
+                                            'id': 'ZGlldGFyeUZsYWc6Ng==',
+                                            'name': 'soy beans'
+                                        }
+                                    }
+                                ],
                                 'recipeInstructions': [
                                     {
                                         'position': 0,
@@ -142,7 +159,8 @@ mock_recipeTreeComponents = [
                         'ingredient': {
                             'externalName': 'Spring Mix Lettuce*',
                             'id': 'aW5ncmVkaWVudDoyNDQ1NjE=',
-                            'name': 'lettuce, spring mix, SEND TO PLATE'
+                            'name': 'lettuce, spring mix, SEND TO PLATE',
+                            'dietaryFlags': []
                         },
                         'quantityUnitValues': [
                             {
@@ -211,7 +229,8 @@ mock_recipeTreeComponents = [
                         'ingredient': {
                             'externalName': 'Crispy Chickpeas (Chickpeas, Sunflower Oil, Sea Salt)',
                             'id': 'aW5ncmVkaWVudDoyNzQ4ODA=',
-                            'name': 'crispy roasted chickpeas, 0.85 oz bag'
+                            'name': 'crispy roasted chickpeas, 0.85 oz bag',
+                            'dietaryFlags': []
                         },
                         'quantityUnitValues': [
                             {
@@ -277,12 +296,14 @@ mock_recipeTreeComponents = [
                 'externalName': None,
                 'id': 'cmVjaXBlOjE3MDU4NA==',
                 'name': 'Smashed Chickpea Salad - COOKED GARBANZOS',
+                'dietaryFlagsWithUsages': [],
                 'recipeTreeComponents': [
                     {
                         'ingredient': {
                             'externalName': 'Sumac',
                             'id': 'aW5ncmVkaWVudDoyNDQ4MzQ=',
-                            'name': 'spice sumac'
+                            'name': 'spice sumac',
+                            'dietaryFlags': []
                         },
                         'quantityUnitValues': [
                             {
@@ -311,7 +332,8 @@ mock_recipeTreeComponents = [
                         'ingredient': {
                             'externalName': 'Black Pepper',
                             'id': 'aW5ncmVkaWVudDoyNDQ3OTM=',
-                            'name': 'spice, black pepper, ground'
+                            'name': 'spice, black pepper, ground',
+                            'dietaryFlags': []
                         },
                         'quantityUnitValues': [
                             {
@@ -406,6 +428,7 @@ mock_recipeTreeComponents = [
                                 'externalName': None,
                                 'id': 'cmVjaXBlOjE3NjQ4MA==',
                                 'name': 'Cooked Garbanzo Beans',
+                                'dietaryFlagsWithUsages': [],
                                 'recipeInstructions': [
                                     {
                                         'position': 0,
@@ -431,7 +454,8 @@ mock_recipeTreeComponents = [
                         'ingredient': {
                             'externalName': 'Extra Virgin Olive Oil',
                             'id': 'aW5ncmVkaWVudDoyNDQ2MzA=',
-                            'name': 'oil, olive'
+                            'name': 'oil, olive',
+                            'dietaryFlags': [],
                         },
                         'quantityUnitValues': [
                             {
@@ -496,7 +520,8 @@ mock_recipeTreeComponents = [
                         'ingredient': {
                             'externalName': 'Lemon Juice',
                             'id': 'aW5ncmVkaWVudDoyNDQ1MzU=',
-                            'name': 'juice, lemon'
+                            'name': 'juice, lemon',
+                            'dietaryFlags': []
                         },
                         'quantityUnitValues': [
                             {
@@ -655,6 +680,7 @@ mock_recipeTreeComponents = [
                 'externalName': 'Red Wine Vinaigrette',
                 'id': 'cmVjaXBlOjIyMzU3MQ==',
                 'name': 'Red Wine Vinaigrette 2oz',
+                'dietaryFlagsWithUsages': [],
                 'recipeTreeComponents': [
                     {
                         'ingredient': None,
@@ -694,6 +720,7 @@ mock_recipeTreeComponents = [
                                 'externalName': None,
                                 'id': 'cmVjaXBlOjE3NDI4OA==',
                                 'name': 'Red Wine Vinaigrette BASE',
+                                'dietaryFlagsWithUsages': [],
                                 'recipeInstructions': [
                                     {
                                         'position': 0,

--- a/tests/test_ops_queries.py
+++ b/tests/test_ops_queries.py
@@ -89,6 +89,10 @@ class TestOpsMenuDataQuery(TestCase):
             id
             name
             externalName
+            dietaryFlags {
+            id
+            name
+            }
             }
             recipeItem {
             preparations {
@@ -99,6 +103,12 @@ class TestOpsMenuDataQuery(TestCase):
             id
             name
             externalName
+            dietaryFlagsWithUsages {
+            dietaryFlag {
+            id
+            name
+            }
+            }
             recipeInstructions {
             text
             position

--- a/tests/test_ops_queries.py
+++ b/tests/test_ops_queries.py
@@ -77,6 +77,12 @@ class TestOpsMenuDataQuery(TestCase):
             id
             name
             externalName
+            dietaryFlagsWithUsages {
+            dietaryFlag {
+            id
+            name
+            }
+            }
             recipeTreeComponents(levels: [1]) {
             quantityUnitValues {
             value


### PR DESCRIPTION
## Description
This PR adds query fields to our existing `get_ops_menu_query` function that allows us to retrieve allergen data at the `subRecipe` layers. 

## Test Plan
```python
(galley-env) python
>>> import galley; from galley.formatted_queries import *; from pprint import pprint; import json
>>> pprint(get_formatted_ops_menu_data(["2022-03-28", "2022-03-31"]))

# perform checks below with a single menu item
>>> menu_items = get_formatted_ops_menu_data(["2022-03-28"])[0]["menuItems"]
>>> menu_item = [m for m in menu_items if m["recipeId"] == "cmVjaXBlOjE5MjY2MQ=="][0]
>>> pprint(menu_item)

# optional for easier readability in the terminal, but b/c this transforms the dict to json, treat null as None
>>> print(json.dumps(menu_item, indent=4))
```

1. Check that `recipe.recipeTreeComponents[i].recipeItem.subRecipe.dietaryFlagsWithUsages` is present (expected value for a subRecipe without allergens is `[]`). If `recipe.recipeTreeComponents[i].recipeItem.subRecipe == None`, skip to the next recipeTreeComponent

2. Check:
a. If `recipe.recipeTreeComponents[i].recipeItem.subRecipe.recipeTreeComponents[i].ingredient` is **not None**, then `ingredient.dietaryFlags` should be present (expected value for an ingredient without allergens is `[]`)
b. If `ingredient` is **None**, look to `recipe.recipeTreeComponents[i].recipeItem.subRecipe.recipeTreeComponents[i].recipeItem` and if `recipeItem` is **not None**, check that `recipeItem.subRecipe.dietaryFlagsWithUsages` is present (expected value for a recipeItem without allergens is `[]`)

## Run Automated Tests
```python
(galley-env) python -m unittest tests/test_*
```

## Versioning
- [x]  Please update the project version in setup.py
