### PR TITLE
Add ounce conversion to formatted menu ops

### DIFF
--- a/galley/formatted_ops_queries.py
+++ b/galley/formatted_ops_queries.py
@@ -55,7 +55,7 @@ class FormattedRecipeComponent:
             id=self.data.get('id'),
             name=get_external_name(self.data),
             usage=dict(value=self.quantity, unit=self.unit),
-            quantity=format_quantity_value(self.quantity_values),
+            quantityValues=format_quantity_value(self.quantity_values),
             binWeight=format_bin_weight(self.data.get('categoryValues')),
             allergens=format_allergens(self.dietary_flags, is_recipe=(self.type=='recipe'))
         )

--- a/galley/formatted_ops_queries.py
+++ b/galley/formatted_ops_queries.py
@@ -156,15 +156,14 @@ def format_quantity_value(quantity_values: List) -> Dict:
     Filters a list of quantity values to return only unit values in
     ounces (oz) and pounds (lb).
     """
-    quantity = dict()
-    unit = QuantityUnitEnum.LB.value
+    quantities = list()
+    units = set([QuantityUnitEnum.OZ.value, QuantityUnitEnum.LB.value])
 
     for qv in quantity_values:
-        if qv.get('unit', {}).get('id') == unit:
-            quantity = dict(value=qv['value'],
-                            unit=qv['unit']['name'])
-            break
-    return quantity
+        if qv.get('unit', {}).get('id') in units:
+            quantities.append(dict(value=qv['value'],
+                                   unit=qv['unit']['name']))
+    return quantities
 
 
 def is_core_recipe(component: Dict) -> bool:

--- a/galley/formatted_ops_queries.py
+++ b/galley/formatted_ops_queries.py
@@ -151,7 +151,7 @@ def format_bin_weight(category_values: List) -> Dict:
                 unit=DEFAULT_BIN_WEIGHT_UNIT)
 
 
-def format_quantity_value(quantity_values: List) -> Dict:
+def format_quantity_value(quantity_values: List) -> List[Dict]:
     """
     Filters a list of quantity values to return only unit values in
     ounces (oz) and pounds (lb).

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # are dependencies that are required on remote installs, not local development.
 setup(
     name='galley_sdk',
-    version='0.38.0',
+    version='0.38.1',
     packages=['galley'],
     install_requires=['sgqlc==14.0', 'backoff==1.11.1']
 )

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # are dependencies that are required on remote installs, not local development.
 setup(
     name='galley_sdk',
-    version='0.38.1',
+    version='0.39.0',
     packages=['galley'],
     install_requires=['sgqlc==14.0', 'backoff==1.11.1']
 )

--- a/tests/mock_responses/mock_ops_menu_data.py
+++ b/tests/mock_responses/mock_ops_menu_data.py
@@ -826,10 +826,13 @@ mock_formatted_primaryRecipeComponents = [
             'value': 4,
             'unit': 'oz'
         },
