### PR TITLE
(FRU-67) Edit ops menu query to return menu items for only whitelisted meal codes

### DIFF
--- a/galley/formatted_ops_queries.py
+++ b/galley/formatted_ops_queries.py
@@ -1,5 +1,4 @@
 import logging
-import re
 from typing import Dict, List, Optional, Union
 
 from galley.queries import get_raw_menu_data

--- a/galley/formatted_ops_queries.py
+++ b/galley/formatted_ops_queries.py
@@ -14,12 +14,21 @@ from galley.enums import (
     DietaryFlagEnum,
     IngredientCategoryTagTypeEnum as IngredientCTagEnum,
     IngredientCategoryValueEnum as IngredientCValEnum,
-    RecipeCategoryTagTypeEnum as RecipeCTagEnum,
+    RecipeCategoryTagTypeEnum as RecipeCTagEnum
 )
 
 
 logger = logging.getLogger(__name__)
 
+
+MEAL_CODES = ['s', 'b', 'lv', 'lm', 'dv', 'dm']
+
+BASE_MEALS = {f'{mc}%d' % (n+1) for mc in MEAL_CODES for n in range(6)}
+JAR_SALADS = {'ssa', 'ssb', 'ssc', 'ssd'}
+SIDE_SOUPS = {'scw', 'sp',  'sm',  'sch'}
+ALLERGEN_MEALS = {f'{mc}%s' % 'a' for mc in BASE_MEALS}
+
+MEAL_CODE_WHITELIST = BASE_MEALS | JAR_SALADS | SIDE_SOUPS
 
 DEFAULT_BIN_WEIGHT_VALUE = 60
 DEFAULT_BIN_WEIGHT_UNIT = 'lb'
