### PR TITLE
(maint) fix type error in format_bin_weight()

### DIFF
--- a/galley/formatted_ops_queries.py
+++ b/galley/formatted_ops_queries.py
@@ -131,16 +131,18 @@ def format_bin_weight(category_values: List) -> Dict:
     returns 'lb'.
     """
     tags = set([RecipeCTagEnum.BIN_WEIGHT_TAG.value, IngredientCTagEnum.BIN_WEIGHT_TAG.value])
-    weight = {
-        'value': DEFAULT_BIN_WEIGHT_VALUE,
-        'unit': DEFAULT_BIN_WEIGHT_UNIT
-    }
+    value = DEFAULT_BIN_WEIGHT_VALUE
+
     if category_values:
         for cv in category_values:
             if cv.get('category', {}).get('id') in tags:
-                value = float(cv['name'])
-                return weight | {'value': value} # type: ignore
-    return weight
+                value = cv['name']
+                break
+
+    return {
+        'value': float(value),
+        'unit': DEFAULT_BIN_WEIGHT_UNIT
+    }
 
 
 def format_quantity_values(quantity_values: List) -> Optional[List[Dict]]:

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # are dependencies that are required on remote installs, not local development.
 setup(
     name='galley_sdk',
-    version='0.32.1',
+    version='0.32.2',
     packages=['galley'],
     install_requires=['sgqlc==14.0', 'backoff==1.11.1']
 )


### PR DESCRIPTION
## Description
This tweaks the logic within format_bin_weight() to be a bit simpler and resolves a Type Error that was being thrown in local environments. The expected behavior and return values of format_bin_weight() are unchanged and look to be adequately covered by tests, so no test changes are included here.

## Test Plan
To confirm that this has no impact on the overall binWeight behavior, you could go into the python shell and run the `get_formatted_ops_menu_data()` function (which returns a `binWeight` attribute for recipeComponents):

`python`
`from pprint import pprint` (optional)
`from galley.formatted_ops_queries import *`
`pprint(get_formatted_ops_menu_data(["2022-05-09", "2022-05-12"]))`

## Versioning
- [x ] Please update the project version in setup.py
