### PR TITLE
VEG-249: update ingredient handling

### DIFF
--- a/galley/formatted_queries.py
+++ b/galley/formatted_queries.py
@@ -25,8 +25,8 @@ def get_external_name_for_ingredient(ingredient: Dict) -> Optional[str]:
 
 
 def get_primary_vendor_item_for_ingredient(ingredient: Dict) -> Optional[Dict]:
-    locationVendorItems: Dict = next(iter(ingredient.get('locationVendorItems',[])),{})
-    vendorItems: List = locationVendorItems.get('vendorItems',[])
+    locationVendorItems: Dict = next(iter(ingredient.get('locationVendorItems') or []),{})
+    vendorItems: List = locationVendorItems.get('vendorItems') or []
     return (
         next((vendorItem for vendorItem in vendorItems if vendorItem.get('priority') == 0 and vendorItem['ingredientListStr']),None)
         or next(iter(vendorItems), None)

--- a/galley/formatted_queries.py
+++ b/galley/formatted_queries.py
@@ -19,13 +19,14 @@ logger = logging.getLogger(__name__)
 
 
 def get_external_name_for_ingredient(ingredient: Dict) -> Optional[str]:
-    name =  (ingredient.get("externalName") or ingredient.get("name"))
+    name = (ingredient.get("externalName") or ingredient.get("name"))
     ingredientListStr = (get_primary_vendor_item_for_ingredient(ingredient) or {}).get("ingredientListStr")
     return f"{name} ({ingredientListStr})" if name and ingredientListStr else name
 
 
 def get_primary_vendor_item_for_ingredient(ingredient: Dict) -> Optional[Dict]:
-    vendorItems = next(iter(ingredient.get('locationVendorItems',[])),{}).get('vendorItems',[])
+    locationVendorItems: Dict = next(iter(ingredient.get('locationVendorItems',[])),{})
+    vendorItems: List = locationVendorItems.get('vendorItems',[])
     return (
         next((vendorItem for vendorItem in vendorItems if vendorItem.get('priority') == 0 and vendorItem['ingredientListStr']),None)
         or next(iter(vendorItems), None)

--- a/galley/queries.py
+++ b/galley/queries.py
@@ -93,12 +93,14 @@ def recipe_connection_query(
     query.viewer.recipeConnection.edges.node.recipeItems.subRecipe.reconciledNutritionals(location_id=location_id)
     query.viewer.recipeConnection.edges.node.recipeItems.ingredient.\
         __fields__('id', 'name', 'externalName', 'categoryValues')
+    query.viewer.recipeConnection.edges.node.recipeItems.ingredient.locationVendorItems(location_ids=location_id)
     query.viewer.recipeConnection.edges.node.recipeTreeComponents(levels=[1]).\
         __fields__('id', 'quantity', 'unit', 'quantityUnitValues')
     query.viewer.recipeConnection.edges.node.recipeTreeComponents.recipeItem.\
         __fields__('quantity', 'unit', 'preparations', 'subRecipeId')
     query.viewer.recipeConnection.edges.node.recipeTreeComponents.recipeItem.ingredient.\
         __fields__('name','externalName', 'categoryValues')
+    query.viewer.recipeConnection.edges.node.recipeTreeComponents.recipeItem.ingredient.locationVendorItems(location_ids=location_id)
     query.viewer.recipeConnection.edges.node.recipeTreeComponents.recipeItem.subRecipe.\
         __fields__('id', 'externalName', 'name', 'allIngredients', 'nutritionalsQuantity', 'nutritionalsUnit')
     query.viewer.recipeConnection.edges.node.recipeTreeComponents.recipeItem.subRecipe.reconciledNutritionals(location_id=location_id)
@@ -108,6 +110,7 @@ def recipe_connection_query(
         __fields__('totalQuantity', 'unit', 'totalQuantityUnitValues')
     query.viewer.recipeConnection.edges.node.recipeTreeComponents.recipeItem.subRecipe.allIngredientsWithUsages.ingredient.\
         __fields__('id', 'externalName', 'name')
+    query.viewer.recipeConnection.edges.node.recipeTreeComponents.recipeItem.subRecipe.allIngredientsWithUsages.ingredient.locationVendorItems(location_ids=location_id)
     query.viewer.recipeConnection.edges.node.reconciledNutritionals(location_id=location_id)
     query.viewer.recipeConnection.edges.node.dietaryFlagsWithUsages(location_id=location_id).dietaryFlag.\
         __fields__('id')

--- a/galley/types.py
+++ b/galley/types.py
@@ -93,13 +93,23 @@ class Nutrition(Type):
     zincPercentRDI = float
 
 
+class VendorItem(Type):
+    name = str
+    priority = int
+    ingredientListStr = str
+
+
+class LocationVendorItem(Type):
+    vendorItems = Field(list_of(VendorItem))
+
+
 class Ingredient(Type):
     id = Field(ID)
     name = str
     externalName = str
     categoryValues = Field(CategoryValue)
     dietaryFlags = Field('DietaryFlag')
-
+    locationVendorItems = Field(list_of(LocationVendorItem), args=ArgDict(location_ids=ID))
 
 class RecipeInstruction(Type):
     text = str

--- a/tests/test_formatted_queries.py
+++ b/tests/test_formatted_queries.py
@@ -277,41 +277,40 @@ class TestIngredientExternalName(TestCase):
         self.assertEqual(result, ingredient['externalName'])
 
     def test_should_return_external_name_plus_ingredientListStr_if_ingredientListStr(self):
-        FIRST_LOCATION_VENDOR_ITEM = 0
-        FIRST_VENDOR_ITEM = 0
+        EXTERNAL_NAME = 'Garlic'
+        INGREDIENT_STRING = 'Stuff, Water'
         ingredient = {
-            'externalName': 'Garlic',
+            'externalName': EXTERNAL_NAME,
             'locationVendorItems': [{
                 'vendorItems': [{
-                    "ingredientListStr": "Stuff, Water"
+                    'ingredientListStr': INGREDIENT_STRING
                 }]
             }]
         }
         result = get_external_name_for_ingredient(ingredient)
-        expected_ing_str = f"{ingredient['externalName']} ({ingredient['locationVendorItems'][FIRST_LOCATION_VENDOR_ITEM]['vendorItems'][FIRST_VENDOR_ITEM]['ingredientListStr']})"
-        self.assertEqual(result, expected_ing_str)
+        self.assertEqual(result,  f'{EXTERNAL_NAME} ({INGREDIENT_STRING})')
 
     def test_should_return_ingredientListStr_of_vendorItem_with_priority(self):
-        FIRST_LOCATION_VENDOR_ITEM = 0
-        PRIORITY_VENDOR_ITEM = 1
+        EXTERNAL_NAME = 'Garlic'
+        INGREDIENT_STRING = 'Stuff, Water'
+        PRIORITY_INGREDIENT_STRING = 'Priority Stuff, Water'
         ingredient = {
-            'externalName': 'Garlic',
+            'externalName':  EXTERNAL_NAME,
             'locationVendorItems': [{
                 'vendorItems': [
                     {
-                         "priority": 1,
-                        "ingredientListStr": "Stuff, Water"
+                        'priority': 1,
+                        'ingredientListStr': INGREDIENT_STRING
                     },
                      {
-                        "priority": 0,
-                        "ingredientListStr": "Priority Stuff, Water"
+                        'priority': 0,
+                        'ingredientListStr': PRIORITY_INGREDIENT_STRING
                     }
                 ]
             }]
         }
         result = get_external_name_for_ingredient(ingredient)
-        expected_ing_str = f"{ingredient['externalName']} ({ingredient['locationVendorItems'][FIRST_LOCATION_VENDOR_ITEM]['vendorItems'][PRIORITY_VENDOR_ITEM]['ingredientListStr']})"
-        self.assertEqual(result, expected_ing_str)
+        self.assertEqual(result, f'{EXTERNAL_NAME} ({PRIORITY_INGREDIENT_STRING})')
 
 
 class TestRecipeItemLabelName(TestCase):

--- a/tests/test_formatted_queries.py
+++ b/tests/test_formatted_queries.py
@@ -290,6 +290,21 @@ class TestIngredientExternalName(TestCase):
         result = get_external_name_for_ingredient(ingredient)
         self.assertEqual(result,  f'{EXTERNAL_NAME} ({INGREDIENT_STRING})')
 
+    def test_should_return_name_plus_ingredientListStr_if_name_and_ingredientListStr_and_no_externalName(self):
+        NAME = 'Garlic'
+        INGREDIENT_STRING = 'Stuff, Water'
+        ingredient = {
+            'externalName': None,
+            'name': NAME,
+            'locationVendorItems': [{
+                'vendorItems': [{
+                    'ingredientListStr': INGREDIENT_STRING
+                }]
+            }]
+        }
+        result = get_external_name_for_ingredient(ingredient)
+        self.assertEqual(result,  f'{NAME} ({INGREDIENT_STRING})')
+
     def test_should_return_ingredientListStr_of_vendorItem_with_priority(self):
         EXTERNAL_NAME = 'Garlic'
         INGREDIENT_STRING = 'Stuff, Water'

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -222,60 +222,67 @@ def get_argument_from_query_selector(selection: Selection, key: str) -> Any:
 # this is the pattern going forward for testing queries
 class TestRecipeConnectionQuery(TestCase):
     def test_recipe_connection_query_should_include_reconciledNutritionals_with_locationId_on_node(self):
+        LOCATION_ID = 'test'
         query = recipe_connection_query(
             recipe_ids=['test-recipe-id'],
-            location_id='test'
+            location_id=LOCATION_ID
         )
         location_id_value = get_argument_from_query_selector(query.viewer.recipeConnection.edges.node.reconciledNutritionals, 'location_id')
-        self.assertEqual(location_id_value, 'test')
+        self.assertEqual(location_id_value, LOCATION_ID)
 
     def test_recipe_connection_query_should_include_reconciledNutritionals_with_locationId_on_recipeItems_subRecipe(self):
+        LOCATION_ID = 'test'
         query = recipe_connection_query(
             recipe_ids=['test-recipe-id'],
-            location_id='test'
+            location_id=LOCATION_ID
         )
         location_id_value = get_argument_from_query_selector(query.viewer.recipeConnection.edges.node.recipeItems.subRecipe.reconciledNutritionals, 'location_id')
-        self.assertEqual(location_id_value, 'test')
+        self.assertEqual(location_id_value, LOCATION_ID)
 
     def test_recipe_connection_query_should_include_reconciledNutritionals_with_locationId_on_recipeTreeComponents(self):
+        LOCATION_ID = 'test'
         query = recipe_connection_query(
             recipe_ids=['test-recipe-id'],
-            location_id='test'
+            location_id=LOCATION_ID
         )
         location_id_value = get_argument_from_query_selector(query.viewer.recipeConnection.edges.node.recipeTreeComponents.recipeItem.subRecipe.reconciledNutritionals, 'location_id')
-        self.assertEqual(location_id_value, 'test')
+        self.assertEqual(location_id_value, LOCATION_ID)
 
     def test_recipe_connection_query_should_include_dietaryFlagsWithUsages_with_locationId(self):
+        LOCATION_ID = 'test'
         query = recipe_connection_query(
             recipe_ids=['test-recipe-id'],
-            location_id='test'
+            location_id=LOCATION_ID
         )
         location_id_value = get_argument_from_query_selector(query.viewer.recipeConnection.edges.node.dietaryFlagsWithUsages, 'location_id')
-        self.assertEqual(location_id_value, 'test')
+        self.assertEqual(location_id_value, LOCATION_ID)
 
     def test_recipe_connection_query_should_include_locationVendorItems_with_locationIds_on_recipeItem(self):
+        LOCATION_ID = 'test'
         query = recipe_connection_query(
             recipe_ids=['test-recipe-id'],
-            location_id='test'
+            location_id=LOCATION_ID
         )
         location_id_value = get_argument_from_query_selector(query.viewer.recipeConnection.edges.node.recipeItems.ingredient.locationVendorItems, 'location_ids')
-        self.assertEqual(location_id_value, 'test')
+        self.assertEqual(location_id_value, LOCATION_ID)
 
     def test_recipe_connection_query_should_include_locationVendorItems_with_locationIds_on_recipeTreeComponents_recipeItem(self):
+        LOCATION_ID = 'test'
         query = recipe_connection_query(
             recipe_ids=['test-recipe-id'],
-            location_id='test'
+            location_id=LOCATION_ID
         )
         location_id_value = get_argument_from_query_selector(query.viewer.recipeConnection.edges.node.recipeTreeComponents.recipeItem.ingredient.locationVendorItems, 'location_ids')
-        self.assertEqual(location_id_value, 'test')
+        self.assertEqual(location_id_value, LOCATION_ID)
 
     def test_recipe_connection_query_should_include_locationVendorItems_with_locationIds_on_allIngredientsWithUsages(self):
+        LOCATION_ID = 'test'
         query = recipe_connection_query(
             recipe_ids=['test-recipe-id'],
-            location_id='test'
+            location_id=LOCATION_ID
         )
         location_id_value = get_argument_from_query_selector(query.viewer.recipeConnection.edges.node.recipeTreeComponents.recipeItem.subRecipe.allIngredientsWithUsages.ingredient.locationVendorItems, 'location_ids')
-        self.assertEqual(location_id_value, 'test')
+        self.assertEqual(location_id_value, LOCATION_ID)
 
 class TestQueryGetRawRecipesData(TestCase):
     @mock.patch('galley.queries.make_request_to_galley')


### PR DESCRIPTION
## Description
Please include a summary of the change. List any dependencies that are required for this pull request.

## Test Plan
1. In Galley staging, pull up a recipe like [Cuban Ropa Vieja with Plantains and Jackfruit Ropa Vieja](https://staging-app.galleysolutions.com/recipes/cmVjaXBlOjE4NTUxMA==?userLocationId=bG9jYXRpb246MTkyOA%3D%3D) that has base recipe, and sub recipes with multiple vendor items.
2. Navigate to a location specific vendor item (West or East Coast) for a sub recipe, and add ingredients to the ingredients list field. Repeat for another sub recipe. 
3. In the galley-sdk virtual environment, call `get_formatted_recipes_data` and `get_raw_recipes_data` with the recipe id and location name of the vendor item you modified. Example queries for Cuban Ropa Vieja, Burlington:
```
import galley
from galley.queries import *
from galley.formatted_queries import *

get_raw_recipes_data(recipe_ids=['cmVjaXBlOjE4NTUxMA==], location_name='Burlington')
get_formatted_recipes_data(recipe_ids=['cmVjaXBlOjE4NTUxMA=='], location_name='Burlington')

```
4. Verify that your modifications from Galley are present in the results. 
 - For `get_raw_recipes_data`, the ingredient list items you added  should be present in square brackets after the ingredient at the sub recipe level. 
 - For the `get_formatted_recipes_data` result, the ingredient list items you added should be present in parenthesis after the ingredient.  
5. Repeat these calls with the opposite location name, and verify that the return data matches what is in Galley for that location. 
## Versioning
0.43.0