@@ -215,17 +224,19 @@ def get_formatted_ops_menu_data(
 
         menu_items = menu.get('menuItems') or []
         for menu_item in menu_items:
-            formatted_recipe = FormattedRecipe(menu_item.get('recipe') or {})
-            formatted_menu['menuItems'].append({
-                'menuItemId': menu_item.get('id'),
-                'mealCode': get_meal_code(menu_item.get('categoryValues')),
-                'recipeId': menu_item.get('recipeId'),
-                'recipeName': formatted_recipe.externalName,
-                'mealContainer': formatted_recipe.recipe_tags.get('mealContainer', ''),
-                'platePhotoUrl': formatted_recipe.plate_photo_url,
-                'totalCount': menu_item.get('volume'),
-                'totalCountUnit': menu_item.get('unit', {}).get('name'),
-                'primaryRecipeComponents': format_ops_menu_rtc_data(formatted_recipe.recipe_tree_components)
-            })
+            meal_code = get_meal_code(menu_item.get('categoryValues'))
+            if meal_code.lower() in MEAL_CODE_WHITELIST:
+                formatted_recipe = FormattedRecipe(menu_item.get('recipe') or {})
+                formatted_menu['menuItems'].append({
+                    'menuItemId': menu_item.get('id'),
+                    'mealCode': meal_code,
+                    'recipeId': menu_item.get('recipeId'),
+                    'recipeName': formatted_recipe.externalName,
+                    'mealContainer': formatted_recipe.recipe_tags.get('mealContainer', ''),
+                    'platePhotoUrl': formatted_recipe.plate_photo_url,
+                    'totalCount': menu_item.get('volume'),
+                    'totalCountUnit': menu_item.get('unit', {}).get('name'),
+                    'primaryRecipeComponents': format_ops_menu_rtc_data(formatted_recipe.recipe_tree_components)
+                })
         formatted_menus.append(formatted_menu)
     return formatted_menus

--- a/galley/formatted_ops_queries.py
+++ b/galley/formatted_ops_queries.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from typing import Dict, List, Optional, Union
 
 from galley.queries import get_raw_menu_data
@@ -21,13 +22,10 @@ from galley.enums import (
 logger = logging.getLogger(__name__)
 
 
-MEAL_CODES = ['s', 'b', 'lv', 'lm', 'dv', 'dm']
-
-BASE_MEALS = {f'{mc}%d' % (n+1) for mc in MEAL_CODES for n in range(6)}
+BASE_CODES = ['s', 'b', 'lv', 'lm', 'dv', 'dm']
+BASE_MEALS = {f'{b}{n+1}' for b in BASE_CODES for n in range(6)}
 JAR_SALADS = {'ssa', 'ssb', 'ssc', 'ssd'}
 SIDE_SOUPS = {'scw', 'sp',  'sm',  'sch'}
-ALLERGEN_MEALS = {f'{mc}%s' % 'a' for mc in BASE_MEALS}
-
 MEAL_CODE_WHITELIST = BASE_MEALS | JAR_SALADS | SIDE_SOUPS
 
 DEFAULT_BIN_WEIGHT_VALUE = 60

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # are dependencies that are required on remote installs, not local development.
 setup(
     name='galley_sdk',
-    version='0.34.0',
+    version='0.35.0',
     packages=['galley'],
     install_requires=['sgqlc==14.0', 'backoff==1.11.1']
 )

--- a/tests/mock_responses/mock_ops_menu_data.py
+++ b/tests/mock_responses/mock_ops_menu_data.py
@@ -1595,6 +1595,140 @@ def mock_ops_menu(date, location_name='Vacaville', menu_type='production'):
                         'name': 'each',
                         'id': 'unitIdEach123'
                     }
+                },
+                {
+                    'id': 'MENUITEM4JKL-OPS',
+                    'recipeId': 'RECIPE4JKL-OPS',
+                    'categoryValues': [
+                        {
+                            'name': 'ssa',
+                            'category': {
+                                'id': MenuItemCategoryEnum.PRODUCT_CODE.value,
+                                'itemType': 'menuItem',
+                                'name': 'product_code'
+                            }
+                        }
+                    ],
+                    'recipe': {
+                        'id': 'RECIPE4JKL-OPS',
+                        'name': 'Jar Salad 1',
+                        'categoryValues': [
+                            {
+                                'id': 'Y2F0ZWdvcnlWYWx1ZToxNTExNg==',
+                                'name': 'ts32',
+                                'category': {
+                                    'id': RecipeCategoryTagTypeEnum.MEAL_CONTAINER_TAG.value,
+                                    'name': 'meal container',
+                                    'itemType': 'recipe'
+                                },
+                            }
+                        ],
+                        'files': {},
+                        'recipeTreeComponents': mock_recipeTreeComponents
+                    },
+                    'volume': 123,
+                    'unit': {
+                        'name': 'each',
+                        'id': 'unitIdEach123'
+                    }
+                },
+                {
+                    'id': 'MENUITEM5MNO-OPS',
+                    'recipeId': 'RECIPE5MNO-OPS',
+                    'categoryValues': [
+                        {
+                            'name': 'sch',
+                            'category': {
+                                'id': MenuItemCategoryEnum.PRODUCT_CODE.value,
+                                'itemType': 'menuItem',
+                                'name': 'product_code'
+                            }
+                        }
+                    ],
+                    'recipe': {
+                        'id': 'RECIPE5MNO-OPS',
+                        'name': 'Side Soup 4',
+                        'categoryValues': [
+                            {
+                                'id': 'Y2F0ZWdvcnlWYWx1ZToxNTExNg==',
+                                'name': 'ts32',
+                                'category': {
+                                    'id': RecipeCategoryTagTypeEnum.MEAL_CONTAINER_TAG.value,
+                                    'name': 'meal container',
+                                    'itemType': 'recipe'
+                                },
+                            }
+                        ],
+                        'files': {},
+                        'recipeTreeComponents': mock_recipeTreeComponents
+                    },
+                    'volume': 321,
+                    'unit': {
+                        'name': 'each',
+                        'id': 'unitIdEach123'
+                    }
+                },
+                {
+                    'id': 'MENUITEM6PQR-OPS',
+                    'recipeId': 'RECIPE6PQR-OPS',
+                    'categoryValues': [
+                        {
+                            'name': 'av',
+                            'category': {
+                                'id': MenuItemCategoryEnum.PRODUCT_CODE.value,
+                                'itemType': 'menuItem',
+                                'name': 'product_code'
+                            }
+                        }
+                    ],
+                    'recipe': {
+                        'id': 'RECIPE6PQR-OPS',
+                        'name': 'Baby Avocado',
+                        'categoryValues': [
+                            {
+                                'id': 'Y2F0ZWdvcnlWYWx1ZToxNTExNg==',
+                                'name': 'ts32',
+                                'category': {
+                                    'id': RecipeCategoryTagTypeEnum.MEAL_CONTAINER_TAG.value,
+                                    'name': 'meal container',
+                                    'itemType': 'recipe'
+                                },
+                            }
+                        ],
+                        'files': {},
+                        'recipeTreeComponents': mock_recipeTreeComponents
+                    },
+                    'volume': 456,
+                    'unit': {
+                        'name': 'each',
+                        'id': 'unitIdEach123'
+                    }
+                },
+                {
+                    'id': 'MENUITEM7STU-OPS',
+                    'recipeId': 'RECIPE7STU-OPS',
+                    'categoryValues': [
+                        {
+                            'name': 'hla',
+                            'category': {
+                                'id': MenuItemCategoryEnum.PRODUCT_CODE.value,
+                                'itemType': 'menuItem',
+                                'name': 'product_code'
+                            }
+                        }
+                    ],
+                    'recipe': {
+                        'id': 'RECIPE7STU-OPS',
+                        'name': 'Juice',
+                        'categoryValues': [],
+                        'files': {},
+                        'recipeTreeComponents': mock_recipeTreeComponents
+                    },
+                    'volume': 199,
+                    'unit': {
+                        'name': 'each',
+                        'id': 'unitIdEach123'
+                    }
                 }
             ]
         }


### PR DESCRIPTION
## Description
This PR targets `get_formatted_ops_menu_data()` to only return menu item data for specific meal codes, specifically our base meals, jar salads, and side soups. The whitelisted meal codes are:

BASE MEALS: **S1-6, B1-6, LV1-6, LM1-6, DV1-6, DM1-6**
JAR SALADS: **SSA, SSB, SSC, SSD**
SIDE SOUPS: **SCW, SCH, SP, SM**

## Test Plan
### Manual Test
```python3
(galley-env) python
```
```python3
>>> import galley; from galley.formatted_ops_queries import *

>>> MENUS = get_formatted_ops_menu_data(["2022-06-06", "2022-06-09"])        # full week menu (1_2_3 & 4_5_6)
>>> len(MENUS[0]['menuItems']) + len(MENUS[1]['menuItems'])                  # 52 = 2 * (18 BASE MEALS + 4 JAR SALADS + 4 SIDE SOUPS)
>>> MEAL_CODES = {mi['mealCode'] for m in MENUS for mi in m['menuItems']}    # set of all meal codes returned from MENUS
>>> MEAL_CODES == MEAL_CODE_WHITELIST                                        # True
```

### Run Automated Test
```python3
(galley-env) python -m unittest tests/test_*
```

## Versioning
- [x] Please update the project version in setup.py (v0.34.0 --> v0.35.0)
