### PR TITLE
Add menuItemId to formatted ops data & update tests

### DIFF
--- a/galley/formatted_ops_queries.py
+++ b/galley/formatted_ops_queries.py
@@ -216,6 +216,7 @@ def get_formatted_ops_menu_data(
         for menu_item in menu_items:
             formatted_recipe = FormattedRecipe(menu_item.get('recipe') or {})
             formatted_menu['menuItems'].append({
+                'menuItemId': menu_item.get('id'),
                 'mealCode': get_meal_code(menu_item.get('categoryValues')),
                 'recipeId': menu_item.get('recipeId'),
                 'recipeName': formatted_recipe.externalName,

--- a/galley/formatted_ops_queries.py
+++ b/galley/formatted_ops_queries.py
@@ -1,5 +1,4 @@
 import logging
-from re import M
 from typing import Dict, List, Optional, Union
 
 from galley.queries import get_raw_menu_data
@@ -223,6 +222,7 @@ def get_formatted_ops_menu_data(
                 'mealContainer': formatted_recipe.recipe_tags.get('mealContainer', ''),
                 'platePhotoUrl': formatted_recipe.plate_photo_url,
                 'totalCount': menu_item.get('volume'),
+                'totalCountUnit': menu_item.get('unit', {}).get('name'),
                 'primaryRecipeComponents': format_ops_menu_rtc_data(formatted_recipe.recipe_tree_components)
             })
         formatted_menus.append(formatted_menu)

--- a/galley/formatted_queries.py
+++ b/galley/formatted_queries.py
@@ -1,5 +1,4 @@
 import logging
-from re import M
 from typing import Dict, List, Optional
 
 from galley.enums import (

--- a/galley/queries.py
+++ b/galley/queries.py
@@ -150,7 +150,7 @@ def get_menu_query(dates: List[str]) -> Operation:
 def get_ops_menu_query(dates: List[str]) -> Operation:
     query = Operation(Query)
     query.viewer.menus(where=MenuFilterInput(date=dates)).__fields__('id', 'name', 'date', 'location', 'categoryValues', 'menuItems')
-    query.viewer.menus.menuItems.__fields__('id', 'recipeId', 'categoryValues', 'recipe', 'volume')
+    query.viewer.menus.menuItems.__fields__('id', 'recipeId', 'categoryValues', 'recipe', 'volume', 'unit')
     query.viewer.menus.menuItems.recipe.files.__fields__('photos')
     query.viewer.menus.menuItems.recipe.__fields__('id', 'name', 'categoryValues')
     query.viewer.menus.menuItems.recipe.files.photos.__fields__('sourceUrl', 'caption')

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # are dependencies that are required on remote installs, not local development.
 setup(
     name='galley_sdk',
-    version='0.32.0',
+    version='0.32.1',
     packages=['galley'],
     install_requires=['sgqlc==14.0', 'backoff==1.11.1']
 )

--- a/tests/mock_responses/mock_ops_menu_data.py
+++ b/tests/mock_responses/mock_ops_menu_data.py
@@ -1507,7 +1507,11 @@ def mock_ops_menu(date, location_name='Vacaville', menu_type='production'):
                         },
                         'recipeTreeComponents': mock_recipeTreeComponents
                     },
-                    'volume': 923
+                    'volume': 923,
+                    'unit': {
+                        'name': 'each',
+                        'id': 'unitIdEach123'
+                    }
                 },
                 {
                     'id': 'MENUITEM2DEF-OPS',
@@ -1550,7 +1554,11 @@ def mock_ops_menu(date, location_name='Vacaville', menu_type='production'):
                         },
                         'recipeTreeComponents': mock_recipeTreeComponents
                     },
-                    'volume': 1228
+                    'volume': 1228,
+                    'unit': {
+                        'name': 'each',
+                        'id': 'unitIdEach123'
+                    }
                 },
                 {
                     'id': 'MENUITEM3GHI-OPS',
@@ -1582,7 +1590,11 @@ def mock_ops_menu(date, location_name='Vacaville', menu_type='production'):
                         'files': {},
                         'recipeTreeComponents': mock_recipeTreeComponents
                     },
