### PR TITLE
(HRB-346) Reduce default page size to 20

### DIFF
--- a/galley/queries.py
+++ b/galley/queries.py
@@ -17,7 +17,7 @@ from galley.types import (FilterInput, Menu, MenuFilterInput,
 logger = logging.getLogger(__name__)
 
 
-DEFAULT_PAGE_SIZE = 25
+DEFAULT_PAGE_SIZE = 20
 
 
 class Viewer(Type):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # are dependencies that are required on remote installs, not local development.
 setup(
     name='galley_sdk',
-    version='0.43.0',
+    version='0.44.0',
     packages=['galley'],
     install_requires=['sgqlc==14.0', 'backoff==1.11.1']
 )


### PR DESCRIPTION
## Description
This reduces the default page size used for queries to Galley's API to 20 instead of 25, upon request from Galley's engineering team. They are experiencing performance issues related to our queries and think a smaller max page size will help.
## Test Plan
You can test that the default page size var can safely be changed in this way by setting it to a low number (like 2) and pulling a batch of recipe details, then setting to to _another_ low number (like 3) and pulling the same batch. The output you receive should be the same no matter what the page size var is. To retrieve recipe details:
- Enter the shell via `python`
- `import galley`
- `from galley.queries import *`
- `recipe_ids = ["cmVjaXBlOjE2NDgzNQ==", "cmVjaXBlOjE2NTE3NA==", "cmVjaXBlOjE2NTE3NQ==", "cmVjaXBlOjE2NTE3Ng==", "cmVjaXBlOjE2NTE3OQ=="]`
- `get_formatted_recipes_data(recipe_ids=recipe_ids, location_name='Burlington')`
## Versioning
- [ X] Please update the project version in setup.py