-        'quantity': {
+        'quantityValues': [{
             'value': 0.2499999997795377,
             'unit': 'lb'
-        },
+        },{
+            'value': 4,
+            'unit': 'oz'
+        }],
         'binWeight': {
             'value': 50.0,
             'unit': 'lb'
@@ -882,10 +885,13 @@ mock_formatted_primaryRecipeComponents = [
             'value': 1.5,
             'unit': 'oz'
         },
-        'quantity': {
+        'quantityValues': [{
             'value': 0.09374999991732665,
             'unit': 'lb'
-        },
+        },{
+            'value': 1.5,
+            'unit': 'oz'
+        }],
         'binWeight': {
             'value': 60.0,
             'unit': 'lb'
@@ -930,10 +936,13 @@ mock_formatted_primaryRecipeComponents = [
             'value': 2.5,
             'unit': 'oz'
         },
-        'quantity': {
+        'quantityValues': [{
             'value': 0.15624999986221108,
             'unit': 'lb'
-        },
+        },{
+            'value': 2.5,
+            'unit': 'oz'
+        }],
         'binWeight': {
             'value': 30.0,
             'unit': 'lb'
@@ -948,10 +957,13 @@ mock_formatted_primaryRecipeComponents = [
             'value': 0.85,
             'unit': 'oz'
         },
-        'quantity': {
+        'quantityValues': [{
             'value': 0.05312499995315176,
             'unit': 'lb'
-        },
+        },{
+            'value': 0.85,
+            'unit': 'oz'
+        }],
         'binWeight': {
             'value': 40.0,
             'unit': 'lb'
@@ -966,10 +978,13 @@ mock_formatted_primaryRecipeComponents = [
             'value': 3,
             'unit': 'oz'
         },
-        'quantity': {
+        'quantityValues': [{
             'value': 0.1874999998346533,
             'unit': 'lb'
-        },
+        },{
+            'value': 3,
+            'unit': 'oz'
+        }],
         'binWeight': {
             'value': 60.0,
             'unit': 'lb'
@@ -1066,10 +1081,13 @@ mock_formatted_primaryRecipeComponents = [
             'value': 2,
             'unit': 'oz'
         },
-        'quantity': {
+        'quantityValues': [{
             'value': 0.12499999988976886,
             'unit': 'lb'
-        },
+        },{
+            'value': 2,
+            'unit': 'oz'
+        }],
         'binWeight': {
             'value': 60,
             'unit': 'lb'

--- a/tests/mock_responses/mock_ops_menu_data.py
+++ b/tests/mock_responses/mock_ops_menu_data.py
@@ -827,11 +827,11 @@ mock_formatted_primaryRecipeComponents = [
             'unit': 'oz'
         },
         'quantityValues': [{
-            'value': 0.2499999997795377,
-            'unit': 'lb'
-        },{
             'value': 4,
             'unit': 'oz'
+        }, {
+            'value': 0.2499999997795377,
+            'unit': 'lb'
         }],
         'binWeight': {
             'value': 50.0,
@@ -886,11 +886,11 @@ mock_formatted_primaryRecipeComponents = [
             'unit': 'oz'
         },
         'quantityValues': [{
-            'value': 0.09374999991732665,
-            'unit': 'lb'
-        },{
             'value': 1.5,
             'unit': 'oz'
+        }, {
+            'value': 0.09374999991732665,
+            'unit': 'lb'
         }],
         'binWeight': {
             'value': 60.0,
@@ -937,11 +937,11 @@ mock_formatted_primaryRecipeComponents = [
             'unit': 'oz'
         },
         'quantityValues': [{
-            'value': 0.15624999986221108,
-            'unit': 'lb'
-        },{
             'value': 2.5,
             'unit': 'oz'
+        }, {
+            'value': 0.15624999986221108,
+            'unit': 'lb'
         }],
         'binWeight': {
             'value': 30.0,
@@ -958,11 +958,11 @@ mock_formatted_primaryRecipeComponents = [
             'unit': 'oz'
         },
         'quantityValues': [{
-            'value': 0.05312499995315176,
-            'unit': 'lb'
-        },{
             'value': 0.85,
             'unit': 'oz'
+        }, {
+            'value': 0.05312499995315176,
+            'unit': 'lb'
         }],
         'binWeight': {
             'value': 40.0,
@@ -979,14 +979,14 @@ mock_formatted_primaryRecipeComponents = [
             'unit': 'oz'
         },
         'quantityValues': [{
-            'value': 0.1874999998346533,
-            'unit': 'lb'
-        },{
             'value': 3,
             'unit': 'oz'
+        }, {
+            'value': 0.1874999998346533,
+            'unit': 'lb'
         }],
         'binWeight': {
-            'value': 60.0,
+            'value': 60,
             'unit': 'lb'
         },
         'instructions': [
@@ -1082,11 +1082,11 @@ mock_formatted_primaryRecipeComponents = [
             'unit': 'oz'
         },
         'quantityValues': [{
-            'value': 0.12499999988976886,
-            'unit': 'lb'
-        },{
             'value': 2,
             'unit': 'oz'
+        }, {
+            'value': 0.12499999988976886,
+            'unit': 'lb'
         }],
         'binWeight': {
             'value': 60,


### PR DESCRIPTION
## Description
- [x]  Expose the oz quantity unit value to send with `get_formatted_ops_menu_data` to predominately get the oz conversion equivalent for any "each" quantity value usage.

## Test Plan
```python
from galley.formatted_ops_queries import *; import json
print(json.dumps(get_formatted_ops_menu_data(["2022-09-12"]), indent=4))

# check that all primary and secondary components contain a quantityValues list consisting of lb. and oz. values (if exists); tertiary components will only have a usage object, but not quantityValues
```

## Versioning
- [x] Please update the project version in setup.py
