### PR TITLE
drewdas/fru 158 galley sdk not correctly throwing errors

### DIFF
--- a/galley/common.py
+++ b/galley/common.py
@@ -33,9 +33,9 @@ def can_retry(data: Optional[Dict]) -> bool:
 
 # REQUEST OPERATION FUNCTION TO QUERY / MUTATE GALLEY DATA
 @backoff.on_predicate(lambda: backoff.constant(interval=0.5), predicate=can_retry, max_tries=max_retries + 1)
-def make_request_to_galley(operation: Operation, variables: Optional[Dict] = None) -> Optional[Dict]:
+def make_request_to_galley(op: Operation, variables: Optional[Dict] = None) -> Optional[Dict]:
     endpoint = build_galley_endpoint()
-    return endpoint(operation, {} if variables is None else variables)
+    return endpoint(op, {} if variables is None else variables)
 
 # DATA VALIDATORS
 def validate_response_data(data, *fields):

--- a/galley/common.py
+++ b/galley/common.py
@@ -32,7 +32,6 @@ def can_retry(data: Optional[Dict]) -> bool:
 
 
 # REQUEST OPERATION FUNCTION TO QUERY / MUTATE GALLEY DATA
-
 @backoff.on_predicate(lambda: backoff.constant(interval=0.5), predicate=can_retry, max_tries=max_retries + 1)
 def make_request_to_galley(op: Operation, variables: Optional[Dict] = None) -> Optional[Dict]:
     endpoint = build_galley_endpoint()
@@ -81,18 +80,21 @@ def validate_fields(data, keys):
 
 def validate_response_data_structure(forecasted_data_struct: Any, response_data: Any) -> bool:
     if isinstance(forecasted_data_struct, dict) and isinstance(response_data, dict):
+        # check if all keys in forecasted_data_struct are in response_data
         return all(
             key in response_data and validate_response_data_structure(
                 forecasted_data_struct[key], response_data[key]
             ) for key in forecasted_data_struct
         )
     elif isinstance(forecasted_data_struct, list) and isinstance(response_data, list):
+        # check if all elements in forecasted_data_struct are in response_data
         return all(validate_response_data_structure(forecasted_data_struct[0], rds) for rds in response_data)
     elif isinstance(forecasted_data_struct, type):
+        # check if response_data is of type forecasted_data_struct
         return isinstance(response_data, forecasted_data_struct)
     elif forecasted_data_struct == Any:
         # If the value has return type Any we should assume this field could have any type of value.
         # These values are hard to do data validation.
         return True
-    else:
-        return False
+
+    return False

--- a/galley/common.py
+++ b/galley/common.py
@@ -33,9 +33,9 @@ def can_retry(data: Optional[Dict]) -> bool:
 
 # REQUEST OPERATION FUNCTION TO QUERY / MUTATE GALLEY DATA
 @backoff.on_predicate(lambda: backoff.constant(interval=0.5), predicate=can_retry, max_tries=max_retries + 1)
-def make_request_to_galley(op: Operation, variables: Optional[Dict] = None) -> Optional[Dict]:
+def make_request_to_galley(operation: Operation, variables: Optional[Dict] = None) -> Optional[Dict]:
     endpoint = build_galley_endpoint()
-    return endpoint(op, {} if variables is None else variables)
+    return endpoint(operation, {} if variables is None else variables)
 
 # DATA VALIDATORS
 def validate_response_data(data, *fields):

--- a/galley/common.py
+++ b/galley/common.py
@@ -42,13 +42,11 @@ def validate_response_data(data, *fields):
     error = None
 
     if data is None:
-        logger.info(f"{GALLEY_ERROR_PREFIX} Error retrieving response data: API return null value or raised an exception")
-        return None
+        raise ValueError(f"{GALLEY_ERROR_PREFIX} Error retrieving response data: API return null value or raised an exception")
 
     if any(key in data for key in ('error', 'errors')):
         error = data.get('error') or data.get('errors')
-        logger.error(f"{GALLEY_ERROR_PREFIX} Error retrieving response data{f': {error}' if error else ''}")
-        return None
+        raise ValueError(f"{GALLEY_ERROR_PREFIX} Error retrieving response data{f': {error}' if error else ''}")
 
     if 'data' in data and data['data']:
         head = data['data']
