### PR TITLE
Added location to menu query

### DIFF
--- a/galley/enums.py
+++ b/galley/enums.py
@@ -1,6 +1,14 @@
 from enum import Enum
 
 
+class LocationEnum(Enum):
+    """
+    Enum for locations. <location name>: <location id>
+    """
+    VACAVILLE = 'bG9jYXRpb246MTkyOA=='
+    BURLINGTON = 'bG9jYXRpb246Mzg1MQ=='
+
+
 class MenuCategoryEnum(Enum):
     """
     Enum for categories, for item type menu <category name>: <category id>

--- a/galley/queries.py
+++ b/galley/queries.py
@@ -6,7 +6,7 @@ from sgqlc.operation import Operation
 from sgqlc.types import ArgDict, Field, Type
 
 from galley.common import make_request_to_galley, validate_response_data
-from galley.enums import MenuCategoryEnum, PreparationEnum
+from galley.enums import LocationEnum, MenuCategoryEnum, PreparationEnum
 from galley.types import (FilterInput, Menu, MenuFilterInput,
                           PaginationOptions, Recipe, RecipeConnection,
                           RecipeConnectionFilter,
@@ -139,9 +139,9 @@ def get_raw_recipes_data(recipe_ids: List[str]) -> Optional[List[Dict]]:
         has_next_page = page_info.get('hasNextPage', False)
     return raw_recipes_data
 
-def get_menu_query(dates: List[str]) -> Operation:
+def get_menu_query(dates: List[str], location_id: str) -> Operation:
     query = Operation(Query)
-    query.viewer.menus(where=MenuFilterInput(date=dates)).__fields__('id', 'name', 'date', 'location', 'categoryValues', 'menuItems')
+    query.viewer.menus(where=MenuFilterInput(date=dates, locationId=location_id)).__fields__('id', 'name', 'date', 'location', 'categoryValues', 'menuItems')
     query.viewer.menus.menuItems.__fields__('id', 'recipeId', 'categoryValues', 'recipe')
     query.viewer.menus.menuItems.recipe.__fields__('externalName', 'name', 'recipeItems', 'categoryValues', 'media', 'isDish', 'dietaryFlagsWithUsages')
     query.viewer.menus.menuItems.recipe.dietaryFlagsWithUsages.dietaryFlag.__fields__('id', 'name')
@@ -187,7 +187,8 @@ def get_raw_menu_data(dates: List[str],
     :param menu_type: The type of menu to be fetched. ex. "production",
     "development"
     """
-    query = get_menu_query(dates=dates)
+    location_id = LocationEnum[location_name.upper()].value
+    query = get_menu_query(dates=dates, location_id=location_id)
 
     if is_ops:
         query = get_ops_menu_query(dates=dates)

--- a/galley/queries.py
+++ b/galley/queries.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Iterable, List, Optional
 from sgqlc.operation import Operation
 from sgqlc.types import ArgDict, Field, Type
 
