### PR TITLE
Fixed capitalizing the apostrophe s in base meal

### DIFF
--- a/galley/formatted_queries.py
+++ b/galley/formatted_queries.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from typing import Dict, List, Optional
 
 from galley.enums import (
@@ -350,6 +351,8 @@ def format_standalone_data(standalone_recipe_item):
             standalone_data['standaloneServings'] = standalone_servings if standalone_servings else None
     return standalone_data
 
+def format_title(text):
+  return re.sub("(?<!\s)'S", "'s", text.title())
 
 def ingredients_from_recipe_items(recipe_items: List[Dict]) -> Optional[List]:
     ingredients: List[str] = []
@@ -481,7 +484,7 @@ def get_formatted_menu_data(dates: List[str],
 
             formatted_menu['menuItems'].append({
                 'allergens': formatted_recipe_dict.get('allergens', []),
-                'baseMeal': formatted_recipe.recipe_tags.get('baseMeal', '').title(),
+                'baseMeal': format_title(formatted_recipe.recipe_tags.get('baseMeal', '')),
                 'deliveryDate': menu.get('date'),
                 'hasAllergen': formatted_recipe_dict.get('hasAllergen', False),
                 'highlightTags': formatted_recipe_dict.get('highlightTags', []),

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # are dependencies that are required on remote installs, not local development.
 setup(
     name='galley_sdk',
-    version='0.37.0',
+    version='0.37.1',
     packages=['galley'],
     install_requires=['sgqlc==14.0', 'backoff==1.11.1']
 )

--- a/tests/test_formatted_queries.py
+++ b/tests/test_formatted_queries.py
@@ -2,13 +2,14 @@ from unittest import TestCase, mock
 
 from galley.enums import RecipeCategoryTagTypeEnum
 from galley.formatted_queries import (
+    calculate_serving_size_weight,
+    calculate_servings,
     format_recipe_tree_components_data,
+    format_title,
     get_formatted_menu_data,
     get_formatted_recipes_data,
-    ingredients_from_recipe_items,
-    calculate_servings,
-    calculate_serving_size_weight,
     get_recipe_category_tags,
+    ingredients_from_recipe_items,
 )
 
 from tests.mock_responses import (
@@ -820,3 +821,16 @@ class TestGetFormattedMenuData(TestCase):
         mock_grmd.assert_called_with(dates, 'Vacaville', 'production')
         get_formatted_menu_data(dates, 'Montana', 'staging')
         mock_grmd.assert_called_with(dates, 'Montana', 'staging')
+
+    @mock.patch('galley.queries.make_request_to_galley')
+    def test_get_formatted_menu_data_base_meal_title_format(self, mock_retrieval_method):
+        self.assertEqual(format_title("beet-poke"), "Beet-Poke")
+        self.assertEqual(format_title("persephone's salad"), "Persephone's Salad")
+        self.assertEqual(
+            format_title("brussel sprout & asian pear 'fried' rice"),
+            "Brussel Sprout & Asian Pear 'Fried' Rice"
+        )
+        self.assertEqual(
+            format_title('beetroot quinoa & sun "cheese" salad'),
+            'Beetroot Quinoa & Sun "Cheese" Salad'
+        )


### PR DESCRIPTION
## Description
Fixes capitalizing the `'s` in the base meal name. Python's `.title()` function will capitalize any letter in a string that is not preceded by an a-z character causing title formatting such as `Forager'S Pie`.

## Test Plan

### Diff checking
[Here is a Gist](https://gist.github.com/ErikBrown/8299d970e269a05d53336cc1996894f4) that includes:

- [Base meals raw](https://gist.githubusercontent.com/ErikBrown/8299d970e269a05d53336cc1996894f4/raw/2414fd9261e005dfb4205f86ea448b02ffc2f5ec/base_meals_raw)
- [Base meals formatted with .title()](https://gist.githubusercontent.com/ErikBrown/8299d970e269a05d53336cc1996894f4/raw/9750a838791bfc91eb5bebd32e04ede85e69035f/base_meals_using_title)
- [Base meals formatted with .title() and regex()](https://gist.githubusercontent.com/ErikBrown/8299d970e269a05d53336cc1996894f4/raw/2414fd9261e005dfb4205f86ea448b02ffc2f5ec/base_meals_using_title_and_regex)
    - This is the proposed solution
- [Base meals formatted with string.capwords()](https://gist.githubusercontent.com/ErikBrown/8299d970e269a05d53336cc1996894f4/raw/9750a838791bfc91eb5bebd32e04ede85e69035f/base_meals_using_string_capwords)
    - We are not, and have not been using this, but is useful as reference for the other built-in way python does title capitalization

You can use a [diff checker](https://www.diffchecker.com/) to see the difference between the previous `.title()` implementation against the regex solution and observe that the `'s` capitalization issue is resolved without changing any of the other base meals' formatting.

### Testing the `get_formatted_menu_data` query
To manually test against a menu:
```python
python

>>> from galley.queries import *; from galley.formatted_queries import *; import json;
>>> print(json.dumps(get_formatted_menu_data(["2022-03-17"]), indent=4))
```

Observe that the base meal of `Forager's Pie` is formatted correctly.
## Versioning
Please update the project version in setup.py
