### PR TITLE
(VEG-88) adding version to recipe

### DIFF
--- a/galley/formatted_queries.py
+++ b/galley/formatted_queries.py
@@ -156,11 +156,14 @@ class FormattedRecipe:
         self.recipe_tree_components = recipe_data.get('recipeTreeComponents', [])
         self.formatted_recipe_tree_components_data = format_recipe_tree_components_data(self.recipe_tree_components)
         self.allergens = get_recipe_allergens(recipe_dietry_flags=recipe_data.get('dietaryFlagsWithUsages', []))
+        version_edges = recipe_data.get('versionConnection', {}).get('edges', [])
+        self.version_id = version_edges[0].get('node', {}).get('id') if version_edges else None
 
     def to_dict(self):
         return {
             'id': self.galleyId,
             'externalName': self.externalName,
+            'version': self.version_id,
             'notes': self.notes,
             'description': self.description,
             'nutrition': self.nutrition,

--- a/galley/queries.py
+++ b/galley/queries.py
@@ -72,6 +72,8 @@ def recipe_connection_query(
         __fields__('id', 'externalName', 'name', 'notes', 'description', 'media', 'categoryValues', 'reconciledNutritionals')
     query.viewer.recipeConnection.edges.node.media.\
         __fields__('altText', 'caption', 'sourceUrl')
+    query.viewer.recipeConnection.edges.node.versionConnection(paginationOptions=PaginationOptions(orderBy='createdAt', sortDirection="desc", first=1)).edges.node.\
+        __fields__('id')
     query.viewer.recipeConnection.edges.node.recipeItems.\
         __fields__('ingredient')
     query.viewer.recipeConnection.edges.node.recipeItems.subRecipe.\

--- a/galley/types.py
+++ b/galley/types.py
@@ -1,3 +1,4 @@
+from ensurepip import version
 from os import name
 from typing import Any, Dict
 from sgqlc.types import (ID, ArgDict, Enum, Field, Input, Int, Type, datetime
@@ -168,6 +169,27 @@ class DietaryFlagsWithUsages(Type):
     dietaryFlag = Field(DietaryFlag)
 
 
+class PageInfoType(Type):
+    endIndex = int
+    hasNextPage = bool
+    hasPreviousPage = bool
+    startIndex = int
+
+
+class VersionNode(Node):
+    id = Field(ID)
+
+
+class RecipeVersionConnectionEdge(Type):
+    node = Field(VersionNode)
+
+
+class RecipeVersionConnection(Connection):
+    edges = Field(RecipeVersionConnectionEdge)
+    pageInfo = Field(PageInfoType)
+    totalCount = int
+
+
 class Recipe(Type):
     id = str
     name = str
@@ -178,6 +200,7 @@ class Recipe(Type):
     description = str
     recipeTreeComponents = Field(RecipeTreeComponent, args=ArgDict(levels=list_of(Int)))
     reconciledNutritionals = Field(Nutrition)
+    versionConnection = Field(RecipeVersionConnection)
     categoryValues = Field(CategoryValue)
     recipeItems = Field(RecipeItem)
     media = Field(RecipeMedia)
@@ -185,6 +208,18 @@ class Recipe(Type):
     isDish = bool
     totalYield = float
     dietaryFlagsWithUsages = Field(DietaryFlagsWithUsages)
+
+
+class SortDirection(str, Enum):
+    asc = 'asc'
+    desc = 'desc'
+
+
+class PaginationOptions(Input):
+    first = int
+    orderBy = str
+    sortDirection = SortDirection
+    startIndex = int
 
 
 class RecipeNode(Node):
@@ -196,6 +231,7 @@ class RecipeNode(Node):
     description = str
     recipeTreeComponents = Field(RecipeTreeComponent, args=ArgDict(levels=list_of(Int)))
     reconciledNutritionals = Field(Nutrition)
+    versionConnection = Field(RecipeVersionConnection, args=ArgDict({'paginationOptions': PaginationOptions}))
     categoryValues = Field(CategoryValue)
     recipeItems = Field(RecipeItem)
     media = Field(RecipeMedia)
@@ -204,13 +240,6 @@ class RecipeNode(Node):
 
 class RecipeEdge(Type):
     node = Field(RecipeNode)
-
-
-class PageInfoType(Type):
-    endIndex = int
-    hasNextPage = bool
-    hasPreviousPage = bool
-    startIndex = int
 
 
 class RecipeConnection(Connection):
@@ -278,8 +307,3 @@ class MenuFilterInput(Input):
 
 class RecipeConnectionFilter(Input):
     id = list_of(str)
-
-
-class PaginationOptions(Input):
-    first = int
-    startIndex = int

--- a/galley/types.py
+++ b/galley/types.py
@@ -1,6 +1,3 @@
-from ensurepip import version
-from os import name
-from typing import Any, Dict
 from sgqlc.types import (ID, ArgDict, Enum, Field, Input, Int, Type, datetime
                          as d, list_of)
 from sgqlc.types.relay import (Connection, Node)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # are dependencies that are required on remote installs, not local development.
 setup(
     name='galley_sdk',
-    version='0.35.2',
+    version='0.36.0',
     packages=['galley'],
     install_requires=['sgqlc==14.0', 'backoff==1.11.1']
 )

--- a/tests/mock_responses/mock_menu_data.py
+++ b/tests/mock_responses/mock_menu_data.py
@@ -78,6 +78,17 @@ def mock_menu(date, location_name="Vacaville", menu_type="production"):
                          'name': 'vegan'}
                     ],
                     'isDish': True,
+                    "versionConnection": {
+                        "edges": [
+                            {
+                                "node": {
+                                    "id": "dmVyc2lvbjozNjQ0NTY1",
+                                    "versionNumber": 107,
+                                    "action": "update"
+                                }
+                            }
+                        ]
+                    },
                     'media': [
                         {
                             'altText': 'Recipe_1_Plating.jpg',

--- a/tests/mock_responses/mock_ops_menu_data.py
+++ b/tests/mock_responses/mock_ops_menu_data.py
@@ -1171,6 +1171,17 @@ def mock_ops_menu(date, location_name='Vacaville', menu_type='production'):
                     'recipe': {
                         'id': 'RECIPE2DEF-OPS',
                         'name': 'Test Recipe Name 2',
+                        "versionConnection": {
+                            "edges": [
+                                {
+                                    "node": {
+                                        "id": "dmVyc2lvbjozNjQ0NTY1",
+                                        "versionNumber": 107,
+                                        "action": "update"
+                                    }
+                                }
+                            ]
+                        },
                         'categoryValues': [
                             {
                                 'id': 'Y2F0ZWdvcnlWYWx1ZToxNTExNg==',
@@ -1218,6 +1229,17 @@ def mock_ops_menu(date, location_name='Vacaville', menu_type='production'):
                     'recipe': {
                         'id': 'RECIPE3GHI-OPS',
                         'name': 'Test Recipe Name 3',
+                        "versionConnection": {
+                            "edges": [
+                                {
+                                    "node": {
+                                        "id": "dmVyc2lvbjozNjQ0NTY1",
+                                        "versionNumber": 107,
+                                        "action": "update"
+                                    }
+                                }
+                            ]
+                        },
                         'categoryValues': [
                             {
                                 'id': 'Y2F0ZWdvcnlWYWx1ZToxNTExNg==',
@@ -1254,6 +1276,17 @@ def mock_ops_menu(date, location_name='Vacaville', menu_type='production'):
                     'recipe': {
                         'id': 'RECIPE4JKL-OPS',
                         'name': 'Jar Salad 1',
+                        "versionConnection": {
+                            "edges": [
+                                {
+                                    "node": {
+                                        "id": "dmVyc2lvbjozNjQ0NTY1",
+                                        "versionNumber": 107,
+                                        "action": "update"
+                                    }
+                                }
+                            ]
+                        },
                         'categoryValues': [
                             {
                                 'id': 'Y2F0ZWdvcnlWYWx1ZToxNTExNg==',
@@ -1290,6 +1323,17 @@ def mock_ops_menu(date, location_name='Vacaville', menu_type='production'):
                     'recipe': {
                         'id': 'RECIPE5MNO-OPS',
                         'name': 'Side Soup 4',
+                        "versionConnection": {
+                            "edges": [
+                                {
+                                    "node": {
+                                        "id": "dmVyc2lvbjozNjQ0NTY1",
+                                        "versionNumber": 107,
+                                        "action": "update"
+                                    }
+                                }
+                            ]
+                        },
                         'categoryValues': [
                             {
                                 'id': 'Y2F0ZWdvcnlWYWx1ZToxNTExNg==',
@@ -1326,6 +1370,17 @@ def mock_ops_menu(date, location_name='Vacaville', menu_type='production'):
                     'recipe': {
                         'id': 'RECIPE6PQR-OPS',
                         'name': 'Baby Avocado',
+                        "versionConnection": {
+                            "edges": [
+                                {
+                                    "node": {
+                                        "id": "dmVyc2lvbjozNjQ0NTY1",
+                                        "versionNumber": 107,
+                                        "action": "update"
+                                    }
+                                }
+                            ]
+                        },
                         'categoryValues': [
                             {
                                 'id': 'Y2F0ZWdvcnlWYWx1ZToxNTExNg==',
@@ -1362,6 +1417,17 @@ def mock_ops_menu(date, location_name='Vacaville', menu_type='production'):
                     'recipe': {
                         'id': 'RECIPE7STU-OPS',
                         'name': 'Juice',
+                        "versionConnection": {
+                            "edges": [
+                                {
+                                    "node": {
+                                        "id": "dmVyc2lvbjozNjQ0NTY1",
+                                        "versionNumber": 107,
+                                        "action": "update"
+                                    }
+                                }
+                            ]
+                        },
                         'categoryValues': [],
                         'files': {},
                         'recipeTreeComponents': mock_recipeTreeComponents

--- a/tests/mock_responses/mock_ops_menu_data.py
+++ b/tests/mock_responses/mock_ops_menu_data.py
@@ -1171,17 +1171,6 @@ def mock_ops_menu(date, location_name='Vacaville', menu_type='production'):
                     'recipe': {
                         'id': 'RECIPE2DEF-OPS',
                         'name': 'Test Recipe Name 2',
-                        "versionConnection": {
-                            "edges": [
-                                {
-                                    "node": {
-                                        "id": "dmVyc2lvbjozNjQ0NTY1",
-                                        "versionNumber": 107,
-                                        "action": "update"
-                                    }
-                                }
-                            ]
-                        },
                         'categoryValues': [
                             {
                                 'id': 'Y2F0ZWdvcnlWYWx1ZToxNTExNg==',
@@ -1229,17 +1218,6 @@ def mock_ops_menu(date, location_name='Vacaville', menu_type='production'):
                     'recipe': {
                         'id': 'RECIPE3GHI-OPS',
                         'name': 'Test Recipe Name 3',
-                        "versionConnection": {
-                            "edges": [
-                                {
-                                    "node": {
-                                        "id": "dmVyc2lvbjozNjQ0NTY1",
-                                        "versionNumber": 107,
-                                        "action": "update"
-                                    }
-                                }
-                            ]
-                        },
                         'categoryValues': [
                             {
                                 'id': 'Y2F0ZWdvcnlWYWx1ZToxNTExNg==',
@@ -1276,17 +1254,6 @@ def mock_ops_menu(date, location_name='Vacaville', menu_type='production'):
                     'recipe': {
                         'id': 'RECIPE4JKL-OPS',
                         'name': 'Jar Salad 1',
-                        "versionConnection": {
-                            "edges": [
-                                {
-                                    "node": {
-                                        "id": "dmVyc2lvbjozNjQ0NTY1",
-                                        "versionNumber": 107,
-                                        "action": "update"
-                                    }
-                                }
-                            ]
-                        },
                         'categoryValues': [
                             {
                                 'id': 'Y2F0ZWdvcnlWYWx1ZToxNTExNg==',
@@ -1323,17 +1290,6 @@ def mock_ops_menu(date, location_name='Vacaville', menu_type='production'):
                     'recipe': {
                         'id': 'RECIPE5MNO-OPS',
                         'name': 'Side Soup 4',
-                        "versionConnection": {
-                            "edges": [
-                                {
-                                    "node": {
-                                        "id": "dmVyc2lvbjozNjQ0NTY1",
-                                        "versionNumber": 107,
-                                        "action": "update"
-                                    }
-                                }
-                            ]
-                        },
                         'categoryValues': [
                             {
                                 'id': 'Y2F0ZWdvcnlWYWx1ZToxNTExNg==',
@@ -1370,17 +1326,6 @@ def mock_ops_menu(date, location_name='Vacaville', menu_type='production'):
                     'recipe': {
                         'id': 'RECIPE6PQR-OPS',
                         'name': 'Baby Avocado',
-                        "versionConnection": {
-                            "edges": [
-                                {
-                                    "node": {
-                                        "id": "dmVyc2lvbjozNjQ0NTY1",
-                                        "versionNumber": 107,
-                                        "action": "update"
-                                    }
-                                }
-                            ]
-                        },
                         'categoryValues': [
                             {
                                 'id': 'Y2F0ZWdvcnlWYWx1ZToxNTExNg==',
@@ -1417,17 +1362,6 @@ def mock_ops_menu(date, location_name='Vacaville', menu_type='production'):
                     'recipe': {
                         'id': 'RECIPE7STU-OPS',
                         'name': 'Juice',
-                        "versionConnection": {
-                            "edges": [
-                                {
-                                    "node": {
-                                        "id": "dmVyc2lvbjozNjQ0NTY1",
-                                        "versionNumber": 107,
-                                        "action": "update"
-                                    }
-                                }
-                            ]
-                        },
                         'categoryValues': [],
                         'files': {},
                         'recipeTreeComponents': mock_recipeTreeComponents

--- a/tests/mock_responses/mock_recipes_data.py
+++ b/tests/mock_responses/mock_recipes_data.py
@@ -36,6 +36,17 @@ def mock_recipe_base(id):
                 'storageKey': f'Thistle/Media/1uTFWcWhTIGBpybJ1axc_menu{id}.jpg'
             },
         ],
+        "versionConnection": {
+            "edges": [
+                {
+                    "node": {
+                        "id": "dmVyc2lvbjozNjQ0NTY1",
+                        "versionNumber": 107,
+                        "action": "update"
+                    }
+                }
+            ]
+        },
         'isDish': True,
         'recipeItems': mock_recipe_items.mock_data,
         'reconciledNutritionals': mock_nutrition_data.mock_data,

--- a/tests/test_formatted_queries.py
+++ b/tests/test_formatted_queries.py
@@ -509,6 +509,7 @@ class TestGetFormattedRecipesData(TestCase):
             {
                 'id': '1',
                 'externalName': 'Test Recipe 1',
+                'version': 'dmVyc2lvbjozNjQ0NTY1',
                 'notes': 'Some notes about recipe 1',
                 'description': 'Details about recipe 1',
                 'menuPhotoUrl': 'https://cdn.filestackcontent.com/MENU1',
@@ -547,6 +548,7 @@ class TestGetFormattedRecipesData(TestCase):
                 'id': '2',
                 'externalName': 'Test Recipe 2',
                 'notes': 'Some notes about recipe 2',
+                'version': 'dmVyc2lvbjozNjQ0NTY1',
                 'description': 'Details about recipe 2',
                 'menuPhotoUrl': 'https://cdn.filestackcontent.com/MENU2',
                 'nutrition': mock_nutrition_data.mock_data,
@@ -645,6 +647,7 @@ class TestGetFormattedRecipesData(TestCase):
             {
                 'id': '1',
                 'externalName': 'Test Recipe 1',
+                'version': 'dmVyc2lvbjozNjQ0NTY1',
                 'notes': 'Some notes about recipe 1',
                 'description': 'Details about recipe 1',
                 'menuPhotoUrl': 'https://cdn.filestackcontent.com/MENU1',
@@ -708,6 +711,7 @@ class TestGetFormattedRecipesData(TestCase):
             {
                 'id': '1',
                 'externalName': 'Test Recipe 1',
+                'version': 'dmVyc2lvbjozNjQ0NTY1',
                 'notes': 'Some notes about recipe 1',
                 'description': 'Details about recipe 1',
                 'menuPhotoUrl': 'https://cdn.filestackcontent.com/MENU1',

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -299,6 +299,13 @@ class TestRecipeConnectionQuery(TestCase):
             zincMg
             zincPercentRDI
             }
+            versionConnection(paginationOptions: {first: 1, orderBy: "createdAt", sortDirection: desc}) {
+            edges {
+            node {
+            id
+            }
+            }
+            }
             recipeItems {
             ingredient {
             externalName


### PR DESCRIPTION
## Description
adding `version` to response for `get_formatted_recipes_data`
## Test Plan
automated tests and to test manually, since version is not available in staging, 
1. log in to galley staging dashboard
2. select a recipe
3. edit something (easy is the name) to generate a version. (feel free to edit several times if you want to test pagination in query when there are many versions)
4. open shell
5. `>>> from galley.formatted_queries import get_formatted_recipes_data`
6.  confirm `version` is in the output of `>>> get_formatted_recipes_data(['<recipeID_for_recipe_with_versions_you_created'])`

## Versioning
Please update the project version in setup.py
