### PR TITLE
Add PercentDRV for addedSugar and saturatedFat

### DIFF
--- a/galley/types.py
+++ b/galley/types.py
@@ -31,6 +31,7 @@ class UnitValue(Type):
 
 class Nutrition(Type):
     addedSugarG = float
+    addedSugarPercentDRV = float
     calciumMg = float
     calciumPercentRDI = float
     caloriesKCal = float
@@ -62,6 +63,7 @@ class Nutrition(Type):
     riboflavinMg = float
     riboflavinPercentRDI = float
     saturatedFatG = float
+    saturatedFatPercentDRV = float
     seleniumMcg = float
     seleniumPercentRDI = float
     sodiumMg = float

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # are dependencies that are required on remote installs, not local development.
 setup(
     name='galley_sdk',
-    version='0.42.0',
+    version='0.42.1',
     packages=['galley'],
     install_requires=['sgqlc==14.0', 'backoff==1.11.1']
 )

--- a/tests/mock_responses/mock_nutrition_data.py
+++ b/tests/mock_responses/mock_nutrition_data.py
@@ -1,5 +1,6 @@
 mock_data = {
 	'addedSugarG': 0,
+	'addedSugarPercentDRV': 0.0,
 	'calciumMg': 111.98919574121712,
 	'calciumPercentRDI': 0.086,
 	'caloriesKCal': 432.85693190562375,
@@ -31,6 +32,7 @@ mock_data = {
 	'riboflavinMg': 0.25357865086256715,
 	'riboflavinPercentRDI': 0.195,
 	'saturatedFatG': 4.504105090278564,
+	'saturatedFatPercentDRV': 0.06929392446,
 	'seleniumMcg': 25.00140713878487,
 	'seleniumPercentRDI': 0.455,
 	'sodiumMg': 259.10792677825793,

--- a/tests/mock_responses/mock_recipe_tree_components.py
+++ b/tests/mock_responses/mock_recipe_tree_components.py
@@ -488,6 +488,7 @@ mock_recipe_tree_components_data = [
                 "name": "Vanilla Cashew Cream",
                 "reconciledNutritionals": {
                     'addedSugarG': 0,
+                    'addedSugarPercentDRV': 0.0,
                     'calciumMg': 3.1684181569284497,
                     'calciumPercentRDI': 0.002,
                     'caloriesKCal': 53.66203631343362,
@@ -519,6 +520,7 @@ mock_recipe_tree_components_data = [
                     'riboflavinMg': 0.009900242547519483,
                     'riboflavinPercentRDI': 0.008,
                     'saturatedFatG': 1.1966419313881989,
+                    'saturatedFatPercentDRV': 0.01840987586,
                     'seleniumMcg': 0.1983239364917749,
                     'seleniumPercentRDI': 0.004,
                     'sodiumMg': 80.1688699548479,
@@ -2269,6 +2271,7 @@ mock_recipe_tree_components_data_with_multiple_servings_of_standalone = [
                 "name": "Vanilla Cashew Cream",
                 "reconciledNutritionals": {
                     'addedSugarG': 0,
+                    'addedSugarPercentDRV': 0.0,
                     'calciumMg': 3.1684181569284497,
                     'calciumPercentRDI': 0.002,
                     'caloriesKCal': 53.66203631343362,
@@ -2300,6 +2303,7 @@ mock_recipe_tree_components_data_with_multiple_servings_of_standalone = [
                     'riboflavinMg': 0.009900242547519483,
                     'riboflavinPercentRDI': 0.008,
                     'saturatedFatG': 1.1966419313881989,
+                    'saturatedFatPercentDRV': 0.01840987586,
                     'seleniumMcg': 0.1983239364917749,
                     'seleniumPercentRDI': 0.004,
                     'sodiumMg': 80.1688699548479,
@@ -3231,6 +3235,7 @@ mock_recipe_tree_components_data_with_one_serving_of_standalone = [
                 "name": "Vanilla Cashew Cream",
                 "reconciledNutritionals": {
                     'addedSugarG': 0,
+                    'addedSugarPercentDRV': 0.0,
                     'calciumMg': 3.1684181569284497,
                     'calciumPercentRDI': 0.002,
                     'caloriesKCal': 53.66203631343362,
@@ -3262,6 +3267,7 @@ mock_recipe_tree_components_data_with_one_serving_of_standalone = [
                     'riboflavinMg': 0.009900242547519483,
                     'riboflavinPercentRDI': 0.008,
                     'saturatedFatG': 1.1966419313881989,
+                    'saturatedFatPercentDRV': 0.01840987586,
                     'seleniumMcg': 0.1983239364917749,
                     'seleniumPercentRDI': 0.004,
                     'sodiumMg': 80.1688699548479,
@@ -4201,6 +4207,7 @@ mock_recipe_tree_components_data_with_standalone_missing_nutritionals_quantity_d
                 "name": "Vanilla Cashew Cream",
                 "reconciledNutritionals": {
                     'addedSugarG': 0,
+                    'addedSugarPercentDRV': 0.0,
                     'calciumMg': 3.1684181569284497,
                     'calciumPercentRDI': 0.002,
                     'caloriesKCal': 53.66203631343362,
@@ -4232,6 +4239,7 @@ mock_recipe_tree_components_data_with_standalone_missing_nutritionals_quantity_d
                     'riboflavinMg': 0.009900242547519483,
                     'riboflavinPercentRDI': 0.008,
                     'saturatedFatG': 1.1966419313881989,
+                    'saturatedFatPercentDRV': 0.01840987586,
                     'seleniumMcg': 0.1983239364917749,
                     'seleniumPercentRDI': 0.004,
                     'sodiumMg': 80.1688699548479,

--- a/tests/test_formatted_queries.py
+++ b/tests/test_formatted_queries.py
@@ -21,6 +21,7 @@ from tests.mock_responses import (
 
 
 STANDALONE_NUTRITION = {'addedSugarG': 0,
+                        'addedSugarPercentDRV': 0.0,
                         'calciumMg': 3.1684181569284497,
                         'calciumPercentRDI': 0.002,
                         'caloriesKCal': 53.66203631343362,
@@ -52,6 +53,7 @@ STANDALONE_NUTRITION = {'addedSugarG': 0,
                         'riboflavinMg': 0.009900242547519483,
                         'riboflavinPercentRDI': 0.008,
                         'saturatedFatG': 1.1966419313881989,
+                        'saturatedFatPercentDRV': 0.01840987586,
                         'seleniumMcg': 0.1983239364917749,
                         'seleniumPercentRDI': 0.004,
                         'sodiumMg': 80.1688699548479,

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -240,6 +240,7 @@ class TestRecipeConnectionQuery(TestCase):
             }
             reconciledNutritionals {
             addedSugarG
+            addedSugarPercentDRV
             calciumMg
             calciumPercentRDI
             caloriesKCal
@@ -271,6 +272,7 @@ class TestRecipeConnectionQuery(TestCase):
             riboflavinMg
             riboflavinPercentRDI
             saturatedFatG
+            saturatedFatPercentDRV
             seleniumMcg
             seleniumPercentRDI
             sodiumMg
@@ -318,6 +320,7 @@ class TestRecipeConnectionQuery(TestCase):
             externalName
             reconciledNutritionals {
             addedSugarG
+            addedSugarPercentDRV
             calciumMg
             calciumPercentRDI
             caloriesKCal
@@ -349,6 +352,7 @@ class TestRecipeConnectionQuery(TestCase):
             riboflavinMg
             riboflavinPercentRDI
             saturatedFatG
+            saturatedFatPercentDRV
             seleniumMcg
             seleniumPercentRDI
             sodiumMg
@@ -447,6 +451,7 @@ class TestRecipeConnectionQuery(TestCase):
             allIngredients
             reconciledNutritionals {
             addedSugarG
+            addedSugarPercentDRV
             calciumMg
             calciumPercentRDI
             caloriesKCal
@@ -478,6 +483,7 @@ class TestRecipeConnectionQuery(TestCase):
             riboflavinMg
             riboflavinPercentRDI
             saturatedFatG
+            saturatedFatPercentDRV
             seleniumMcg
             seleniumPercentRDI
             sodiumMg


### PR DESCRIPTION
## Description
Adds the nutrition values `addedSugarPercentDRV` and `saturatedFatPercentDRV` to our queries.

## Test Plan
In a python console:
```
from galley.formatted_queries import get_formatted_recipes_data
get_formatted_recipes_data(recipe_ids=["cmVjaXBlOjE3ODAwMg=="])
```

- [x] Make sure `addedSugarPercentDRV` and `saturatedFatPercentDRV` appear in both the main recipe nutrition and standalone nutrition