@@ -57,14 +55,12 @@ def validate_response_data(data, *fields):
             if data['data']['viewer']:
                 head = data['data']['viewer']
             else:
-                logger.error(f"{GALLEY_ERROR_PREFIX} Error retrieving 'viewer' data")
-                return None
+                raise ValueError(f"{GALLEY_ERROR_PREFIX} Error retrieving 'viewer' data")
 
         return validate_fields(head, fields) if fields else head
 
     else:
-        logger.error(f"{GALLEY_ERROR_PREFIX} Error retrieving response data")
-        return None
+        raise ValueError(f"{GALLEY_ERROR_PREFIX} Error retrieving response data")
 
 
 def validate_fields(data, keys):

--- a/galley/common.py
+++ b/galley/common.py
@@ -36,15 +36,9 @@ def can_retry(data: Optional[Dict]) -> bool:
 @backoff.on_predicate(lambda: backoff.constant(interval=0.5), predicate=can_retry, max_tries=max_retries + 1)
 def make_request_to_galley(op: Operation, variables: Optional[Dict] = None) -> Optional[Dict]:
     endpoint = build_galley_endpoint()
-    try:
-        return endpoint(op, {} if variables is None else variables)
-    except Exception as ex:
-        logger.exception(ex)
-        return None
-
+    return endpoint(op, {} if variables is None else variables)
 
 # DATA VALIDATORS
-
 def validate_response_data(data, *fields):
     error = None
 

--- a/galley/formatted_ops_queries.py
+++ b/galley/formatted_ops_queries.py
@@ -166,7 +166,7 @@ def format_quantity_value(quantity_values: List) -> Dict:
             break
     return quantity
 