-from galley.common import make_request_to_galley, validate_response_data
+from galley.common import GALLEY_ERROR_PREFIX, make_request_to_galley, validate_response_data
 from galley.enums import LocationEnum, MenuCategoryEnum, PreparationEnum
 from galley.types import (FilterInput, Menu, MenuFilterInput,
                           PaginationOptions, Recipe, RecipeConnection,
@@ -187,7 +187,10 @@ def get_raw_menu_data(dates: List[str],
     :param menu_type: The type of menu to be fetched. ex. "production",
     "development"
     """
-    location_id = LocationEnum[location_name.upper()].value
+    try:
+        location_id = LocationEnum[location_name.upper()].value
+    except KeyError:
+        raise ValueError(f"{GALLEY_ERROR_PREFIX} Invalid location name: {f'{location_name}'}")
     query = get_menu_query(dates=dates, location_id=location_id)
 
     if is_ops:

--- a/galley/queries.py
+++ b/galley/queries.py
@@ -150,9 +150,9 @@ def get_menu_query(dates: List[str], location_id: str) -> Operation:
     query.viewer.menus.menuItems.recipe.recipeItems.preparations.__fields__('id', 'name')
     return query
 
-def get_ops_menu_query(dates: List[str]) -> Operation:
+def get_ops_menu_query(dates: List[str], location_id: str) -> Operation:
     query = Operation(Query)
-    query.viewer.menus(where=MenuFilterInput(date=dates)).__fields__('id', 'name', 'date', 'location', 'categoryValues', 'menuItems')
+    query.viewer.menus(where=MenuFilterInput(date=dates, locationId=location_id)).__fields__('id', 'name', 'date', 'location', 'categoryValues', 'menuItems')
     query.viewer.menus.menuItems.__fields__('id', 'recipeId', 'categoryValues', 'recipe', 'volume', 'unit')
     query.viewer.menus.menuItems.recipe.files.__fields__('photos')
     query.viewer.menus.menuItems.recipe.__fields__('id', 'name', 'categoryValues')
@@ -191,7 +191,7 @@ def get_raw_menu_data(dates: List[str],
     query = get_menu_query(dates=dates, location_id=location_id)
 
     if is_ops:
-        query = get_ops_menu_query(dates=dates)
+        query = get_ops_menu_query(dates=dates, location_id=location_id)
 
     validated_response_data = validate_response_data(
             make_request_to_galley(

--- a/galley/types.py
+++ b/galley/types.py
@@ -313,6 +313,7 @@ class FilterInput(Input):
 class MenuFilterInput(Input):
     id = ID
     date = list_of(d.Date)
+    locationId = ID
 
 
 class RecipeConnectionFilter(Input):

--- a/tests/test_ops_queries.py
+++ b/tests/test_ops_queries.py
@@ -1,5 +1,6 @@
 import logging
 from unittest import TestCase, mock
+from galley.enums import LocationEnum
 from galley.queries import (get_ops_menu_query,
                             get_ops_recipe_item_connection_query,
                             get_raw_recipe_items_data_via_connection)
@@ -11,7 +12,7 @@ class TestOpsMenuDataQuery(TestCase):
     def setUp(self) -> None:
         self.expected_query = '''query {
             viewer {
-            menus(where: {date: ["2022-03-28"]}) {
+            menus(where: {date: ["2022-03-28"], locationId: "bG9jYXRpb246MTkyOA=="}) {
             id
             name
             date
@@ -218,7 +219,7 @@ class TestOpsMenuDataQuery(TestCase):
             }'''.replace(' '*12, '')
 
     def test_get_ops_menu_query(self):
-        query = get_ops_menu_query(dates=["2022-03-28"])
+        query = get_ops_menu_query(dates=["2022-03-28"], location_id=LocationEnum.VACAVILLE.value)
         query_str = bytes(query).decode('utf-8')
         self.maxDiff = None
         self.assertEqual(query_str, self.expected_query)

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -49,7 +49,7 @@ class TestQueryWeekMenuData(TestCase):
     def setUp(self) -> None:
         self.expected_query = '''query {
             viewer {
-            menus(where: {date: ["2021-10-04", "2021-10-07"], locationId:"bG9jYXRpb246MTkyOA=="}) {
+            menus(where: {date: ["2021-10-04", "2021-10-07"], locationId: "bG9jYXRpb246MTkyOA=="}) {
             id
             name
             date

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -1,5 +1,6 @@
 import logging
 from unittest import TestCase, mock
+from galley.enums import LocationEnum
 from sgqlc.operation import Operation
 
 from galley.queries import (
@@ -48,7 +49,7 @@ class TestQueryWeekMenuData(TestCase):
     def setUp(self) -> None:
         self.expected_query = '''query {
             viewer {
-            menus(where: {date: ["2021-10-04", "2021-10-07"]}) {
+            menus(where: {date: ["2021-10-04", "2021-10-07"], locationId:"bG9jYXRpb246MTkyOA=="}) {
             id
             name
             date
@@ -123,7 +124,7 @@ class TestQueryWeekMenuData(TestCase):
         })
 
     def test_week_menu_data_query(self):
-        query = get_menu_query(["2021-10-04", "2021-10-07"])
+        query = get_menu_query(["2021-10-04", "2021-10-07"], location_id=LocationEnum.VACAVILLE.value)
         query_str = query.__to_graphql__(auto_select_depth=3)
         self.assertEqual(query_str.replace(' ', ''),
                          self.expected_query.replace(' ', ''))


### PR DESCRIPTION
## Description
Adds location_id to the `get_menu_query` and `get_ops_menu_query` functions. There is a limit of 25 menus returned, and had been fetching ALL menus then filtering them down. This will cause issues once we activate the Burlington menus. This PR adds a filter to the GraphQL query itself so we don't need to return as much data.

## Test Plan
Test that `get_raw_menu_data` returns only the menus for the location provided to it. Here's some code to help with that testing:
### Thistle-web menu testing:
```
from galley.queries import get_raw_menu_data
expected_dates = ['2022-10-10', '2022-10-13', '2022-10-17', '2022-10-20', '2022-10-24', '2022-10-27', '2022-10-31', '2022-11-03', '2022-11-07', '2022-11-10']
raw_data_burlington = get_raw_menu_data(expected_dates, 'Burlington', 'production')

len(raw_data_burlington) # Should be 10
[[m['date'], m['location']['name']] for m in raw_data_burlington] # Can verify that it's only Burlington menus

raw_data_vacaville = get_raw_menu_data(expected_dates, 'Vacaville', 'production')

len(raw_data_vacaville) # Should be 10
[[m['date'], m['location']['name']] for m in raw_data_vacaville] # Can verify that it's only Vacaville menus
```
### Okra menu testing (takes a couple minutes to fetch):
```
raw_ops_data = get_raw_menu_data(expected_dates, 'Burlington', 'production', is_ops=True)

len(raw_ops_data) # Should be 10
[[m['date'], m['location']['name']] for m in raw_ops_data] # Can verify that it's only Burlington menus
```

**Test on BOTH staging and production Galley**

## Versioning
Please update the project version in setup.py
