### PR TITLE
(FRU-278) Use ingredient name instead of externalName

### DIFF
--- a/galley/formatted_ops_queries.py
+++ b/galley/formatted_ops_queries.py
@@ -57,7 +57,7 @@ class FormattedRecipeComponent:
         component = dict(
             type=self.type,
             id=self.data.get('id'),
-            name=get_external_name(self.data),
+            name=self.data.get('name'),
             usage=dict(value=self.quantity, unit=self.unit),
             quantityValues=format_quantity_value(self.quantity_values),
             binWeight=format_bin_weight(self.data.get('categoryValues')),

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # are dependencies that are required on remote installs, not local development.
 setup(
     name='galley_sdk',
-    version='0.42.1',
+    version='0.42.2',
     packages=['galley'],
     install_requires=['sgqlc==14.0', 'backoff==1.11.1']
 )

--- a/tests/mock_responses/mock_ops_menu_data.py
+++ b/tests/mock_responses/mock_ops_menu_data.py
@@ -988,7 +988,7 @@ mock_formatted_primaryRecipeComponents = [
     {
         'type': 'ingredient',
         'id': 'aW5ncmVkaWVudDoyNDQ1NjE=',
-        'name': 'Spring Mix Lettuce*',
+        'name': 'lettuce, spring mix, SEND TO PLATE',
         'allergens': [],
         'cuppingContainer': None,
         'usage': {
@@ -1010,7 +1010,7 @@ mock_formatted_primaryRecipeComponents = [
     {
         'type': 'ingredient',
         'id': 'aW5ncmVkaWVudDoyNzQ4ODA=',
-        'name': 'Crispy Chickpeas (Chickpeas, Sunflower Oil, Sea Salt)',
+        'name': 'crispy roasted chickpeas, 0.85 oz bag',
         'allergens': ['sesame_seeds', 'tree_nuts'],
         'cuppingContainer': None,
         'usage': {
@@ -1047,7 +1047,7 @@ mock_formatted_primaryRecipeComponents = [
             'unit': 'lb'
         }],
         'binWeight': {
-            'value': 60,
+            'value': 60.0,
             'unit': 'lb'
         },
         'instructions': [
@@ -1136,7 +1136,7 @@ mock_formatted_primaryRecipeComponents = [
     {
         'type': 'ingredient',
         'id': 'aW5ncmVkaWVudDoyNDUyMDQ=',
-        'name': 'Seed Crackers (Brown Rice, Quinoa, Pumpkin Seeds, Sunflower Seeds, Sesame Seeds, Flax Seeds, Poppy Seeds, Minced Onion, Garlic Powder, Sea Salt)*',
+        'name': "crackers, Mary's seeded GF, SEND TO PLATE",
         'allergens': ['sesame_seeds'],
         'cuppingContainer': '12-oz-clean-round-sided-INSERT',
         'usage': {
@@ -1158,7 +1158,7 @@ mock_formatted_primaryRecipeComponents = [
     {
         'type': 'recipe',
         'id': 'cmVjaXBlOjIyMzU3MQ==',
-        'name': 'Red Wine Vinaigrette',
+        'name': 'Red Wine Vinaigrette 2oz',
         'allergens': [],
         'cuppingContainer': '2 oz WINPAK',
         'usage': {
@@ -1173,7 +1173,7 @@ mock_formatted_primaryRecipeComponents = [
             'unit': 'lb'
         }],
         'binWeight': {
-            'value': 60,
+            'value': 60.0,
             'unit': 'lb'
         },
         'instructions': [],


### PR DESCRIPTION
## Description
This updates ops queries to use ingredient names instead of externalNames in primary components.

## Test Plan
in a python console:
```
from galley.formatted_ops_queries import *
get_formatted_ops_menu_data(dates=['2022-10-31'])
```
Check that you see `'spring mix & arugula PF, SEND TO PLATE'` instead of `'Spring Mix Lettuce*, Baby Arugula*'` in the output