-  
+
 def is_core_recipe(component: Dict) -> bool:
     """
     Returns True if a recipe component contains a "Core Recipe"

--- a/galley/mutations.py
+++ b/galley/mutations.py
@@ -82,7 +82,11 @@ def build_upsert_mutation_query(args):
 # ]
 def upsert_menu_data(args):
     mutation = build_upsert_mutation_query(args)
-    response = make_request_to_galley(op=mutation)
+    try:
+        response = make_request_to_galley(op=mutation)
+    except Exception as ex:
+        logger.exception(ex)
+        response = None
     return validate_response_data(response)
 
 def build_bulk_update_recipe_item_query(args):

--- a/galley/mutations.py
+++ b/galley/mutations.py
@@ -82,11 +82,7 @@ def build_upsert_mutation_query(args):
 # ]
 def upsert_menu_data(args):
     mutation = build_upsert_mutation_query(args)
-    try:
-        response = make_request_to_galley(op=mutation)
-    except Exception as ex:
-        logger.exception(ex)
-        response = None
+    response = make_request_to_galley(op=mutation)
     return validate_response_data(response)
 
 def build_bulk_update_recipe_item_query(args):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # are dependencies that are required on remote installs, not local development.
 setup(
     name='galley_sdk',
-    version='0.37.0',
+    version='0.38.0',
     packages=['galley'],
     install_requires=['sgqlc==14.0', 'backoff==1.11.1']
 )

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # are dependencies that are required on remote installs, not local development.
 setup(
     name='galley_sdk',
-    version='0.38.0',
+    version='0.39.0',
     packages=['galley'],
     install_requires=['sgqlc==14.0', 'backoff==1.11.1']
 )

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # are dependencies that are required on remote installs, not local development.
 setup(
     name='galley_sdk',
-    version='0.39.0',
+    version='0.38.0',
     packages=['galley'],
     install_requires=['sgqlc==14.0', 'backoff==1.11.1']
 )

--- a/tests/test_common_utils.py
+++ b/tests/test_common_utils.py
@@ -139,12 +139,6 @@ class TestQueryGalleyDataOperation(TestCase):
         self.assertEqual(mock_endpoint_call.call_count, 3)
         self.assertEqual(result, MockUnavailableResponse)
 
-    @mock.patch('sgqlc.endpoint.http.HTTPEndpoint.__call__', **{'side_effect': Exception()})
-    def test_retrieve_exception_no_retry(self, mock_endpoint_call):
-        result = make_request_to_galley(op=Operation(Query))
-        self.assertEqual(mock_endpoint_call.call_count, 1)
-        self.assertEqual(result, None)
-
 
 class TestMutateGalleyDataOperation(TestCase):
     @mock.patch('sgqlc.endpoint.http.HTTPEndpoint.__call__')
@@ -161,12 +155,6 @@ class TestMutateGalleyDataOperation(TestCase):
         result = make_request_to_galley(op=Operation(Mutation))
         self.assertEqual(mock_endpoint_call.call_count, 3)
         self.assertEqual(result, MockUnavailableResponse)
-
-    @mock.patch('sgqlc.endpoint.http.HTTPEndpoint.__call__', **{'side_effect': Exception()})
-    def test_mutation_exception_no_retry(self, mock_endpoint_call):
-        result = make_request_to_galley(op=Operation(Mutation))
-        self.assertEqual(mock_endpoint_call.call_count, 1)
-        self.assertEqual(result, None)
 
 
 class TestCanRetry(TestCase):

--- a/tests/test_common_utils.py
+++ b/tests/test_common_utils.py
@@ -55,8 +55,8 @@ class TestValidateResponseData(TestCase):
             }],
             "data": None
         }
-        result = validate_response_data(self.response_data)
-        self.assertEqual(result, None)
+        with self.assertRaises(ValueError):
+            validate_response_data(self.response_data)
 
     def test_query_viewer_field_successful(self):
         self.data = {
@@ -79,15 +79,15 @@ class TestValidateResponseData(TestCase):
                 "viewer": None
             }
         }
-        result = validate_response_data(self.return_value)
-        self.assertEqual(result, None)
+        with self.assertRaises(ValueError):
+            validate_response_data(self.return_value)
 
     def test_response_data_failure(self):
         self.return_value = {
             'data': None
         }
-        result = validate_response_data(self.return_value)
-        self.assertEqual(result, None)
+        with self.assertRaises(ValueError):
+            validate_response_data(self.return_value)
 
     def test_response_data_fields_check_success(self):
         self.data = {

--- a/tests/test_formatted_queries.py
+++ b/tests/test_formatted_queries.py
@@ -808,10 +808,10 @@ class TestGetFormattedMenuData(TestCase):
         self.assertEqual(result, [formatted_menu('2021-11-14', onlySellableMenuItems=True)])
 
     @mock.patch('galley.queries.make_request_to_galley')
-    def test_get_formatted_menu_data_null(self, mock_retrieval_method):
+    def test_get_formatted_menu_data_exception(self, mock_retrieval_method):
         mock_retrieval_method.return_value = None
-        result = get_formatted_menu_data([])
-        self.assertEqual(result, None)
+        with self.assertRaises(ValueError):
+            get_formatted_menu_data([])
 
     @mock.patch('galley.formatted_queries.get_raw_menu_data')
     def test_get_formatted_menu_data_args_defaults(self, mock_grmd):

--- a/tests/test_mutations.py
+++ b/tests/test_mutations.py
@@ -198,8 +198,8 @@ class TestUpsertMenuData(TestCase):
                 }
             ]
         }]
-        result = upsert_menu_data(payload)
-        self.assertIsNone(result)
+        with self.assertRaises(ValueError):
+            upsert_menu_data(payload)
 
     def test_exception_raised_if_no_menu_id_present(self):
         payload = [{
@@ -363,8 +363,10 @@ class TestUpdateRecipeItemData(TestCase):
         # self.assertIsNone(result)
 
     @mock.patch('galley.mutations.make_request_to_galley')
-    def test_bulk_update_recipe_item_data_returns_expected_response_data(self, mock_mr):
+    @mock.patch('galley.queries.make_request_to_galley')
+    def test_bulk_update_recipe_item_data_returns_expected_response_data(self, mock_mr, mock_mr_2):
         mock_mr.return_value = self.response_data
+        mock_mr_2.return_value = self.response_data
         payload = {
             "ids": ["cmVjaXBlOjIwMjI5NA=="],
             "attrs": {
@@ -375,7 +377,7 @@ class TestUpdateRecipeItemData(TestCase):
         self.assertEqual(result, self.response_data['data'])
 
     @mock.patch('galley.mutations.make_request_to_galley')
-    @mock.patch('galley.mutations.make_request_to_galley')
+    @mock.patch('galley.queries.make_request_to_galley')
     def test_bulk_update_recipe_item_data_avoids_duplications(self, mock_first, mock_second):
         # first migration run
         mock_first.return_value = { "data": self.response_data["data"] }

--- a/tests/test_ops_formatted_queries.py
+++ b/tests/test_ops_formatted_queries.py
@@ -220,10 +220,10 @@ class TestGetFormattedOpsMenuData(TestCase):
                                   formatted_ops_menu('2022-04-18')])
 
     @mock.patch('galley.queries.make_request_to_galley')
-    def test_get_formatted_ops_menu_data_null(self, mock_retrieval_method):
+    def test_get_formatted_ops_menu_data_exception(self, mock_retrieval_method):
         mock_retrieval_method.return_value = None
-        result = get_formatted_ops_menu_data([])
-        self.assertEqual(result, None)
+        with self.assertRaises(ValueError):
+            get_formatted_ops_menu_data([])
 
     @mock.patch('galley.formatted_ops_queries.get_raw_menu_data')
     def test_get_formatted_ops_menu_data_args_defaults(self, mock_gromd):

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -171,10 +171,10 @@ class TestQueryWeekMenuData(TestCase):
             get_raw_menu_data(['YYYY-MM-DD'], "Vacaville", "production")
 
     @mock.patch('galley.queries.make_request_to_galley')
-    def test_get_raw_menu_data_null(self, mock_retrieval_method):
+    def test_get_raw_menu_data_exception(self, mock_retrieval_method):
         mock_retrieval_method.return_value = None
-        result = get_raw_menu_data([], 'Vacaville', 'production')
-        self.assertEqual(result, [])
+        with self.assertRaises(ValueError):
+            get_raw_menu_data([], 'Vacaville', 'production')
 
     @mock.patch('galley.queries.make_request_to_galley')
     def test_get_raw_menu_data_filters_by_location(self, mock_retrieval_method):


### PR DESCRIPTION
## Description
- remove general exception from query method
- removing unnecessary tests
- removing general exception for upsert_menu_data
- fixes tests that call the galley staging endpoint when run
- fixed tests that assert result is none, replacing thems to check for assertRaises 

## Test Plan
- activate galley-sdk virtualenv and open python console
- [x] calling method with wrong input throws exception. the variable is not set to None or an empty array. For ex.
```
$ python
>>> from galley.formatted_ops_queries import get_formatted_ops_menu_data
>>> a = get_formatted_ops_menu_data(['2011-22-11'])
...
    return cls.converter(json_data)
  File "/usr/local/Cellar/python/3.7.7/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/sgqlc/types/datetime.py", line 210, in converter
    return datetime.date(year, month, day)
ValueError: month must be in 1..12
>>> print(a)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NameError: name 'a' is not defined
```
- [x] Scramble or remove api key from `.env`, reload the python console.
    - [x] check that authentication error is not thrown when running tests `python -m unittest tests/test_*`
    - [x] also check that calling get_formatted_ops_menu_data(["2022-08-01"]) throws an exception. The results should look as the following:
```
python
>>> from galley.formatted_ops_queries import get_formatted_ops_menu_data
>>> get_formatted_ops_menu_data(["2022-08-01"])
https://staging-api.galleysolutions.com/graphql: HTTP Error 400: Bad Request
GraphQL query failed with 1 errors
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../galley-sdk/galley/formatted_ops_queries.py", line 209, in get_formatted_ops_menu_data
    menus = get_raw_menu_data(dates, location_name, menu_type, is_ops=True)
  File ".../galley-sdk/galley/queries.py", line 203, in get_raw_menu_data
    validated_response_data = validate_response_data(
  File ".../galley-sdk/galley/common.py", line 49, in validate_response_data
    raise ValueError(f"{GALLEY_ERROR_PREFIX} Error retrieving response data{f': {error}' if error else ''}")
ValueError: (GalleyError) Error retrieving response data: [{'message': 'Unauthenticated', 'extensions': {'code': 'UNAUTHENTICATED'}}]
```
 - [x] Remember to restore api key in .env after testing