-                    'volume': 549
+                    'volume': 549,
+                    'unit': {
+                        'name': 'each',
+                        'id': 'unitIdEach123'
+                    }
                 }
             ]
         }

--- a/tests/test_ops_formatted_queries.py
+++ b/tests/test_ops_formatted_queries.py
@@ -22,6 +22,7 @@ def formatted_ops_menu(date, location_name='Vacaville', menu_type='production'):
         'location': location_name,
         'categoryMenuType': menu_type,
         'menuItems': [{
+            'menuItemId': 'MENUITEM1ABC-OPS',
             'mealCode': 'lm1',
             'recipeId': 'RECIPE1ABC-OPS',
             'recipeName': 'Test Recipe Name 1',
@@ -31,6 +32,7 @@ def formatted_ops_menu(date, location_name='Vacaville', menu_type='production'):
             'primaryRecipeComponents': mock_formatted_primaryRecipeComponents,
 
         }, {
+            'menuItemId': 'MENUITEM2DEF-OPS',
             'mealCode': 'lv2',
             'recipeId': 'RECIPE2DEF-OPS',
             'recipeName': 'Test Recipe Name 2',
@@ -40,6 +42,7 @@ def formatted_ops_menu(date, location_name='Vacaville', menu_type='production'):
             'primaryRecipeComponents': mock_formatted_primaryRecipeComponents,
 
         }, {
+            'menuItemId': 'MENUITEM3GHI-OPS',
             'mealCode': 'dv3',
             'recipeId': 'RECIPE3GHI-OPS',
             'recipeName': 'Test Recipe Name 3',

--- a/tests/test_ops_formatted_queries.py
+++ b/tests/test_ops_formatted_queries.py
@@ -29,6 +29,7 @@ def formatted_ops_menu(date, location_name='Vacaville', menu_type='production'):
             'mealContainer': 'ts48',
             'platePhotoUrl': 'https://cdn.filestackcontent.com/2X5ivrEYQvuEh30DyYot',
             'totalCount': 923,
+            'totalCountUnit': 'each',
             'primaryRecipeComponents': mock_formatted_primaryRecipeComponents,
 
         }, {
@@ -39,6 +40,7 @@ def formatted_ops_menu(date, location_name='Vacaville', menu_type='production'):
             'mealContainer': 'ts32',
             'platePhotoUrl': 'https://cdn.filestackcontent.com/IQM3KcAkRye81xuN5JY4',
             'totalCount': 1228,
+            'totalCountUnit': 'each',
             'primaryRecipeComponents': mock_formatted_primaryRecipeComponents,
 
         }, {
@@ -49,6 +51,7 @@ def formatted_ops_menu(date, location_name='Vacaville', menu_type='production'):
             'mealContainer': 'ts32',
             'platePhotoUrl': None,
             'totalCount': 549,
+            'totalCountUnit': 'each',
             'primaryRecipeComponents': mock_formatted_primaryRecipeComponents,
 
         }]

--- a/tests/test_ops_queries.py
+++ b/tests/test_ops_queries.py
@@ -2,7 +2,6 @@ import logging
 from unittest import TestCase
 from galley.queries import get_ops_menu_query
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -199,6 +198,10 @@ class TestOpsMenuDataQuery(TestCase):
             }
             }
             volume
+            unit {
+            id
+            name
+            }
             }
             }
             }


### PR DESCRIPTION
## Description
Add `menuItemId` field to formatted ops query data & pull in menu item volume unit.

## Test Plan

### Manual Test
```python3
$ python
>>> import galley; from galley.formatted_ops_queries import *; import json
>>> print(json.dumps(get_formatted_ops_menu_data(["2022-03-21", "2022-05-02"]), indent=4))
# CMD + F for the recipeId: "cmVjaXBlOjE4ODk5OQ==" // there should be 2 instances
# confirm their menuItemId is unique
# check for totalCountUnit field
```

## Versioning
- [x] Please update the project version in setup.py
