### PR TITLE
(ENG-1675) Refactor menu ops query

### DIFF
--- a/galley/formatted_ops_queries.py
+++ b/galley/formatted_ops_queries.py
@@ -229,11 +229,10 @@ def build_recipe_tree(acc: Tuple[Dict, Dict], rtc: Dict) -> Tuple[Dict, Dict]:
 
     if len(ancestors) == 0:
         tree['recipe'] = rtc
-
-    if 0 < len(ancestors) <= 3:
+    else:
         parent = components[ancestors[-1]]
         parent.setdefault('components', []).append(rtc)
-    return tree, components
+    return acc
 
 
 def format_components(rtc: List) -> List[Dict]:

--- a/galley/queries.py
+++ b/galley/queries.py
@@ -159,6 +159,7 @@ def get_ops_menu_query(dates: List[str], location_id: str) -> Operation:
     query.viewer.menus.menuItems.__fields__('id', 'recipeId', 'categoryValues', 'volume')
     query.viewer.menus.menuItems.unit.__fields__('id', 'name')
     query.viewer.menus.menuItems.recipe.__fields__('id', 'name', 'categoryValues', 'files')
+    query.viewer.menus.menuItems.recipe.recipeTreeComponents(levels=[0, 1, 2, 3])
     query.viewer.menus.menuItems.recipe.recipeTreeComponents.__fields__('id', 'ancestorComponentIds', 'quantity')
     query.viewer.menus.menuItems.recipe.recipeTreeComponents.unit.__fields__('id', 'name')
     query.viewer.menus.menuItems.recipe.recipeTreeComponents.unit.unitValues.__fields__('value')

--- a/galley/queries.py
+++ b/galley/queries.py
@@ -156,28 +156,19 @@ def get_menu_query(dates: List[str], location_id: str) -> Operation:
 def get_ops_menu_query(dates: List[str], location_id: str) -> Operation:
     query = Operation(Query)
     query.viewer.menus(where=MenuFilterInput(date=dates, locationId=location_id)).__fields__('id', 'name', 'date', 'location', 'categoryValues', 'menuItems')
-    query.viewer.menus.menuItems.__fields__('id', 'recipeId', 'categoryValues', 'recipe', 'volume')
+    query.viewer.menus.menuItems.__fields__('id', 'recipeId', 'categoryValues', 'volume')
     query.viewer.menus.menuItems.unit.__fields__('id', 'name')
-    query.viewer.menus.menuItems.recipe.files.__fields__('photos')
-    query.viewer.menus.menuItems.recipe.__fields__('id', 'name', 'categoryValues')
-    query.viewer.menus.menuItems.recipe.files.photos.__fields__('sourceUrl', 'caption')
-    # query top level recipeTreeComponents
-    query.viewer.menus.menuItems.recipe.recipeTreeComponents(levels=[1]).__fields__('quantityUnitValues', 'quantity')
+    query.viewer.menus.menuItems.recipe.__fields__('id', 'name', 'categoryValues', 'files')
+    query.viewer.menus.menuItems.recipe.recipeTreeComponents.__fields__('id', 'ancestorComponentIds', 'quantity')
     query.viewer.menus.menuItems.recipe.recipeTreeComponents.unit.__fields__('id', 'name')
-    query.viewer.menus.menuItems.recipe.recipeTreeComponents.recipeItem.__fields__('preparations')
+    query.viewer.menus.menuItems.recipe.recipeTreeComponents.unit.unitValues.__fields__('value')
+    query.viewer.menus.menuItems.recipe.recipeTreeComponents.unit.unitValues.unit.__fields__('id', 'name')
+    query.viewer.menus.menuItems.recipe.recipeTreeComponents.recipeItem.__fields__('preparations', 'quantity')
+    query.viewer.menus.menuItems.recipe.recipeTreeComponents.recipeItem.unit.__fields__('id', 'name')
+    query.viewer.menus.menuItems.recipe.recipeTreeComponents.recipeItem.ingredient.locationVendorItems(location_ids=[location_id])
     query.viewer.menus.menuItems.recipe.recipeTreeComponents.recipeItem.ingredient.__fields__('id', 'name', 'externalName', 'categoryValues', 'dietaryFlags')
-    query.viewer.menus.menuItems.recipe.recipeTreeComponents.recipeItem.subRecipe.__fields__('id', 'name', 'externalName', 'categoryValues', 'recipeInstructions', 'dietaryFlagsWithUsages')
-    # query second level recipeTreeComponents
-    query.viewer.menus.menuItems.recipe.recipeTreeComponents.recipeItem.subRecipe.recipeTreeComponents(levels=[1]).__fields__('quantityUnitValues', 'quantity')
-    query.viewer.menus.menuItems.recipe.recipeTreeComponents.recipeItem.subRecipe.recipeTreeComponents.unit.__fields__('id', 'name')
-    query.viewer.menus.menuItems.recipe.recipeTreeComponents.recipeItem.subRecipe.recipeTreeComponents.recipeItem.__fields__('preparations')
-    query.viewer.menus.menuItems.recipe.recipeTreeComponents.recipeItem.subRecipe.recipeTreeComponents.recipeItem.ingredient.__fields__('id', 'name', 'externalName', 'categoryValues', 'dietaryFlags')
-    query.viewer.menus.menuItems.recipe.recipeTreeComponents.recipeItem.subRecipe.recipeTreeComponents.recipeItem.subRecipe.__fields__('id', 'name', 'externalName', 'categoryValues', 'recipeInstructions', 'dietaryFlagsWithUsages')
-    # query third level recipeTreeComponents
-    query.viewer.menus.menuItems.recipe.recipeTreeComponents.recipeItem.subRecipe.recipeTreeComponents.recipeItem.subRecipe.recipeTreeComponents(levels=[1]).__fields__('quantity')
-    query.viewer.menus.menuItems.recipe.recipeTreeComponents.recipeItem.subRecipe.recipeTreeComponents.recipeItem.subRecipe.recipeTreeComponents.unit.__fields__('id', 'name')
-    query.viewer.menus.menuItems.recipe.recipeTreeComponents.recipeItem.subRecipe.recipeTreeComponents.recipeItem.subRecipe.recipeTreeComponents.recipeItem.ingredient.__fields__('id', 'name', 'externalName', 'dietaryFlags')
-    query.viewer.menus.menuItems.recipe.recipeTreeComponents.recipeItem.subRecipe.recipeTreeComponents.recipeItem.subRecipe.recipeTreeComponents.recipeItem.subRecipe.__fields__('id', 'name', 'externalName', 'dietaryFlagsWithUsages')
+    query.viewer.menus.menuItems.recipe.recipeTreeComponents.recipeItem.subRecipe.__fields__('id', 'name', 'externalName', 'categoryValues', 'recipeInstructions')
+    query.viewer.menus.menuItems.recipe.recipeTreeComponents.recipeItem.subRecipe.dietaryFlagsWithUsages(location_id=location_id)
     return query
 
 
@@ -185,7 +176,7 @@ def get_raw_menu_data(
     dates: List[str],
     location_name: str,
     menu_type: str,
-    is_ops: bool=False,
+    is_ops: bool = False,
 ) -> Optional[List[Dict]]:
     """
     Returns a list of dictionaries containing the menu data for the week.

--- a/galley/types.py
+++ b/galley/types.py
@@ -129,6 +129,7 @@ class RecipeTreeComponent(Type):
     quantityUnitValues = Field(UnitValue)
     ingredient = Field(Ingredient)
     recipeItem = Field('RecipeItem')
+    ancestorComponentIds = Field(list_of(ID))
 
 
 class AncestorRecipe(Type):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # are dependencies that are required on remote installs, not local development.
 setup(
     name='galley_sdk',
-    version='0.45.0',
+    version='0.46.0',
     packages=['galley'],
     install_requires=['sgqlc==14.0', 'backoff==1.11.1']
 )

--- a/tests/mock_responses/mock_ops_menu_data.py
+++ b/tests/mock_responses/mock_ops_menu_data.py
@@ -235,60 +235,6 @@ MOCK_RECIPE_TREE_COMPONENTS = [
         }
     },
     {
-        "id": "j3k9vc4ai2",
-        "ancestorComponentIds": [
-            "x5ccun97m7",
-            "k41l3crd8of",
-            "d44pdeapsdk",
-            "wuet0e3vilq"
-        ],
-        "quantity": 0.06009615379315811,
-        "unit": {
-            "id": UnitEnum.LB.value,
-            "name": "lb",
-            "unitValues": [
-                {
-                    "value": 453.59237,
-                    "unit": {
-                        "id": UnitEnum.G.value,
-                        "name": "g"
-                    }
-                },
-                {
-                    "value": 16.000000014109585,
-                    "unit": {
-                        "id": UnitEnum.OZ.value,
-                        "name": "oz"
-                    }
-                },
-                {
-                    "value": 1,
-                    "unit": {
-                        "id": UnitEnum.LB.value,
-                        "name": "lb"
-                    }
-                }
-            ]
-        },
-        "recipeItem": {
-            "preparations": [],
-            "quantity": 75,
-            "unit": {
-                "id": UnitEnum.LB.value,
-                "name": "lb"
-            },
-            "ingredient": {
-                "locationVendorItems": [],
-                "id": "aW5ncmVkaWVudDoyNDQ3NDQ=",
-                "name": "quinoa, rainbow, dry",
-                "externalName": "Quinoa",
-                "categoryValues": [],
-                "dietaryFlags": []
-            },
-            "subRecipe": None
-        }
-    },
-    {
         "id": "ss91mevjky",
         "ancestorComponentIds": [
             "x5ccun97m7",
@@ -417,60 +363,6 @@ MOCK_RECIPE_TREE_COMPONENTS = [
                 ],
                 "dietaryFlagsWithUsages": []
             }
-        }
-    },
-    {
-        "id": "vy2t2yi9vkj",
-        "ancestorComponentIds": [
-            "x5ccun97m7",
-            "k41l3crd8of",
-            "d44pdeapsdk",
-            "a3rm32jf58"
-        ],
-        "quantity": 0.001644736839204444,
-        "unit": {
-            "id": UnitEnum.LB.value,
-            "name": "lb",
-            "unitValues": [
-                {
-                    "value": 453.59237,
-                    "unit": {
-                        "id": UnitEnum.G.value,
-                        "name": "g"
-                    }
-                },
-                {
-                    "value": 16.000000014109585,
-                    "unit": {
-                        "id": UnitEnum.OZ.value,
-                        "name": "oz"
-                    }
-                },
-                {
-                    "value": 1,
-                    "unit": {
-                        "id": UnitEnum.LB.value,
-                        "name": "lb"
-                    }
-                }
-            ]
-        },
-        "recipeItem": {
-            "preparations": [],
-            "quantity": 2,
-            "unit": {
-                "id": UnitEnum.LB.value,
-                "name": "lb"
-            },
-            "ingredient": {
-                "locationVendorItems": [],
-                "id": "aW5ncmVkaWVudDoyNDk1NDE=",
-                "name": "onion, green (scallion), whole",
-                "externalName": "Scallion",
-                "categoryValues": [],
-                "dietaryFlags": []
-            },
-            "subRecipe": None
         }
     },
     {
@@ -613,60 +505,6 @@ MOCK_RECIPE_TREE_COMPONENTS = [
         }
     },
     {
-        "id": "bwcj1c4z5zm",
-        "ancestorComponentIds": [
-            "x5ccun97m7",
-            "k41l3crd8of",
-            "hdeta8wr90j",
-            "trr5acd7ly"
-        ],
-        "quantity": 0.022321428551744446,
-        "unit": {
-            "id": UnitEnum.LB.value,
-            "name": "lb",
-            "unitValues": [
-                {
-                    "value": 453.59237,
-                    "unit": {
-                        "id": UnitEnum.G.value,
-                        "name": "g"
-                    }
-                },
-                {
-                    "value": 16.000000014109585,
-                    "unit": {
-                        "id": UnitEnum.OZ.value,
-                        "name": "oz"
-                    }
-                },
-                {
-                    "value": 1,
-                    "unit": {
-                        "id": UnitEnum.LB.value,
-                        "name": "lb"
-                    }
-                }
-            ]
-        },
-        "recipeItem": {
-            "preparations": [],
-            "quantity": 20,
-            "unit": {
-                "id": UnitEnum.LB.value,
-                "name": "lb"
-            },
-            "ingredient": {
-                "locationVendorItems": [],
-                "id": "aW5ncmVkaWVudDoyNDQ5MDU=",
-                "name": "vinegar, apple cider",
-                "externalName": "Apple Cider Vinegar",
-                "categoryValues": [],
-                "dietaryFlags": []
-            },
-            "subRecipe": None
-        }
-    },
-    {
         "id": "oz9yp3l0aek",
         "ancestorComponentIds": [
             "x5ccun97m7",
@@ -733,65 +571,6 @@ MOCK_RECIPE_TREE_COMPONENTS = [
                     }
                 ]
             }
-        }
-    },
-    {
-        "id": "x133e7x7hp",
-        "ancestorComponentIds": [
-            "x5ccun97m7",
-            "k41l3crd8of",
-            "hdeta8wr90j",
-            "oz9yp3l0aek"
-        ],
-        "quantity": 0.09374999991732666,
-        "unit": {
-            "id": UnitEnum.LB.value,
-            "name": "lb",
-            "unitValues": [
-                {
-                    "value": 453.59237,
-                    "unit": {
-                        "id": UnitEnum.G.value,
-                        "name": "g"
-                    }
-                },
-                {
-                    "value": 16.000000014109585,
-                    "unit": {
-                        "id": UnitEnum.OZ.value,
-                        "name": "oz"
-                    }
-                },
-                {
-                    "value": 1,
-                    "unit": {
-                        "id": UnitEnum.LB.value,
-                        "name": "lb"
-                    }
-                }
-            ]
-        },
-        "recipeItem": {
-            "preparations": [],
-            "quantity": 40,
-            "unit": {
-                "id": UnitEnum.LB.value,
-                "name": "lb"
-            },
-            "ingredient": {
-                "locationVendorItems": [],
-                "id": "aW5ncmVkaWVudDoyNDQ4Nzc=",
-                "name": "tofu, firm",
-                "externalName": "Tofu",
-                "categoryValues": [],
-                "dietaryFlags": [
-                    {
-                        "id": DietaryFlagEnum.SOY_BEANS.value,
-                        "name": "soybeans"
-                    }
-                ]
-            },
-            "subRecipe": None
         }
     },
     {
@@ -1704,60 +1483,6 @@ MOCK_RECIPE_TREE_COMPONENTS = [
                 ],
                 "dietaryFlagsWithUsages": []
             }
-        }
-    },
-    {
-        "id": "tv3haa35fk",
-        "ancestorComponentIds": [
-            "x5ccun97m7",
-            "9ty070197l",
-            "arlkvxgdzvv",
-            "4pf3lu669b"
-        ],
-        "quantity": 0.00520833332874037,
-        "unit": {
-            "id": UnitEnum.LB.value,
-            "name": "lb",
-            "unitValues": [
-                {
-                    "value": 453.59237,
-                    "unit": {
-                        "id": UnitEnum.G.value,
-                        "name": "g"
-                    }
-                },
-                {
-                    "value": 16.000000014109585,
-                    "unit": {
-                        "id": UnitEnum.OZ.value,
-                        "name": "oz"
-                    }
-                },
-                {
-                    "value": 1,
-                    "unit": {
-                        "id": UnitEnum.LB.value,
-                        "name": "lb"
-                    }
-                }
-            ]
-        },
-        "recipeItem": {
-            "preparations": [],
-            "quantity": 40,
-            "unit": {
-                "id": UnitEnum.LB.value,
-                "name": "lb"
-            },
-            "ingredient": {
-                "locationVendorItems": [],
-                "id": "aW5ncmVkaWVudDoyNDQ0NjI=",
-                "name": "garlic, cloves",
-                "externalName": "Garlic",
-                "categoryValues": [],
-                "dietaryFlags": []
-            },
-            "subRecipe": None
         }
     },
     {

--- a/tests/mock_responses/mock_ops_menu_data.py
+++ b/tests/mock_responses/mock_ops_menu_data.py
@@ -1,441 +1,91 @@
 from galley.common import DEFAULT_LOCATION, DEFAULT_MENU_TYPE
-from galley.enums import MenuCategoryEnum, MenuItemCategoryEnum, PreparationEnum, RecipeCategoryTagTypeEnum, IngredientCategoryValueEnum, DietaryFlagEnum
+from galley.enums import IngredientCategoryTagTypeEnum, MenuCategoryEnum, MenuItemCategoryEnum, PreparationEnum, RecipeCategoryTagTypeEnum, IngredientCategoryValueEnum, DietaryFlagEnum, UnitEnum
 
-mock_recipeTreeComponents = [
+
+MOCK_RECIPE_TREE_COMPONENTS = [
     {
-        'quantity': 8.85,
-        'unit': {
-            'id': 'dW5pdDoz',
-            'name': 'oz'
-        },
-        'quantityUnitValues': [
-            {
-                'unit': { 'id': 'dW5pdDox', 'name': 'g' },
-                'value': 250.893279435
-            },
-            {
-                'unit': { 'id': 'dW5pdDoy', 'name': 'kg' },
-                'value': 0.250893279435
-            },
-            {
-                'unit': { 'id': 'dW5pdDoz', 'name': 'oz' },
-                'value': 8.85
-            },
-            {
-                'unit': { 'id': 'dW5pdDo0', 'name': 'lb' },
-                'value': 0.5531249995122273
-            },
-            {
-                'unit': { 'id': 'dW5pdDoxNA==','name': 'each' },
-                'value': 1
-            }
-        ],
-        'recipeItem': {
-            'preparations': [
+        "id": "x5ccun97m7",
+        "ancestorComponentIds": [],
+        "quantity": 1,
+        "unit": {
+            "id": UnitEnum.EACH.value,
+            "name": "each",
+            "unitValues": [
                 {
-                    'id': PreparationEnum.CORE_RECIPE.value,
-                    'name': 'Base Recipe'
+                    "value": 1,
+                    "unit": {
+                        "id": UnitEnum.EACH.value,
+                        "name": "each"
+                    }
+                }
+            ]
+        },
+        "recipeItem": None
+    },
+    {
+        "id": "k41l3crd8of",
+        "ancestorComponentIds": [
+            "x5ccun97m7"
+        ],
+        "quantity": 1,
+        "unit": {
+            "id": UnitEnum.EACH.value,
+            "name": "each",
+            "unitValues": [
+                {
+                    "value": 222.54375633499996,
+                    "unit": {
+                        "id": UnitEnum.G.value,
+                        "name": "g"
+                    }
+                },
+                {
+                    "value": 7.85,
+                    "unit": {
+                        "id": UnitEnum.OZ.value,
+                        "name": "oz"
+                    }
+                },
+                {
+                    "value": 0.4906249995673427,
+                    "unit": {
+                        "id": UnitEnum.LB.value,
+                        "name": "lb"
+                    }
+                },
+                {
+                    "value": 1,
+                    "unit": {
+                        "id": UnitEnum.EACH.value,
+                        "name": "each"
+                    }
+                }
+            ]
+        },
+        "recipeItem": {
+            "preparations": [
+                {
+                    "id": PreparationEnum.CORE_RECIPE.value,
+                    "name": "Core Recipe"
                 }
             ],
-            'ingredient': None,
-            'subRecipe': {
-                'externalName': None,
-                'id': 'cmVjaXBlOjE5MjY1NA==',
-                'name': 'Greek Salad with Crispy Chickpeas BASE',
-                'recipeInstructions': [],
-                'categoryValues': [],
-                'dietaryFlagsWithUsages': [
+            "quantity": 1,
+            "unit": {
+                "id": UnitEnum.EACH.value,
+                "name": "each"
+            },
+            "ingredient": None,
+            "subRecipe": {
+                "id": "cmVjaXBlOjE5MjY1NA==",
+                "name": "Greek Salad with Crispy Chickpeas BASE",
+                "externalName": None,
+                "categoryValues": [],
+                "recipeInstructions": [],
+                "dietaryFlagsWithUsages": [
                     {
-                        'dietaryFlag': {
-                            'id': 'ZGlldGFyeUZsYWc6Ng==',
-                            'name': 'soy beans'
-                        }
-                    }
-                ],
-                'recipeTreeComponents': [
-                    {
-                        'quantity': 4,
-                        'unit': {
-                            'id': 'dW5pdDoz',
-                            'name': 'oz'
-                        },
-                        'quantityUnitValues': [
-                            {
-                                'unit': { 'id': 'dW5pdDox', 'name': 'g'},
-                                'value': 113.3980924
-                            },
-                            {
-                                'unit': { 'id': 'dW5pdDoy', 'name': 'kg' },
-                                'value': 0.1133980924
-                            },
-                            {
-                                'unit': { 'id': 'dW5pdDoz', 'name': 'oz' },
-                                'value': 4
-                            },
-                            {
-                                'unit': { 'id': 'dW5pdDo0', 'name': 'lb' },
-                                'value': 0.2499999997795377
-                            },
-                            {
-                                'unit': { 'id': 'dW5pdDo4NDI0ODk=', 'name': 'batch' },
-                                'value': 0.004166666662992295
-                            },
-                            {
-                                'unit': { 'id': 'dW5pdDo5MjU0MjU=', 'name': 'min batch' },
-                                'value': 0.024999999977953772
-                            },
-                            {
-                                'unit': { 'id': 'dW5pdDo5MjU0MjY=', 'name': 'max batch' },
-                                'value': 0.004166666662992295
-                            }
-                        ],
-                        'recipeItem': {
-                            'preparations': [
-                                {
-                                    'id': PreparationEnum.TWO_OZ_RAM.value,
-                                    'name': '2 oz RAM'
-                                }
-                            ],
-                            'ingredient': None,
-                            'subRecipe': {
-                                'externalName': None,
-                                'id':'cmVjaXBlOjE4OTcwNA==',
-                                'name': 'Olive Red Pepper & Cucumber Quinoa Pilaf',
-                                'dietaryFlagsWithUsages': [],
-                                'categoryValues': [
-                                    {
-                                        "id": "Y2F0ZWdvcnlWYWx1ZToxODQ3NA==",
-                                        "name": "50",
-                                        "category": {
-                                            "id": "Y2F0ZWdvcnk6MzExOQ==",
-                                            "name": "bin weight",
-                                            "itemType": "recipe"
-                                        }
-                                    }
-                                ],
-                                'recipeInstructions': [
-                                    {
-                                        'position': 0,
-                                        'text': 'Stage lexans for mixing. With sleeved gloves, mix the cucumber, red bell pepper, olives, hemp seeds, parsley and scallions in the quinoa being sure to distribute each ingredient evenly.'
-                                    }
-                                ],
-                                'recipeTreeComponents': [
-                                    {
-                                        'quantity': 30,
-                                        'unit': {
-                                            'id': 'dW5pdDo0',
-                                            'name': 'lb'
-                                        },
-                                        'recipeItem': {
-                                            'ingredient': None,
-                                            'subRecipe': {
-                                                'id': 'cmVjaXBlOjE4ODYwNg==',
-                                                'name': 'Cooked Rainbow Quinoa',
-                                                'externalName': None,
-                                                'dietaryFlagsWithUsages': [],
-                                                'recipeInstructions': [
-                                                    {
-                                                        'position': 0,
-                                                        'text': 'Bring water in tilt skillet to a boil. Add quinoa to tilt skillet, no more than 75 lbs at a time.'
-                                                    },
-                                                    {
-                                                        'position': 1,
-                                                        'text': 'Simmer, close lid, and cook until tender, stirring occasionally to prevent dry spots in the corners.'
-                                                    },
-                                                    {
-                                                        'position': 2,
-                                                        'text': 'After 10 minutes turn off heat and let steam for 5 minutes.'
-                                                    },
-                                                    {
-                                                        'position': 3,
-                                                        'text': 'Scoop quinoa onto sheet trays to cool down.'
-                                                    }
-                                                ]
-                                            }
-                                        }
-                                    },
-                                    {
-                                        'quantity': 7,
-                                        'unit': {
-                                            'id': 'dW5pdDo0',
-                                            'name': 'lb'
-                                        },
-                                        'recipeItem': {
-                                            'ingredient': {
-                                                'id': 'aW5ncmVkaWVudDoyNDQ2Mzc=',
-                                                'name': 'olives, kalamata, sliced',
-                                                'externalName': 'Kalamata Olives',
-                                                'dietaryFlags': []
-                                            },
-                                            'subRecipe': None
-                                        }
-                                    },
-                                    {
-                                        'quantity': 8,
-                                        'unit': {
-                                            'id': 'dW5pdDoz',
-                                            'name': 'oz'
-                                        },
-                                        'recipeItem': {
-                                            'ingredient': None,
-                                            'subRecipe': {
-                                                'id': 'cmVjaXBlOjE3Mjk2NQ==',
-                                                'name': 'Sliced Scallion',
-                                                'externalName': None,
-                                                'dietaryFlagsWithUsages': [],
-                                                'recipeInstructions': [
-                                                    {
-                                                        'position': 0,
-                                                        'text': 'Pick off any stickers, twisty ties, or rubber bands from any bunched herbs.'
-                                                    },
-                                                    {
-                                                        'position': 1,
-                                                        'text': 'Using the 2 compartment sink, wash the produce well using a diluted veg wash solution.'
-                                                    },
-                                                    {
-                                                        'position': 2,
-                                                        'text': 'Once rinsed and visibly clean, strain onto perforated sheet trays.'
-                                                    },
-                                                    {
-                                                        'position': 3,
-                                                        'text': 'Let air dry on speed rack or spin dry using the electric spinner.'
-                                                    },
-                                                    {
-                                                        'position': 4,
-                                                        'text': 'Trim the tips of the scallions. Gather the scallions within your hand and line them up evenly slice across to make thin slices.'
-                                                    },
-                                                    {
-                                                        'position': 5,
-                                                        'text': 'Store in a cambro.'
-                                                    }
-                                                ]
-                                            }
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    },
-                    {
-                        'quantity': 1.5,
-                        'unit': {
-                            'id': 'dW5pdDoz',
-                            'name': 'oz'
-                        },
-                        'quantityUnitValues': [
-                            {
-                                'unit': { 'id': 'dW5pdDox', 'name': 'g' },
-                                'value': 42.52428465
-                            },
-                            {
-                                'unit': { 'id': 'dW5pdDoy', 'name': 'kg' },
-                                'value': 0.04252428465
-                            },
-                            {
-                                'unit': { 'id': 'dW5pdDoz', 'name': 'oz' },
-                                'value': 1.5
-                            },
-                            {
-                                'unit': { 'id': 'dW5pdDo0', 'name': 'lb' },
-                                'value': 0.09374999991732665
-                            },
-                            {
-                                'unit': { 'id': 'dW5pdDo5MjU0Mjc=', 'name': 'min batch' },
-                                'value': 0.009374999991732665
-                            },
-                            {
-                                'unit': { 'id': 'dW5pdDo5MjU0Mjg=', 'name': 'max batch' },
-                                'value': 0.0015624999986221107
-                            }
-                        ],
-                        'recipeItem': {
-                            'preparations': [
-                                {
-                                    'id': PreparationEnum.INSERT12.value,
-                                    'name': 'INSERT12'
-                                }
-                            ],
-                            'ingredient': None,
-                            'subRecipe': {
-                                'externalName': None,
-                                'id': 'cmVjaXBlOjE3NjQ3Mw==',
-                                'name': 'Tofu Feta',
-                                'categoryValues': [],
-                                'dietaryFlagsWithUsages': [
-                                    {
-                                        'dietaryFlag': {
-                                            'id': 'ZGlldGFyeUZsYWc6Ng==',
-                                            'name': 'soy beans'
-                                        }
-                                    }
-                                ],
-                                'recipeInstructions': [
-                                    {
-                                        'position': 0,
-                                        'text': 'Stage clear polycarbonate lexans for mixing and add brine for tofu feta.'
-                                    },
-                                    {
-                                        'position': 1,
-                                        'text': 'Dice Tofu into small 1/4" diced bite sized squares and add to each lexan, mixing well with the brine for tofu feta, being sure all of the tofu is submerged.'
-                                    },
-                                    {
-                                        'position': 2,
-                                        'text': 'Let sit at least 4 hours, best overnight.'
-                                    },
-                                    {
-                                        'position': 3,
-                                        'text': 'Strain well before serving.'
-                                    }
-                                ],
-                                'recipeTreeComponents': [
-                                    {
-                                        'quantity': 56,
-                                        'unit': {
-                                            'id': 'dW5pdDo0',
-                                            'name': 'lb'
-                                        },
-                                        'recipeItem': {
-                                            'ingredient': None,
-                                            'subRecipe': {
-                                                'id': 'cmVjaXBlOjE5MDA5MQ==',
-                                                'name': 'Small Diced Tofu (1/4")',
-                                                'externalName': None,
-                                                'dietaryFlagsWithUsages': [
-                                                    {
-                                                        'dietaryFlag': {
-                                                            'id': 'ZGlldGFyeUZsYWc6Ng==',
-                                                            'name': 'soy beans'
-                                                        }
-                                                    }
-                                                ],
-                                                'recipeInstructions': [
-                                                    {
-                                                        'position': 0,
-                                                        'text': 'Start by opening the bags of firm tofu over perforated lexans to strain any liquid.'
-                                                    },
-                                                    {
-                                                        'position': 1,
-                                                        'text': 'Dice the tofu into 1/4" pieces. Reserve in lexans.'
-                                                    }
-                                                ]
-                                            }
-                                        }
-                                    }
-                                ],
-                            }
-                        }
-                    },
-                    {
-                        'quantity': 2.5,
-                        'unit': {
-                            'id': 'dW5pdDoz',
-                            'name': 'oz'
-                        },
-                        'quantityUnitValues': [
-                            {
-                                'unit': { 'id': 'dW5pdDoz', 'name': 'oz' },
-                                'value': 2.5
-                            },
-                            {
-                                'unit': { 'id': 'dW5pdDo1', 'name': 'l' },
-                                'value': 0.4657752582200901
-                            },
-                            {
-                                'unit': { 'id': 'dW5pdDo2', 'name': 'ml' },
-                                'value': 465.7752582200901
-                            },
-                            {
-                                'unit': { 'id': 'dW5pdDo3', 'name': 'tsp' },
-                                'value': 94.49841062091676
-                            },
-                            {
-                                'unit': { 'id': 'dW5pdDo4', 'name': 'tbsp' },
-                                'value': 31.49947027087968
-                            },
-                            {
-                                'unit': { 'id': 'dW5pdDo0', 'name': 'lb' },
-                                'value': 0.15624999986221108
-                            }
-                        ],
-                        'recipeItem': {
-                            'preparations': [],
-                            'ingredient': {
-                                'externalName': 'Spring Mix Lettuce*',
-                                'id': 'aW5ncmVkaWVudDoyNDQ1NjE=',
-                                'name': 'lettuce, spring mix, SEND TO PLATE',
-                                'categoryValues': [
-                                    {
-                                        "id": "Y2F0ZWdvcnlWYWx1ZToxODQ3Mw==",
-                                        "name": "30",
-                                        "category": {
-                                            "id": "Y2F0ZWdvcnk6MzExOA==",
-                                            "name": "bin weight",
-                                            "itemType": "ingredient"
-                                        }
-                                    }
-                                ],
-                                'dietaryFlags': []
-                            },
-                            'subRecipe': None
-                        }
-                    },
-                    {
-                        'quantity': 0.85,
-                        'unit': {
-                            'id': 'dW5pdDoz',
-                            'name': 'oz'
-                        },
-                        'quantityUnitValues': [
-                            {
-                                'unit': { 'id': 'dW5pdDox', 'name': 'g'},
-                                'value': 24.097094634999998
-                            },
-                            {
-                                'unit': { 'id': 'dW5pdDoy', 'name': 'kg'},
-                                'value': 0.024097094634999996
-                            },
-                            {
-                                'unit': { 'id': 'dW5pdDoz', 'name': 'oz'},
-                                'value': 0.85
-                            },
-                            {
-                                'unit': { 'id': 'dW5pdDo0', 'name': 'lb'},
-                                'value': 0.05312499995315176
-                            },
-                            {
-                                'unit': { 'id': 'dW5pdDoxNA==', 'name': 'each'},
-                                'value': 1
-                            }
-                        ],
-                        'recipeItem': {
-                            'preparations': [],
-                            'ingredient': {
-                                'externalName': 'Crispy Chickpeas (Chickpeas, Sunflower Oil, Sea Salt)',
-                                'id': 'aW5ncmVkaWVudDoyNzQ4ODA=',
-                                'name': 'crispy roasted chickpeas, 0.85 oz bag',
-                                'categoryValues': [
-                                    {
-                                        "id": "Y2F0ZWdvcnlWYWx1ZToxODQ3NQ==",
-                                        "name": "40",
-                                        "category": {
-                                            "id": "Y2F0ZWdvcnk6MzExOA==",
-                                            "name": "bin weight",
-                                            "itemType": "ingredient"
-                                        }
-                                    }
-                                ],
-                                'dietaryFlags': [
-                                    {
-                                        'id': DietaryFlagEnum.SESAME_SEEDS.value,
-                                        'name': 'sesame seeds'
-                                    },
-                                    {
-                                        'id': DietaryFlagEnum.TREE_NUTS.value,
-                                        'name': 'tree nuts'
-                                    }
-                                ]
-                            },
-                            'subRecipe': None
+                        "dietaryFlag": {
+                            "id": DietaryFlagEnum.SOY_BEANS.value,
+                            "name": "soybeans"
                         }
                     }
                 ]
@@ -443,753 +93,2074 @@ mock_recipeTreeComponents = [
         }
     },
     {
-        'quantity': 3,
-        'unit': {
-            'id': 'dW5pdDoz',
-            'name': 'oz'
-        },
-        'quantityUnitValues': [
-            {
-                'unit': { 'id': 'dW5pdDoz', 'name': 'oz' },
-                'value': 3
-            },
-            {
-                'unit': { 'id': 'dW5pdDo0', 'name': 'lb' },
-                'value': 0.1874999998346533
-            },
-            {
-                'unit': { 'id': 'dW5pdDo5MzY4MzI=', 'name': 'max batch' },
-                'value': 0.0018749999983465329
-            },
-            {
-                'unit': { 'id': 'dW5pdDo5MzY4MzM=', 'name': 'min batch' },
-                'value': 0.012499999988976886
-            }
+        "id": "d44pdeapsdk",
+        "ancestorComponentIds": [
+            "x5ccun97m7",
+            "k41l3crd8of"
         ],
-        'recipeItem': {
-            'preparations': [],
-            'ingredient': None,
-            'subRecipe': {
-                'externalName': None,
-                'id': 'cmVjaXBlOjE3MDU4NA==',
-                'name': 'Smashed Chickpea Salad - COOKED GARBANZOS',
-                'recipeInstructions': [
-                    {
-                        'position': 0,
-                        'text': 'The hobart must be used for this task, do not mix by hand.'
-                    },
-                    {
-                        'position': 1,
-                        'text': 'Latch bowl into the hobart, ensuring it is secured. While it is lowered, add in the garbanzo beans, lemon juice, and olive oil.'
-                    },
-                    {
-                        'position': 2,
-                        'text': 'Equip the PADDLE attachment, and patiently press the up arrow to rise the bowl until locked in place. Slide over the safeguard.'
-                    },
-                    {
-                        'position': 3,
-                        'text': 'Mix on Level 1 for 2 minutes to mash the beans.'
-                    },
-                    {
-                        'position': 4,
-                        'text': 'Slide the safeguard back, and add the remaining ingredients to the mixture. Mix again for 1 minute until fully combined, while pausing every now and then to scrape down the sides and bottom of bowl with a rubber spatula.'
-                    },
-                    {
-                        'position': 5,
-                        'text': 'Lower the bowl, unlatch and grab a buddy to help pour mixture into a lexan.'
-                    },
-                    {
-                        'position': 6,
-                        'text': 'Clean the entire machine after each project, take the bowl and attachments back to the dishpit.'
+        "quantity": 4,
+        "unit": {
+            "id": UnitEnum.OZ.value,
+            "name": "oz",
+            "unitValues": [
+                {
+                    "value": 28.3495231,
+                    "unit": {
+                        "id": UnitEnum.G.value,
+                        "name": "g"
                     }
-                ],
-                'categoryValues': [
+                },
+                {
+                    "value": 1,
+                    "unit": {
+                        "id": UnitEnum.OZ.value,
+                        "name": "oz"
+                    }
+                },
+                {
+                    "value": 0.06249999994488443,
+                    "unit": {
+                        "id": UnitEnum.LB.value,
+                        "name": "lb"
+                    }
+                }
+            ]
+        },
+        "recipeItem": {
+            "preparations": [
+                {
+                    'id': PreparationEnum.TWO_OZ_RAM.value,
+                    'name': '2 oz RAM'
+                }
+            ],
+            "quantity": 4,
+            "unit": {
+                "id": UnitEnum.OZ.value,
+                "name": "oz"
+            },
+            "ingredient": None,
+            "subRecipe": {
+                "id": "cmVjaXBlOjE4OTcwNA==",
+                "name": "Olive, Red Pepper & Cucumber Quinoa Pilaf",
+                "externalName": None,
+                "categoryValues": [
                     {
-                        "id": "Y2F0ZWdvcnlWYWx1ZToxODQ3Ng==",
-                        "name": "60",
+                        "id": "Y2F0ZWdvcnlWYWx1ZToxODQ3NA==",
+                        "name": "50",
                         "category": {
-                            "id": "Y2F0ZWdvcnk6MzExOQ==",
+                            "id": RecipeCategoryTagTypeEnum.BIN_WEIGHT_TAG.value,
                             "name": "bin weight",
                             "itemType": "recipe"
                         }
                     }
                 ],
-                'dietaryFlagsWithUsages': [],
-                'recipeTreeComponents': [
+                "recipeInstructions": [
                     {
-                        'quantity': 0.75,
-                        'unit': {
-                            'id': 'dW5pdDoz',
-                            'name': 'oz'
-                        },
-                        'recipeItem': {
-                            'preparations': [],
-                            'ingredient': {
-                                'externalName': 'Sumac',
-                                'id': 'aW5ncmVkaWVudDoyNDQ4MzQ=',
-                                'name': 'spice sumac',
-                                'categoryValues': [],
-                                'dietaryFlags': []
-                            },
-                            'subRecipe': None
-                        }
-                    },
-                    {
-                        'quantity': 2,
-                        'unit': {
-                            'id': 'dW5pdDoz',
-                            'name': 'oz'
-                        },
-                        'recipeItem': {
-                            'preparations': [],
-                            'ingredient': {
-                                'externalName': 'Black Pepper',
-                                'id': 'aW5ncmVkaWVudDoyNDQ3OTM=',
-                                'name': 'spice, black pepper, ground',
-                                'categoryValues': [],
-                                'dietaryFlags': []
-                            },
-                            'subRecipe': None
-                        }
-                    },
-                    {
-                        'quantity': 75,
-                        'unit': {
-                            'id': 'dW5pdDo0',
-                            'name': 'lb'
-                        },
-                        'recipeItem': {
-                            'preparations': [],
-                            'ingredient': None,
-                            'subRecipe': {
-                                'externalName': None,
-                                'id': 'cmVjaXBlOjE3NjQ4MA==',
-                                'name': 'Cooked Garbanzo Beans',
-                                'categoryValues': [],
-                                'dietaryFlagsWithUsages': [],
-                                'recipeInstructions': [
-                                    {
-                                        'position': 0,
-                                        'text': 'Start by straining and rinsing the beans. Sift through on sheet trays to make sure there aren’t any rocks, discolored beans, or any other foreign objects.'
-                                    },
-                                    {
-                                        'position': 1,
-                                        'text': 'Transfer the sifted beans to a tilt skillet, no more than 75# at a time. Cover with about a foot of water and bring to a boil by setting the temperature to high. Flavor the beans now with salt and the addition of a sachet of mirepoix.'
-                                    },
-                                    {
-                                        'position': 2,
-                                        'text': 'Once brought to a simmer, stir the beans and cover. Set a timer for 40 minutes and check in 5 minute increments afterwards for doneness. Season now with salt. To make sure the beans are cooked through, taste with a spoon. A cooked bean should be creamy on the inside with skin that is intact, not broken.'
-                                    },
-                                    {
-                                        'position': 3,
-                                        'text': 'Turn off the heat and pick out the sachet. Strain beans from their liquids to cool down on sheet trays.'
-                                    }
-                                ],
-                                'recipeTreeComponents': [
-                                    {
-                                        'quantity': 5.125,
-                                        'unit': {
-                                            'id': 'dW5pdDo0',
-                                            'name': 'lb'
-                                        },
-                                        'recipeItem': {
-                                            'ingredient': None,
-                                            'subRecipe': {
-                                                'id': 'cmVjaXBlOjIwMjM5OA==',
-                                                'name': 'Mirepoix Sachet',
-                                                'externalName': None,
-                                                'dietaryFlagsWithUsages': [],
-                                                'recipeInstructions': [
-                                                    {
-                                                        'position': 0,
-                                                        'text': 'Place the onion, carrot, celery, garlic heads, and bay leaves in the center of the square of cheesecloth. Gather the corners together to make a small pouch, tying it tightly with twine.'
-                                                    },
-                                                    {
-                                                        'position': 1,
-                                                        'text': 'Keep one length of the twine long enough to tie to one of the pot handles, for easy removal.'
-                                                    }
-                                                ]
-                                            }
-                                        }
-                                    },
-                                    {
-                                        'quantity': 75,
-                                        'unit': {
-                                            'id': 'dW5pdDo0',
-                                            'name': 'lb'
-                                        },
-                                        'recipeItem': {
-                                            'ingredient': {
-                                                'id': 'aW5ncmVkaWVudDoyNDQyODE=',
-                                                'name': 'beans, garbanzo, dry',
-                                                'externalName': 'Garbanzo Beans',
-                                                'dietaryFlags': []
-                                            },
-                                            'subRecipe': None
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    },
-                    {
-                        'quantity': 6,
-                        'unit': {
-                            'id': 'dW5pdDo0',
-                            'name': 'lb'
-                        },
-                        'recipeItem': {
-                            'preparations': [],
-                            'ingredient': {
-                                'externalName': 'Extra Virgin Olive Oil',
-                                'id': 'aW5ncmVkaWVudDoyNDQ2MzA=',
-                                'name': 'oil, olive',
-                                'categoryValues': [],
-                                'dietaryFlags': [],
-                            },
-                            'subRecipe': None
-                        }
-                    },
-                    {
-                        'quantity': 6,
-                        'unit': {
-                            'id': 'dW5pdDo0',
-                            'name': 'lb'
-                        },
-                        'recipeItem': {
-                            'preparations': [],
-                            'ingredient': {
-                                'externalName': 'Lemon Juice',
-                                'id': 'aW5ncmVkaWVudDoyNDQ1MzU=',
-                                'name': 'juice, lemon',
-                                'categoryValues': [],
-                                'dietaryFlags': []
-                            },
-                            'subRecipe': None
-                        }
+                        "text": "Stage lexans for mixing. With sleeved gloves, mix the cucumber, red bell pepper, olives, hemp seeds, parsley and scallions in the quinoa being sure to distribute each ingredient evenly.",
+                        "position": 0
                     }
                 ],
+                "dietaryFlagsWithUsages": []
             }
         }
     },
     {
-        "quantity": 0.75,
-        "unit": {
-            "id": "dW5pdDoz",
-            "name": "oz"
-        },
-        "quantityUnitValues": [
-            {
-                "unit": { "id": "dW5pdDox", "name": "g" },
-                "value": 21.262142325
-            },
-            {
-                "unit": { "id": "dW5pdDoy", "name": "kg" },
-                "value": 0.021262142325
-            },
-            {
-                "unit": { "id": "dW5pdDoz", "name": "oz" },
-                "value": 0.75
-            },
-            {
-                "unit": { "id": "dW5pdDo0", "name": "lb" },
-                "value": 0.04687499995866332
-            }
+        "id": "wuet0e3vilq",
+        "ancestorComponentIds": [
+            "x5ccun97m7",
+            "k41l3crd8of",
+            "d44pdeapsdk"
         ],
+        "quantity": 0.12499999988976887,
+        "unit": {
+            "id": UnitEnum.LB.value,
+            "name": "lb",
+            "unitValues": [
+                {
+                    "value": 453.59237,
+                    "unit": {
+                        "id": UnitEnum.G.value,
+                        "name": "g"
+                    }
+                },
+                {
+                    "value": 16.000000014109585,
+                    "unit": {
+                        "id": UnitEnum.OZ.value,
+                        "name": "oz"
+                    }
+                },
+                {
+                    "value": 1,
+                    "unit": {
+                        "id": UnitEnum.LB.value,
+                        "name": "lb"
+                    }
+                }
+            ]
+        },
+        "recipeItem": {
+            "preparations": [],
+            "quantity": 30,
+            "unit": {
+                "id": UnitEnum.LB.value,
+                "name": "lb"
+            },
+            "ingredient": None,
+            "subRecipe": {
+                "id": "cmVjaXBlOjE4ODYwNg==",
+                "name": "Cooked Rainbow Quinoa",
+                "externalName": None,
+                "categoryValues": [],
+                "recipeInstructions": [
+                    {
+                        "text": "Bring water in tilt skillet to a boil. Add quinoa to tilt skillet, no more than 75 lbs at a time.",
+                        "position": 0
+                    },
+                    {
+                        "text": "Simmer, close lid, and cook until tender, stirring occasionally to prevent dry spots in the corners.",
+                        "position": 1
+                    },
+                    {
+                        "text": "After 10 minutes turn off heat and let steam for 5 minutes.",
+                        "position": 2
+                    },
+                    {
+                        "text": "Scoop quinoa onto sheet trays to cool down.",
+                        "position": 3
+                    }
+                ],
+                "dietaryFlagsWithUsages": []
+            }
+        }
+    },
+    {
+        "id": "j3k9vc4ai2",
+        "ancestorComponentIds": [
+            "x5ccun97m7",
+            "k41l3crd8of",
+            "d44pdeapsdk",
+            "wuet0e3vilq"
+        ],
+        "quantity": 0.06009615379315811,
+        "unit": {
+            "id": UnitEnum.LB.value,
+            "name": "lb",
+            "unitValues": [
+                {
+                    "value": 453.59237,
+                    "unit": {
+                        "id": UnitEnum.G.value,
+                        "name": "g"
+                    }
+                },
+                {
+                    "value": 16.000000014109585,
+                    "unit": {
+                        "id": UnitEnum.OZ.value,
+                        "name": "oz"
+                    }
+                },
+                {
+                    "value": 1,
+                    "unit": {
+                        "id": UnitEnum.LB.value,
+                        "name": "lb"
+                    }
+                }
+            ]
+        },
+        "recipeItem": {
+            "preparations": [],
+            "quantity": 75,
+            "unit": {
+                "id": UnitEnum.LB.value,
+                "name": "lb"
+            },
+            "ingredient": {
+                "locationVendorItems": [],
+                "id": "aW5ncmVkaWVudDoyNDQ3NDQ=",
+                "name": "quinoa, rainbow, dry",
+                "externalName": "Quinoa",
+                "categoryValues": [],
+                "dietaryFlags": []
+            },
+            "subRecipe": None
+        }
+    },
+    {
+        "id": "ss91mevjky",
+        "ancestorComponentIds": [
+            "x5ccun97m7",
+            "k41l3crd8of",
+            "d44pdeapsdk"
+        ],
+        "quantity": 0.021874999980709554,
+        "unit": {
+            "id": UnitEnum.LB.value,
+            "name": "lb",
+            "unitValues": [
+                {
+                    "value": 453.59237,
+                    "unit": {
+                        "id": UnitEnum.G.value,
+                        "name": "g"
+                    }
+                },
+                {
+                    "value": 16.000000014109585,
+                    "unit": {
+                        "id": UnitEnum.OZ.value,
+                        "name": "oz"
+                    }
+                },
+                {
+                    "value": 1,
+                    "unit": {
+                        "id": UnitEnum.LB.value,
+                        "name": "lb"
+                    }
+                }
+            ]
+        },
+        "recipeItem": {
+            "preparations": [],
+            "quantity": 7,
+            "unit": {
+                "id": UnitEnum.LB.value,
+                "name": "lb"
+            },
+            "ingredient": {
+                "locationVendorItems": [],
+                "id": "aW5ncmVkaWVudDoyNDQ2Mzc=",
+                "name": "olives, kalamata, sliced",
+                "externalName": "Kalamata Olives",
+                "categoryValues": [],
+                "dietaryFlags": []
+            },
+            "subRecipe": None
+        }
+    },
+    {
+        "id": "a3rm32jf58",
+        "ancestorComponentIds": [
+            "x5ccun97m7",
+            "k41l3crd8of",
+            "d44pdeapsdk"
+        ],
+        "quantity": 0.024999999977953775,
+        "unit": {
+            "id": UnitEnum.OZ.value,
+            "name": "oz",
+            "unitValues": [
+                {
+                    "value": 28.3495231,
+                    "unit": {
+                        "id": UnitEnum.G.value,
+                        "name": "g"
+                    }
+                },
+                {
+                    "value": 1,
+                    "unit": {
+                        "id": UnitEnum.OZ.value,
+                        "name": "oz"
+                    }
+                },
+                {
+                    "value": 0.06249999994488443,
+                    "unit": {
+                        "id": UnitEnum.LB.value,
+                        "name": "lb"
+                    }
+                }
+            ]
+        },
+        "recipeItem": {
+            "preparations": [],
+            "quantity": 8,
+            "unit": {
+                "id": UnitEnum.OZ.value,
+                "name": "oz"
+            },
+            "ingredient": None,
+            "subRecipe": {
+                "id": "cmVjaXBlOjE3Mjk2NQ==",
+                "name": "Sliced Scallion",
+                "externalName": None,
+                "categoryValues": [],
+                "recipeInstructions": [
+                    {
+                        "text": "Pick off any stickers, twisty ties, or rubber bands from any bunched herbs.",
+                        "position": 0
+                    },
+                    {
+                        "text": "Using the 2 compartment sink, wash the produce well using a diluted veg wash solution.",
+                        "position": 1
+                    },
+                    {
+                        "text": "Once rinsed and visibly clean, strain onto perforated sheet trays.",
+                        "position": 2
+                    },
+                    {
+                        "text": "Let air dry on speed rack or spin dry using the electric spinner.",
+                        "position": 3
+                    },
+                    {
+                        "text": "Trim the tips of the scallions. Gather the scallions within your hand and line them up evenly slice across to make thin slices.",
+                        "position": 4
+                    },
+                    {
+                        "text": "Store in a cambro.",
+                        "position": 5
+                    }
+                ],
+                "dietaryFlagsWithUsages": []
+            }
+        }
+    },
+    {
+        "id": "vy2t2yi9vkj",
+        "ancestorComponentIds": [
+            "x5ccun97m7",
+            "k41l3crd8of",
+            "d44pdeapsdk",
+            "a3rm32jf58"
+        ],
+        "quantity": 0.001644736839204444,
+        "unit": {
+            "id": UnitEnum.LB.value,
+            "name": "lb",
+            "unitValues": [
+                {
+                    "value": 453.59237,
+                    "unit": {
+                        "id": UnitEnum.G.value,
+                        "name": "g"
+                    }
+                },
+                {
+                    "value": 16.000000014109585,
+                    "unit": {
+                        "id": UnitEnum.OZ.value,
+                        "name": "oz"
+                    }
+                },
+                {
+                    "value": 1,
+                    "unit": {
+                        "id": UnitEnum.LB.value,
+                        "name": "lb"
+                    }
+                }
+            ]
+        },
+        "recipeItem": {
+            "preparations": [],
+            "quantity": 2,
+            "unit": {
+                "id": UnitEnum.LB.value,
+                "name": "lb"
+            },
+            "ingredient": {
+                "locationVendorItems": [],
+                "id": "aW5ncmVkaWVudDoyNDk1NDE=",
+                "name": "onion, green (scallion), whole",
+                "externalName": "Scallion",
+                "categoryValues": [],
+                "dietaryFlags": []
+            },
+            "subRecipe": None
+        }
+    },
+    {
+        "id": "hdeta8wr90j",
+        "ancestorComponentIds": [
+            "x5ccun97m7",
+            "k41l3crd8of"
+        ],
+        "quantity": 1.5,
+        "unit": {
+            "id": UnitEnum.OZ.value,
+            "name": "oz",
+            "unitValues": [
+                {
+                    "value": 28.3495231,
+                    "unit": {
+                        "id": UnitEnum.G.value,
+                        "name": "g"
+                    }
+                },
+                {
+                    "value": 1,
+                    "unit": {
+                        "id": UnitEnum.OZ.value,
+                        "name": "oz"
+                    }
+                },
+                {
+                    "value": 0.06249999994488443,
+                    "unit": {
+                        "id": UnitEnum.LB.value,
+                        "name": "lb"
+                    }
+                }
+            ]
+        },
         "recipeItem": {
             "preparations": [
                 {
-                    "id": PreparationEnum.TWELVE_OZ_ROUND_INSERT.value,
-                    "name": "12-oz-clean-round-sided-INSERT"
+                    "id": PreparationEnum.INSERT12.value,
+                    "name": "INSERT12"
                 }
             ],
+            "quantity": 1.5,
+            "unit": {
+                "id": UnitEnum.OZ.value,
+                "name": "oz"
+            },
+            "ingredient": None,
+            "subRecipe": {
+                "id": "cmVjaXBlOjE3NjQ3Mw==",
+                "name": "Tofu Feta",
+                "externalName": None,
+                "categoryValues": [],
+                "recipeInstructions": [
+                    {
+                        "text": "Stage clear polycarbonate lexans for mixing and add brine for tofu feta.",
+                        "position": 0
+                    },
+                    {
+                        "text": "Dice Tofu into small 1/4\" diced bite sized squares and add to each lexan, mixing well with the brine for tofu feta, being sure all of the tofu is submerged.",
+                        "position": 1
+                    },
+                    {
+                        "text": "Let sit at least 4 hours, best overnight.",
+                        "position": 2
+                    },
+                    {
+                        "text": "Strain well before serving.",
+                        "position": 3
+                    }
+                ],
+                "dietaryFlagsWithUsages": [
+                    {
+                        "dietaryFlag": {
+                            "id": DietaryFlagEnum.SOY_BEANS.value,
+                            "name": "soybeans"
+                        }
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "id": "trr5acd7ly",
+        "ancestorComponentIds": [
+            "x5ccun97m7",
+            "k41l3crd8of",
+            "hdeta8wr90j"
+        ],
+        "quantity": 0.06696428565523334,
+        "unit": {
+            "id": UnitEnum.LB.value,
+            "name": "lb",
+            "unitValues": [
+                {
+                    "value": 453.59237,
+                    "unit": {
+                        "id": UnitEnum.G.value,
+                        "name": "g"
+                    }
+                },
+                {
+                    "value": 16.000000014109585,
+                    "unit": {
+                        "id": UnitEnum.OZ.value,
+                        "name": "oz"
+                    }
+                },
+                {
+                    "value": 1,
+                    "unit": {
+                        "id": UnitEnum.LB.value,
+                        "name": "lb"
+                    }
+                }
+            ]
+        },
+        "recipeItem": {
+            "preparations": [],
+            "quantity": 25,
+            "unit": {
+                "id": UnitEnum.LB.value,
+                "name": "lb"
+            },
+            "ingredient": None,
+            "subRecipe": {
+                "id": "cmVjaXBlOjIxNjA2MA==",
+                "name": "Brine for \"Feta\"",
+                "externalName": None,
+                "categoryValues": [],
+                "recipeInstructions": [
+                    {
+                        "text": "Stage clear polycarbonate lexans for mixing. In each lexan combine all of the ingredients blend using an immersion blender.",
+                        "position": 0
+                    }
+                ],
+                "dietaryFlagsWithUsages": []
+            }
+        }
+    },
+    {
+        "id": "bwcj1c4z5zm",
+        "ancestorComponentIds": [
+            "x5ccun97m7",
+            "k41l3crd8of",
+            "hdeta8wr90j",
+            "trr5acd7ly"
+        ],
+        "quantity": 0.022321428551744446,
+        "unit": {
+            "id": UnitEnum.LB.value,
+            "name": "lb",
+            "unitValues": [
+                {
+                    "value": 453.59237,
+                    "unit": {
+                        "id": UnitEnum.G.value,
+                        "name": "g"
+                    }
+                },
+                {
+                    "value": 16.000000014109585,
+                    "unit": {
+                        "id": UnitEnum.OZ.value,
+                        "name": "oz"
+                    }
+                },
+                {
+                    "value": 1,
+                    "unit": {
+                        "id": UnitEnum.LB.value,
+                        "name": "lb"
+                    }
+                }
+            ]
+        },
+        "recipeItem": {
+            "preparations": [],
+            "quantity": 20,
+            "unit": {
+                "id": UnitEnum.LB.value,
+                "name": "lb"
+            },
             "ingredient": {
-                "id": "aW5ncmVkaWVudDoyNDUyMDQ=",
-                "name": "crackers, Mary's seeded GF, SEND TO PLATE",
-                "externalName": "Seed Crackers (Brown Rice, Quinoa, Pumpkin Seeds, Sunflower Seeds, Sesame Seeds, Flax Seeds, Poppy Seeds, Minced Onion, Garlic Powder, Sea Salt)*",
+                "locationVendorItems": [],
+                "id": "aW5ncmVkaWVudDoyNDQ5MDU=",
+                "name": "vinegar, apple cider",
+                "externalName": "Apple Cider Vinegar",
+                "categoryValues": [],
+                "dietaryFlags": []
+            },
+            "subRecipe": None
+        }
+    },
+    {
+        "id": "oz9yp3l0aek",
+        "ancestorComponentIds": [
+            "x5ccun97m7",
+            "k41l3crd8of",
+            "hdeta8wr90j"
+        ],
+        "quantity": 0.09374999991732666,
+        "unit": {
+            "id": UnitEnum.LB.value,
+            "name": "lb",
+            "unitValues": [
+                {
+                    "value": 453.59237,
+                    "unit": {
+                        "id": UnitEnum.G.value,
+                        "name": "g"
+                    }
+                },
+                {
+                    "value": 16.000000014109585,
+                    "unit": {
+                        "id": UnitEnum.OZ.value,
+                        "name": "oz"
+                    }
+                },
+                {
+                    "value": 1,
+                    "unit": {
+                        "id": UnitEnum.LB.value,
+                        "name": "lb"
+                    }
+                }
+            ]
+        },
+        "recipeItem": {
+            "preparations": [],
+            "quantity": 35,
+            "unit": {
+                "id": UnitEnum.LB.value,
+                "name": "lb"
+            },
+            "ingredient": None,
+            "subRecipe": {
+                "id": "cmVjaXBlOjE5MDA5MQ==",
+                "name": "Small Diced Tofu (1/4\")",
+                "externalName": None,
+                "categoryValues": [],
+                "recipeInstructions": [
+                    {
+                        "text": "Start by opening the bags of firm tofu over perforated lexans to strain any liquid.",
+                        "position": 0
+                    },
+                    {
+                        "text": "Dice the tofu into 1/4\" pieces. Reserve in lexans.",
+                        "position": 1
+                    }
+                ],
+                "dietaryFlagsWithUsages": [
+                    {
+                        "dietaryFlag": {
+                            "id": DietaryFlagEnum.SOY_BEANS.value,
+                            "name": "soybeans"
+                        }
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "id": "x133e7x7hp",
+        "ancestorComponentIds": [
+            "x5ccun97m7",
+            "k41l3crd8of",
+            "hdeta8wr90j",
+            "oz9yp3l0aek"
+        ],
+        "quantity": 0.09374999991732666,
+        "unit": {
+            "id": UnitEnum.LB.value,
+            "name": "lb",
+            "unitValues": [
+                {
+                    "value": 453.59237,
+                    "unit": {
+                        "id": UnitEnum.G.value,
+                        "name": "g"
+                    }
+                },
+                {
+                    "value": 16.000000014109585,
+                    "unit": {
+                        "id": UnitEnum.OZ.value,
+                        "name": "oz"
+                    }
+                },
+                {
+                    "value": 1,
+                    "unit": {
+                        "id": UnitEnum.LB.value,
+                        "name": "lb"
+                    }
+                }
+            ]
+        },
+        "recipeItem": {
+            "preparations": [],
+            "quantity": 40,
+            "unit": {
+                "id": UnitEnum.LB.value,
+                "name": "lb"
+            },
+            "ingredient": {
+                "locationVendorItems": [],
+                "id": "aW5ncmVkaWVudDoyNDQ4Nzc=",
+                "name": "tofu, firm",
+                "externalName": "Tofu",
                 "categoryValues": [],
                 "dietaryFlags": [
                     {
-                        "id": "ZGlldGFyeUZsYWc6MTY=",
-                        "name": "sesame seeds"
-                    },
+                        "id": DietaryFlagEnum.SOY_BEANS.value,
+                        "name": "soybeans"
+                    }
                 ]
             },
             "subRecipe": None
         }
     },
     {
-        'quantity': 2.3,
-        'unit': {
-            'id': 'dW5pdDoz',
-            'name': 'oz'
-        },
-        'quantityUnitValues': [
-            {
-                'unit': { 'id': 'dW5pdDoz', 'name': 'oz' },
-                'value': 2.3
-            },
-            {
-                'unit': { 'id': 'dW5pdDo0', 'name': 'lb' },
-                'value': 0.14374999987323417
-            },
-            {
-                'unit': { 'id': 'dW5pdDoxNA==', 'name': 'each' },
-                'value': 1
-            },
-            {
-                'unit': { 'id': 'dW5pdDo3ODA1MzM=', 'name': 'case' },
-                'value': 0.006666666666666667
-            }
+        "id": "3oiimc548lt",
+        "ancestorComponentIds": [
+            "x5ccun97m7",
+            "k41l3crd8of"
         ],
-        'recipeItem': {
-            'preparations': [],
-            'ingredient': {
-                'id': 'aW5ncmVkaWVudDoyNDQ4OTQ=',
-                'name': 'TS20 - 20oz Meal Boxes',
-                'externalName': 'TS20',
-                'dietaryFlags': [],
-                'categoryValues': [
+        "quantity": 2.5,
+        "unit": {
+            "id": UnitEnum.OZ.value,
+            "name": "oz",
+            "unitValues": [
+                {
+                    "value": 28.3495231,
+                    "unit": {
+                        "id": UnitEnum.G.value,
+                        "name": "g"
+                    }
+                },
+                {
+                    "value": 1,
+                    "unit": {
+                        "id": UnitEnum.OZ.value,
+                        "name": "oz"
+                    }
+                },
+                {
+                    "value": 0.06249999994488443,
+                    "unit": {
+                        "id": UnitEnum.LB.value,
+                        "name": "lb"
+                    }
+                }
+            ]
+        },
+        "recipeItem": {
+            "preparations": [],
+            "quantity": 2.5,
+            "unit": {
+                "id": UnitEnum.OZ.value,
+                "name": "oz"
+            },
+            "ingredient": {
+                "locationVendorItems": [],
+                "id": "aW5ncmVkaWVudDoyNDQ1NjE=",
+                "name": "lettuce, spring mix, SEND TO PLATE",
+                "externalName": "Spring Mix Lettuce* or Seasonal Greens*\u00a7",
+                "categoryValues": [
                     {
-                        'id': 'Y2F0ZWdvcnlWYWx1ZToxNDgwMg==',
-                        'name': 'warehouse - packaging'
-                    },
-                    {
-                        'id': IngredientCategoryValueEnum.FOOD_PACKAGE.value,
-                        'name': 'food pkg'
+                        "id": "Y2F0ZWdvcnlWYWx1ZToxODQ3Mw==",
+                        "name": "30",
+                        "category": {
+                            "id": IngredientCategoryTagTypeEnum.BIN_WEIGHT_TAG.value,
+                            "name": "bin weight",
+                            "itemType": "ingredient"
+                        }
                     }
                 ],
+                "dietaryFlags": []
             },
-            'subRecipe': None
+            "subRecipe": None
         }
     },
     {
-        'quantity': 2,
-        'unit': {
-            'id': 'dW5pdDoz',
-            'name': 'oz'
-        },
-        'quantityUnitValues': [
-            {
-                'unit': { 'id': 'dW5pdDox', 'name': 'g'},
-                'value': 56.6990462
-            },
-            {
-                'unit': { 'id': 'dW5pdDoy', 'name': 'kg'},
-                'value': 0.0566990462
-            },
-            {
-                'unit': { 'id': 'dW5pdDoz', 'name': 'oz'},
-                'value': 2
-            },
-            {
-                'unit': { 'id': 'dW5pdDo0', 'name': 'lb'},
-                'value': 0.12499999988976886
-            }
+        "id": "8o8ode59qdc",
+        "ancestorComponentIds": [
+            "x5ccun97m7",
+            "k41l3crd8of"
         ],
-        'recipeItem': {
-            'preparations': [
+        "quantity": 1,
+        "unit": {
+            "id": UnitEnum.EACH.value,
+            "name": "each",
+            "unitValues": [
                 {
-                    'id': PreparationEnum.TWO_OZ_WINPAK.value,
-                    'name': '2 oz WINPAK'
+                    "value": 24.097094634999998,
+                    "unit": {
+                        "id": UnitEnum.G.value,
+                        "name": "g"
+                    }
                 },
                 {
-                    'id': 'cHJlcGFyYXRpb246MjgzMzQ=',
-                    'name': 'standalone'
+                    "value": 0.85,
+                    "unit": {
+                        "id": UnitEnum.OZ.value,
+                        "name": "oz"
+                    }
+                },
+                {
+                    "value": 0.05312499995315176,
+                    "unit": {
+                        "id": UnitEnum.LB.value,
+                        "name": "lb"
+                    }
+                },
+                {
+                    "value": 1,
+                    "unit": {
+                        "id": UnitEnum.EACH.value,
+                        "name": "each"
+                    }
                 }
-            ],
-            'ingredient': None,
-            'subRecipe': {
-                'externalName': 'Red Wine Vinaigrette',
-                'id': 'cmVjaXBlOjIyMzU3MQ==',
-                'name': 'Red Wine Vinaigrette 2oz',
-                'recipeInstructions': [],
-                'categoryValues': [],
-                'dietaryFlagsWithUsages': [],
-                'recipeTreeComponents': [
+            ]
+        },
+        "recipeItem": {
+            "preparations": [],
+            "quantity": 1,
+            "unit": {
+                "id": UnitEnum.EACH.value,
+                "name": "each"
+            },
+            "ingredient": {
+                "locationVendorItems": [],
+                "id": "aW5ncmVkaWVudDoyNzQ4ODA=",
+                "name": "crispy roasted chickpeas, 0.85 oz bag, SEND TO PLATE",
+                "externalName": "Crispy Chickpeas (Chickpeas, Sunflower Oil, Sea Salt)",
+                "categoryValues": [
                     {
-                        'quantity': 2,
-                        'unit': {
-                            'id': 'dW5pdDoz',
-                            'name': 'oz'
-                        },
-                        'quantityUnitValues': [
-                            {
-                                'unit': { 'id': 'dW5pdDoz', 'name': 'oz' },
-                                'value': 2
-                            },
-                            {
-                                'unit': { 'id': 'dW5pdDo0', 'name': 'lb' },
-                                'value': 0.12499999988976886
-                            },
-                            {
-                                'unit': { 'id': 'dW5pdDo3NTU1MjQ=', 'name': 'batch' },
-                                'value': 0.0020833333314961475
-                            },
-                            {
-                                'unit': { 'id': 'dW5pdDo5MzUzMzg=', 'name': 'max batch' },
-                                'value': 0.0020833333314961475
-                            },
-                            {
-                                'unit': { 'id': 'dW5pdDo5MzUzMzk=', 'name': 'min batch' },
-                                'value': 0.012499999988976886
-                            }
-                        ],
-                        'recipeItem': {
-                            'preparations': [],
-                            'ingredient': None,
-                            'subRecipe': {
-                                'externalName': None,
-                                'id': 'cmVjaXBlOjE3NDI4OA==',
-                                'name': 'Red Wine Vinaigrette BASE',
-                                'categoryValues': [],
-                                'dietaryFlagsWithUsages': [],
-                                'recipeInstructions': [
-                                    {
-                                        'position': 0,
-                                        'text': 'Please keep in mind the tamper seal from bottled containers can fall into the recipe you are making. Be sure to discard any tamper seals immediately after breaking the seal.'
-                                    },
-                                    {
-                                        'position': 1,
-                                        'text': 'In blixer combine half of the liquids to break up the red onion and garlic. Add the remaining liquids (except oil) and blend.'
-                                    },
-                                    {
-                                        'position': 2,
-                                        'text': 'Slowly add in oil through opening on the lid until emulsified.'
-                                    },
-                                    {
-                                        'position': 3,
-                                        'text': 'Pour into lexans.'
-                                    }
-                                ],
-                                'recipeTreeComponents': []
-                            }
+                        "id": "Y2F0ZWdvcnlWYWx1ZToxODQ3NQ==",
+                        "name": "40",
+                        "category": {
+                            "id": IngredientCategoryTagTypeEnum.BIN_WEIGHT_TAG.value,
+                            "name": "bin weight",
+                            "itemType": "ingredient"
                         }
                     }
+                ],
+                "dietaryFlags": [
+                    {
+                        "id": DietaryFlagEnum.SESAME_SEEDS.value,
+                        "name": "sesame seeds"
+                    },
+                    {
+                        "id": DietaryFlagEnum.TREE_NUTS.value,
+                        "name": "tree nuts"
+                    }
+
                 ]
+            },
+            "subRecipe": None
+        }
+    },
+    {
+        "id": "p1izi6jy93l",
+        "ancestorComponentIds": [
+            "x5ccun97m7"
+        ],
+        "quantity": 3,
+        "unit": {
+            "id": UnitEnum.OZ.value,
+            "name": "oz",
+            "unitValues": [
+                {
+                    "value": 28.3495231,
+                    "unit": {
+                        "id": UnitEnum.G.value,
+                        "name": "g"
+                    }
+                },
+                {
+                    "value": 1,
+                    "unit": {
+                        "id": UnitEnum.OZ.value,
+                        "name": "oz"
+                    }
+                },
+                {
+                    "value": 0.06249999994488443,
+                    "unit": {
+                        "id": UnitEnum.LB.value,
+                        "name": "lb"
+                    }
+                }
+            ]
+        },
+        "recipeItem": {
+            "preparations": [],
+            "quantity": 3,
+            "unit": {
+                "id": UnitEnum.OZ.value,
+                "name": "oz"
+            },
+            "ingredient": None,
+            "subRecipe": {
+                "id": "cmVjaXBlOjE3MDU4NA==",
+                "name": "Smashed Chickpea Salad - COOKED GARBANZOS",
+                "externalName": None,
+                "categoryValues": [],
+                "recipeInstructions": [
+                    {
+                        "text": "The hobart must be used for this task, do not mix by hand.",
+                        "position": 0
+                    },
+                    {
+                        "text": "Latch bowl into the hobart, ensuring it is secured. While it is lowered, add in the garbanzo beans, lemon juice, and olive oil.",
+                        "position": 1
+                    },
+                    {
+                        "text": "Equip the PADDLE attachment, and patiently press the up arrow to rise the bowl until locked in place. Slide over the safeguard.",
+                        "position": 2
+                    },
+                    {
+                        "text": "Mix on Level 1 for 2 minutes to mash the beans.",
+                        "position": 3
+                    },
+                    {
+                        "text": "Slide the safeguard back, and add the remaining ingredients to the mixture. Mix again for 1 minute until fully combined, while pausing every now and then to scrape down the sides and bottom of bowl with a rubber spatula.",
+                        "position": 4
+                    },
+                    {
+                        "text": "Lower the bowl, unlatch and grab a buddy to help pour mixture into a lexan.",
+                        "position": 5
+                    },
+                    {
+                        "text": "Clean the entire machine after each project, take the bowl and attachments back to the dishpit.",
+                        "position": 6
+                    }
+                ],
+                "dietaryFlagsWithUsages": []
             }
+        }
+    },
+    {
+        "id": "lkjyq9qnvy",
+        "ancestorComponentIds": [
+            "x5ccun97m7",
+            "p1izi6jy93l"
+        ],
+        "quantity": 0.0014062499987599,
+        "unit": {
+            "id": UnitEnum.OZ.value,
+            "name": "oz",
+            "unitValues": [
+                {
+                    "value": 28.3495231,
+                    "unit": {
+                        "id": UnitEnum.G.value,
+                        "name": "g"
+                    }
+                },
+                {
+                    "value": 1,
+                    "unit": {
+                        "id": UnitEnum.OZ.value,
+                        "name": "oz"
+                    }
+                },
+                {
+                    "value": 0.06249999994488443,
+                    "unit": {
+                        "id": UnitEnum.LB.value,
+                        "name": "lb"
+                    }
+                }
+            ]
+        },
+        "recipeItem": {
+            "preparations": [],
+            "quantity": 0.75,
+            "unit": {
+                "id": UnitEnum.OZ.value,
+                "name": "oz"
+            },
+            "ingredient": {
+                "locationVendorItems": [],
+                "id": "aW5ncmVkaWVudDoyNDQ4MzQ=",
+                "name": "spice, sumac",
+                "externalName": "Sumac",
+                "categoryValues": [],
+                "dietaryFlags": []
+            },
+            "subRecipe": None
+        }
+    },
+    {
+        "id": "4n11rdaopm7",
+        "ancestorComponentIds": [
+            "x5ccun97m7",
+            "p1izi6jy93l"
+        ],
+        "quantity": 0.003749999996693066,
+        "unit": {
+            "id": UnitEnum.OZ.value,
+            "name": "oz",
+            "unitValues": [
+                {
+                    "value": 28.3495231,
+                    "unit": {
+                        "id": UnitEnum.G.value,
+                        "name": "g"
+                    }
+                },
+                {
+                    "value": 1,
+                    "unit": {
+                        "id": UnitEnum.OZ.value,
+                        "name": "oz"
+                    }
+                },
+                {
+                    "value": 0.06249999994488443,
+                    "unit": {
+                        "id": UnitEnum.LB.value,
+                        "name": "lb"
+                    }
+                }
+            ]
+        },
+        "recipeItem": {
+            "preparations": [],
+            "quantity": 2,
+            "unit": {
+                "id": UnitEnum.OZ.value,
+                "name": "oz"
+            },
+            "ingredient": {
+                "locationVendorItems": [],
+                "id": "aW5ncmVkaWVudDoyNDQ3OTM=",
+                "name": "spice, black pepper, ground",
+                "externalName": "Black Pepper",
+                "categoryValues": [],
+                "dietaryFlags": []
+            },
+            "subRecipe": None
+        }
+    },
+    {
+        "id": "t2xotugmk6p",
+        "ancestorComponentIds": [
+            "x5ccun97m7",
+            "p1izi6jy93l"
+        ],
+        "quantity": 0.14062499987598998,
+        "unit": {
+            "id": UnitEnum.LB.value,
+            "name": "lb",
+            "unitValues": [
+                {
+                    "value": 453.59237,
+                    "unit": {
+                        "id": UnitEnum.G.value,
+                        "name": "g"
+                    }
+                },
+                {
+                    "value": 16.000000014109585,
+                    "unit": {
+                        "id": UnitEnum.OZ.value,
+                        "name": "oz"
+                    }
+                },
+                {
+                    "value": 1,
+                    "unit": {
+                        "id": UnitEnum.LB.value,
+                        "name": "lb"
+                    }
+                }
+            ]
+        },
+        "recipeItem": {
+            "preparations": [],
+            "quantity": 75,
+            "unit": {
+                "id": UnitEnum.LB.value,
+                "name": "lb"
+            },
+            "ingredient": None,
+            "subRecipe": {
+                "id": "cmVjaXBlOjE3NjQ4MA==",
+                "name": "Cooked Garbanzo Beans",
+                "externalName": None,
+                "categoryValues": [],
+                "recipeInstructions": [
+                    {
+                        "text": "Start by straining and rinsing the beans. Sift through on sheet trays to make sure there aren\u2019t any rocks, discolored beans, or any other foreign objects.",
+                        "position": 0
+                    },
+                    {
+                        "text": "Transfer the sifted beans to a tilt skillet, no more than 75# at a time. Cover with about a foot of water and bring to a boil by setting the temperature to high. Flavor the beans now with salt.",
+                        "position": 1
+                    },
+                    {
+                        "text": "Once brought to a simmer, stir the beans and cover. Set a timer for 40 minutes and check in 5 minute increments afterwards for doneness. Season now with salt. To make sure the beans are cooked through, taste with a spoon. A cooked bean should be creamy on the inside with skin that is intact, not broken.",
+                        "position": 2
+                    },
+                    {
+                        "text": "Turn off the heat. Strain beans from their liquids to cool down on sheet trays.",
+                        "position": 3
+                    }
+                ],
+                "dietaryFlagsWithUsages": []
+            }
+        }
+    },
+    {
+        "id": "whkxj26090m",
+        "ancestorComponentIds": [
+            "x5ccun97m7",
+            "p1izi6jy93l",
+            "t2xotugmk6p"
+        ],
+        "quantity": 0.07031249993799499,
+        "unit": {
+            "id": UnitEnum.LB.value,
+            "name": "lb",
+            "unitValues": [
+                {
+                    "value": 453.59237,
+                    "unit": {
+                        "id": UnitEnum.G.value,
+                        "name": "g"
+                    }
+                },
+                {
+                    "value": 16.000000014109585,
+                    "unit": {
+                        "id": UnitEnum.OZ.value,
+                        "name": "oz"
+                    }
+                },
+                {
+                    "value": 1,
+                    "unit": {
+                        "id": UnitEnum.LB.value,
+                        "name": "lb"
+                    }
+                }
+            ]
+        },
+        "recipeItem": {
+            "preparations": [],
+            "quantity": 75,
+            "unit": {
+                "id": UnitEnum.LB.value,
+                "name": "lb"
+            },
+            "ingredient": {
+                "locationVendorItems": [],
+                "id": "aW5ncmVkaWVudDoyNDQyODE=",
+                "name": "beans, garbanzo, dry",
+                "externalName": "Garbanzo Beans",
+                "categoryValues": [],
+                "dietaryFlags": []
+            },
+            "subRecipe": None
+        }
+    },
+    {
+        "id": "22r2c3aruw4",
+        "ancestorComponentIds": [
+            "x5ccun97m7",
+            "p1izi6jy93l"
+        ],
+        "quantity": 0.0112499999900792,
+        "unit": {
+            "id": UnitEnum.LB.value,
+            "name": "lb",
+            "unitValues": [
+                {
+                    "value": 453.59237,
+                    "unit": {
+                        "id": UnitEnum.G.value,
+                        "name": "g"
+                    }
+                },
+                {
+                    "value": 16.000000014109585,
+                    "unit": {
+                        "id": UnitEnum.OZ.value,
+                        "name": "oz"
+                    }
+                },
+                {
+                    "value": 1,
+                    "unit": {
+                        "id": UnitEnum.LB.value,
+                        "name": "lb"
+                    }
+                }
+            ]
+        },
+        "recipeItem": {
+            "preparations": [],
+            "quantity": 6,
+            "unit": {
+                "id": UnitEnum.LB.value,
+                "name": "lb"
+            },
+            "ingredient": {
+                "locationVendorItems": [],
+                "id": "aW5ncmVkaWVudDoyNDQ2MzA=",
+                "name": "oil, olive",
+                "externalName": "Extra Virgin Olive Oil",
+                "categoryValues": [],
+                "dietaryFlags": []
+            },
+            "subRecipe": None
+        }
+    },
+    {
+        "id": "vyx5cb1ymt",
+        "ancestorComponentIds": [
+            "x5ccun97m7",
+            "p1izi6jy93l"
+        ],
+        "quantity": 0.0112499999900792,
+        "unit": {
+            "id": UnitEnum.LB.value,
+            "name": "lb",
+            "unitValues": [
+                {
+                    "value": 453.59237,
+                    "unit": {
+                        "id": UnitEnum.G.value,
+                        "name": "g"
+                    }
+                },
+                {
+                    "value": 16.000000014109585,
+                    "unit": {
+                        "id": UnitEnum.OZ.value,
+                        "name": "oz"
+                    }
+                },
+                {
+                    "value": 1,
+                    "unit": {
+                        "id": UnitEnum.LB.value,
+                        "name": "lb"
+                    }
+                }
+            ]
+        },
+        "recipeItem": {
+            "preparations": [],
+            "quantity": 6,
+            "unit": {
+                "id": UnitEnum.LB.value,
+                "name": "lb"
+            },
+            "ingredient": {
+                "locationVendorItems": [],
+                "id": "aW5ncmVkaWVudDoyNDQ1MzU=",
+                "name": "juice, lemon",
+                "externalName": "Lemon Juice",
+                "categoryValues": [],
+                "dietaryFlags": []
+            },
+            "subRecipe": None
+        }
+    },
+    {
+        "id": "sb4q527ncb",
+        "ancestorComponentIds": [
+            "x5ccun97m7"
+        ],
+        "quantity": 1,
+        "unit": {
+            "id": UnitEnum.EACH.value,
+            "name": "each",
+            "unitValues": [
+                {
+                    "value": 65.20390312999999,
+                    "unit": {
+                        "id": UnitEnum.G.value,
+                        "name": "g"
+                    }
+                },
+                {
+                    "value": 2.3,
+                    "unit": {
+                        "id": UnitEnum.OZ.value,
+                        "name": "oz"
+                    }
+                },
+                {
+                    "value": 0.14374999987323417,
+                    "unit": {
+                        "id": UnitEnum.LB.value,
+                        "name": "lb"
+                    }
+                },
+                {
+                    "value": 1,
+                    "unit": {
+                        "id": UnitEnum.EACH.value,
+                        "name": "each"
+                    }
+                }
+            ]
+        },
+        "recipeItem": {
+            "preparations": [],
+            "quantity": 1,
+            "unit": {
+                "id": UnitEnum.EACH.value,
+                "name": "each"
+            },
+            "ingredient": {
+                "locationVendorItems": [],
+                "id": "aW5ncmVkaWVudDoyNDU5MDM=",
+                "name": "TS48 - 48oz Meal Boxes",
+                "externalName": "48 oz Meal Boxes",
+                "categoryValues": [
+                    {
+                        "id": IngredientCategoryValueEnum.FOOD_PACKAGE.value,
+                        "name": "food pkg",
+                        "category": {
+                            "id": "Y2F0ZWdvcnk6MjQyMA==",
+                            "name": "accounting group",
+                            "itemType": "ingredient"
+                        }
+                    }
+                ],
+                "dietaryFlags": []
+            },
+            "subRecipe": None
+        }
+    },
+    {
+        "id": "9ty070197l",
+        "ancestorComponentIds": [
+            "x5ccun97m7"
+        ],
+        "quantity": 2,
+        "unit": {
+            "id": UnitEnum.OZ.value,
+            "name": "oz",
+            "unitValues": [
+                {
+                    "value": 28.3495231,
+                    "unit": {
+                        "id": UnitEnum.G.value,
+                        "name": "g"
+                    }
+                },
+                {
+                    "value": 1,
+                    "unit": {
+                        "id": UnitEnum.OZ.value,
+                        "name": "oz"
+                    }
+                },
+                {
+                    "value": 0.06249999994488443,
+                    "unit": {
+                        "id": UnitEnum.LB.value,
+                        "name": "lb"
+                    }
+                }
+            ]
+        },
+        "recipeItem": {
+            "preparations": [
+                {
+                    "id": PreparationEnum.TWO_OZ_WINPAK.value,
+                    "name": "2 oz WINPAK"
+                },
+                {
+                    "id": PreparationEnum.STANDALONE.value,
+                    "name": "standalone"
+                }
+            ],
+            "quantity": 2,
+            "unit": {
+                "id": UnitEnum.OZ.value,
+                "name": "oz"
+            },
+            "ingredient": None,
+            "subRecipe": {
+                "id": "cmVjaXBlOjIyMzU3MQ==",
+                "name": "Red Wine Vinaigrette 2oz",
+                "externalName": "Red Wine Vinaigrette",
+                "categoryValues": [],
+                "recipeInstructions": [],
+                "dietaryFlagsWithUsages": []
+            }
+        }
+    },
+    {
+        "id": "arlkvxgdzvv",
+        "ancestorComponentIds": [
+            "x5ccun97m7",
+            "9ty070197l"
+        ],
+        "quantity": 2,
+        "unit": {
+            "id": UnitEnum.OZ.value,
+            "name": "oz",
+            "unitValues": [
+                {
+                    "value": 28.3495231,
+                    "unit": {
+                        "id": UnitEnum.G.value,
+                        "name": "g"
+                    }
+                },
+                {
+                    "value": 1,
+                    "unit": {
+                        "id": UnitEnum.OZ.value,
+                        "name": "oz"
+                    }
+                },
+                {
+                    "value": 0.06249999994488443,
+                    "unit": {
+                        "id": UnitEnum.LB.value,
+                        "name": "lb"
+                    }
+                }
+            ]
+        },
+        "recipeItem": {
+            "preparations": [],
+            "quantity": 2,
+            "unit": {
+                "id": UnitEnum.OZ.value,
+                "name": "oz"
+            },
+            "ingredient": None,
+            "subRecipe": {
+                "id": "cmVjaXBlOjE3NDI4OA==",
+                "name": "Red Wine Vinaigrette BASE",
+                "externalName": None,
+                "categoryValues": [],
+                "recipeInstructions": [
+                    {
+                        "text": "In blixer combine half of the liquids to break up the red onion and garlic.",
+                        "position": 0
+                    },
+                    {
+                        "text": "Slowly add in oil through opening on the lid until emulsified.",
+                        "position": 1
+                    },
+                    {
+                        "text": "Pour into lexans.",
+                        "position": 2
+                    }
+                ],
+                "dietaryFlagsWithUsages": []
+            }
+        }
+    },
+    {
+        "id": "jyoqmn9ieg",
+        "ancestorComponentIds": [
+            "x5ccun97m7",
+            "9ty070197l",
+            "arlkvxgdzvv"
+        ],
+        "quantity": 0.022916666646457626,
+        "unit": {
+            "id": UnitEnum.LB.value,
+            "name": "lb",
+            "unitValues": [
+                {
+                    "value": 453.59237,
+                    "unit": {
+                        "id": UnitEnum.G.value,
+                        "name": "g"
+                    }
+                },
+                {
+                    "value": 16.000000014109585,
+                    "unit": {
+                        "id": UnitEnum.OZ.value,
+                        "name": "oz"
+                    }
+                },
+                {
+                    "value": 1,
+                    "unit": {
+                        "id": UnitEnum.LB.value,
+                        "name": "lb"
+                    }
+                }
+            ]
+        },
+        "recipeItem": {
+            "preparations": [],
+            "quantity": 11,
+            "unit": {
+                "id": UnitEnum.LB.value,
+                "name": "lb"
+            },
+            "ingredient": {
+                "locationVendorItems": [],
+                "id": "aW5ncmVkaWVudDoyNDQ5MTE=",
+                "name": "vinegar, red wine",
+                "externalName": "Red Wine Vinegar",
+                "categoryValues": [],
+                "dietaryFlags": []
+            },
+            "subRecipe": None
+        }
+    },
+    {
+        "id": "3v0evgbhdzf",
+        "ancestorComponentIds": [
+            "x5ccun97m7",
+            "9ty070197l",
+            "arlkvxgdzvv"
+        ],
+        "quantity": 0.007291666660236518,
+        "unit": {
+            "id": UnitEnum.LB.value,
+            "name": "lb",
+            "unitValues": [
+                {
+                    "value": 453.59237,
+                    "unit": {
+                        "id": UnitEnum.G.value,
+                        "name": "g"
+                    }
+                },
+                {
+                    "value": 16.000000014109585,
+                    "unit": {
+                        "id": UnitEnum.OZ.value,
+                        "name": "oz"
+                    }
+                },
+                {
+                    "value": 1,
+                    "unit": {
+                        "id": UnitEnum.LB.value,
+                        "name": "lb"
+                    }
+                }
+            ]
+        },
+        "recipeItem": {
+            "preparations": [],
+            "quantity": 3.5,
+            "unit": {
+                "id": UnitEnum.LB.value,
+                "name": "lb"
+            },
+            "ingredient": {
+                "locationVendorItems": [],
+                "id": "aW5ncmVkaWVudDoyNDQ3NzA=",
+                "name": "sauce, mustard, dijon",
+                "externalName": "Dijon Mustard (Water, Mustard Seeds, Vinegar, Salt)",
+                "categoryValues": [],
+                "dietaryFlags": []
+            },
+            "subRecipe": None
+        }
+    },
+    {
+        "id": "4pf3lu669b",
+        "ancestorComponentIds": [
+            "x5ccun97m7",
+            "9ty070197l",
+            "arlkvxgdzvv"
+        ],
+        "quantity": 0.00520833332874037,
+        "unit": {
+            "id": UnitEnum.LB.value,
+            "name": "lb",
+            "unitValues": [
+                {
+                    "value": 453.59237,
+                    "unit": {
+                        "id": UnitEnum.G.value,
+                        "name": "g"
+                    }
+                },
+                {
+                    "value": 16.000000014109585,
+                    "unit": {
+                        "id": UnitEnum.OZ.value,
+                        "name": "oz"
+                    }
+                },
+                {
+                    "value": 1,
+                    "unit": {
+                        "id": UnitEnum.LB.value,
+                        "name": "lb"
+                    }
+                }
+            ]
+        },
+        "recipeItem": {
+            "preparations": [],
+            "quantity": 2.5,
+            "unit": {
+                "id": UnitEnum.LB.value,
+                "name": "lb"
+            },
+            "ingredient": None,
+            "subRecipe": {
+                "id": "cmVjaXBlOjE4NDY0Mg==",
+                "name": "Minced Garlic",
+                "externalName": None,
+                "categoryValues": [],
+                "recipeInstructions": [
+                    {
+                        "text": "Add the garlic cloves to the blixer to process.  Pulse until finely minced.",
+                        "position": 0
+                    },
+                    {
+                        "text": "Transfer to a cambro or lexan.",
+                        "position": 1
+                    }
+                ],
+                "dietaryFlagsWithUsages": []
+            }
+        }
+    },
+    {
+        "id": "tv3haa35fk",
+        "ancestorComponentIds": [
+            "x5ccun97m7",
+            "9ty070197l",
+            "arlkvxgdzvv",
+            "4pf3lu669b"
+        ],
+        "quantity": 0.00520833332874037,
+        "unit": {
+            "id": UnitEnum.LB.value,
+            "name": "lb",
+            "unitValues": [
+                {
+                    "value": 453.59237,
+                    "unit": {
+                        "id": UnitEnum.G.value,
+                        "name": "g"
+                    }
+                },
+                {
+                    "value": 16.000000014109585,
+                    "unit": {
+                        "id": UnitEnum.OZ.value,
+                        "name": "oz"
+                    }
+                },
+                {
+                    "value": 1,
+                    "unit": {
+                        "id": UnitEnum.LB.value,
+                        "name": "lb"
+                    }
+                }
+            ]
+        },
+        "recipeItem": {
+            "preparations": [],
+            "quantity": 40,
+            "unit": {
+                "id": UnitEnum.LB.value,
+                "name": "lb"
+            },
+            "ingredient": {
+                "locationVendorItems": [],
+                "id": "aW5ncmVkaWVudDoyNDQ0NjI=",
+                "name": "garlic, cloves",
+                "externalName": "Garlic",
+                "categoryValues": [],
+                "dietaryFlags": []
+            },
+            "subRecipe": None
+        }
+    },
+    {
+        "id": "2shnflhm1zl",
+        "ancestorComponentIds": [
+            "x5ccun97m7"
+        ],
+        "quantity": 1,
+        "unit": {
+            "id": UnitEnum.EACH.value,
+            "name": "each",
+            "unitValues": [
+                {
+                    "value": 3.685438003,
+                    "unit": {
+                        "id": UnitEnum.G.value,
+                        "name": "g"
+                    }
+                },
+                {
+                    "value": 0.13,
+                    "unit": {
+                        "id": UnitEnum.OZ.value,
+                        "name": "oz"
+                    }
+                },
+                {
+                    "value": 0.008124999992834976,
+                    "unit": {
+                        "id": UnitEnum.LB.value,
+                        "name": "lb"
+                    }
+                },
+                {
+                    "value": 1,
+                    "unit": {
+                        "id": UnitEnum.EACH.value,
+                        "name": "each"
+                    }
+                }
+            ]
+        },
+        "recipeItem": {
+            "preparations": [],
+            "quantity": 1,
+            "unit": {
+                "id": UnitEnum.EACH.value,
+                "name": "each"
+            },
+            "ingredient": {
+                "locationVendorItems": [],
+                "id": "aW5ncmVkaWVudDoyNzQ5NjA=",
+                "name": "WINPAK Portion Cups",
+                "externalName": "WIN2 - WINPAK Portion Cups 2oz WIN2",
+                "categoryValues": [
+                    {
+                        "id": IngredientCategoryValueEnum.FOOD_PACKAGE.value,
+                        "name": "food pkg",
+                        "category": {
+                            "id": "Y2F0ZWdvcnk6MjQyMA==",
+                            "name": "accounting group",
+                            "itemType": "ingredient"
+                        }
+                    }
+                ],
+                "dietaryFlags": []
+            },
+            "subRecipe": None
         }
     }
 ]
 
 
-mock_formatted_primaryRecipeComponents = [
+MOCK_FORMATTED_PRIMARY_RECIPE_COMPONENTS = [
     {
-        'type': 'recipe',
-        'id': 'cmVjaXBlOjE4OTcwNA==',
-        'name': 'Olive Red Pepper & Cucumber Quinoa Pilaf',
-        'allergens': [],
-        'cuppingContainer': '2 oz RAM',
-        'usage': {
-            'value': 4,
-            'unit': 'oz'
+        "allergens": [],
+        "binWeight": {
+            "unit": "lb",
+            "value": 50.0
         },
-        'quantityValues': [{
-            'value': 4,
-            'unit': 'oz'
-        }, {
-            'value': 0.2499999997795377,
-            'unit': 'lb'
-        }],
-        'binWeight': {
-            'value': 50.0,
-            'unit': 'lb'
-        },
-        'instructions':  [
+        "cuppingContainer": "2 oz RAM",
+        "id": "cmVjaXBlOjE4OTcwNA==",
+        "instructions": [
             {
-                'id': 1,
-                'text': 'Stage lexans for mixing. With sleeved gloves, mix the cucumber, red bell pepper, olives, hemp seeds, parsley and scallions in the quinoa being sure to distribute each ingredient evenly.'
+                "id": 1,
+                "text": "Stage lexans for mixing. With sleeved gloves, mix the cucumber, red bell pepper, olives, hemp seeds, parsley and scallions in the quinoa being sure to distribute each ingredient evenly."
             }
         ],
-        'recipeComponents': [
+        "name": "Olive, Red Pepper & Cucumber Quinoa Pilaf",
+        "quantityValues": [
             {
-                'type': 'recipe',
-                'id': 'cmVjaXBlOjE4ODYwNg==',
-                'name': 'Cooked Rainbow Quinoa',
-                'allergens': [],
-                'usage': {
-                    'value': 30,
-                    'unit': 'lb'
-                }
+                "unit": "oz",
+                "value": 4.0
             },
             {
-                'type': 'ingredient',
-                'id': 'aW5ncmVkaWVudDoyNDQ2Mzc=',
-                'name': 'olives, kalamata, sliced',
-                'allergens': [],
-                'usage': {
-                    'value': 7,
-                    'unit': 'lb'
-                }
-            },
-            {
-                'type': 'recipe',
-                'id': 'cmVjaXBlOjE3Mjk2NQ==',
-                'name': 'Sliced Scallion',
-                'allergens': [],
-                'usage': {
-                    'value': 8,
-                    'unit': 'oz'
-                }
-            },
-        ],
-    },
-    {
-        'type': 'recipe',
-        'id': 'cmVjaXBlOjE3NjQ3Mw==',
-        'name': 'Tofu Feta',
-        'allergens': ['soy'],
-        'cuppingContainer': 'INSERT12',
-        'usage': {
-            'value': 1.5,
-            'unit': 'oz'
-        },
-        'quantityValues': [{
-            'value': 1.5,
-            'unit': 'oz'
-        }, {
-            'value': 0.09374999991732665,
-            'unit': 'lb'
-        }],
-        'binWeight': {
-            'value': 60.0,
-            'unit': 'lb'
-        },
-        'instructions': [
-            {
-                'id': 1,
-                'text': 'Stage clear polycarbonate lexans for mixing and add brine for tofu feta.'
-            },
-            {
-                'id': 2,
-                'text': 'Dice Tofu into small 1/4" diced bite sized squares and add to each lexan, mixing well with the brine for tofu feta, being sure all of the tofu is submerged.'
-            },
-            {
-                'id': 3,
-                'text': 'Let sit at least 4 hours, best overnight.'
-            },
-            {
-                'id': 4,
-                'text': 'Strain well before serving.'
+                "unit": "lb",
+                "value": 0.2499999997795377
             }
         ],
-        'recipeComponents': [
+        "recipeComponents": [
             {
-                'type': 'recipe',
-                'id': 'cmVjaXBlOjE5MDA5MQ==',
-                'name': 'Small Diced Tofu (1/4")',
-                'allergens': ['soy'],
-                'usage': {
-                    'value': 56,
-                    'unit': 'lb'
+                "allergens": [],
+                "id": "cmVjaXBlOjE4ODYwNg==",
+                "name": "Cooked Rainbow Quinoa",
+                "type": "recipe",
+                "usage": {
+                    "unit": "lb",
+                    "value": 30
+                }
+            },
+            {
+                "allergens": [],
+                "id": "aW5ncmVkaWVudDoyNDQ2Mzc=",
+                "name": "olives, kalamata, sliced",
+                "type": "ingredient",
+                "usage": {
+                    "unit": "lb",
+                    "value": 7
+                }
+            },
+            {
+                "allergens": [],
+                "id": "cmVjaXBlOjE3Mjk2NQ==",
+                "name": "Sliced Scallion",
+                "type": "recipe",
+                "usage": {
+                    "unit": "oz",
+                    "value": 8
                 }
             }
         ],
-    },
-    {
-        'type': 'ingredient',
-        'id': 'aW5ncmVkaWVudDoyNDQ1NjE=',
-        'name': 'lettuce, spring mix, SEND TO PLATE',
-        'allergens': [],
-        'cuppingContainer': None,
-        'usage': {
-            'value': 2.5,
-            'unit': 'oz'
-        },
-        'quantityValues': [{
-            'value': 2.5,
-            'unit': 'oz'
-        }, {
-            'value': 0.15624999986221108,
-            'unit': 'lb'
-        }],
-        'binWeight': {
-            'value': 30.0,
-            'unit': 'lb'
+        "type": "recipe",
+        "usage": {
+            "unit": "oz",
+            "value": 4
         }
     },
     {
-        'type': 'ingredient',
-        'id': 'aW5ncmVkaWVudDoyNzQ4ODA=',
-        'name': 'crispy roasted chickpeas, 0.85 oz bag',
-        'allergens': ['sesame_seeds', 'tree_nuts'],
-        'cuppingContainer': None,
-        'usage': {
-            'value': 0.85,
-            'unit': 'oz'
+        "allergens": [
+            "soy"
+        ],
+        "binWeight": {
+            "unit": "lb",
+            "value": 60.0
         },
-        'quantityValues': [{
-            'value': 0.85,
-            'unit': 'oz'
-        }, {
-            'value': 0.05312499995315176,
-            'unit': 'lb'
-        }],
-        'binWeight': {
-            'value': 40.0,
-            'unit': 'lb'
-        },
-    },
-    {
-        'type': 'recipe',
-        'id': 'cmVjaXBlOjE3MDU4NA==',
-        'name': 'Smashed Chickpea Salad - COOKED GARBANZOS',
-        'allergens': [],
-        'cuppingContainer': None,
-        'usage': {
-            'value': 3,
-            'unit': 'oz'
-        },
-        'quantityValues': [{
-            'value': 3,
-            'unit': 'oz'
-        }, {
-            'value': 0.1874999998346533,
-            'unit': 'lb'
-        }],
-        'binWeight': {
-            'value': 60.0,
-            'unit': 'lb'
-        },
-        'instructions': [
+        "cuppingContainer": "INSERT12",
+        "id": "cmVjaXBlOjE3NjQ3Mw==",
+        "instructions": [
             {
-                'id': 1,
-                'text': 'The hobart must be used for this task, do not mix by hand.'
+                "id": 1,
+                "text": "Stage clear polycarbonate lexans for mixing and add brine for tofu feta."
             },
             {
-                'id': 2,
-                'text': 'Latch bowl into the hobart, ensuring it is secured. While it is lowered, add in the garbanzo beans, lemon juice, and olive oil.'
+                "id": 2,
+                "text": "Dice Tofu into small 1/4\" diced bite sized squares and add to each lexan, mixing well with the brine for tofu feta, being sure all of the tofu is submerged."
             },
             {
-                'id': 3,
-                'text': 'Equip the PADDLE attachment, and patiently press the up arrow to rise the bowl until locked in place. Slide over the safeguard.'
+                "id": 3,
+                "text": "Let sit at least 4 hours, best overnight."
             },
             {
-                'id': 4,
-                'text': 'Mix on Level 1 for 2 minutes to mash the beans.'
-            },
-            {
-                'id': 5,
-                'text': 'Slide the safeguard back, and add the remaining ingredients to the mixture. Mix again for 1 minute until fully combined, while pausing every now and then to scrape down the sides and bottom of bowl with a rubber spatula.'
-            },
-            {
-                'id': 6,
-                'text': 'Lower the bowl, unlatch and grab a buddy to help pour mixture into a lexan.'
-            },
-            {
-                'id': 7,
-                'text': 'Clean the entire machine after each project, take the bowl and attachments back to the dishpit.'
+                "id": 4,
+                "text": "Strain well before serving."
             }
         ],
-        'recipeComponents': [
+        "name": "Tofu Feta",
+        "quantityValues": [
             {
-                'type': 'ingredient',
-                'id': 'aW5ncmVkaWVudDoyNDQ4MzQ=',
-                'name': 'spice sumac',
-                'allergens': [],
-                'usage': {
-                    'value': 0.75,
-                    'unit': 'oz'
-                }
+                "unit": "oz",
+                "value": 1.5
             },
             {
-                'type': 'ingredient',
-                'id': 'aW5ncmVkaWVudDoyNDQ3OTM=',
-                'name': 'spice, black pepper, ground',
-                'allergens': [],
-                'usage': {
-                    'value': 2,
-                    'unit': 'oz'
-                }
-            },
-            {
-                'type': 'recipe',
-                'id': 'cmVjaXBlOjE3NjQ4MA==',
-                'name': 'Cooked Garbanzo Beans',
-                'allergens': [],
-                'usage': {
-                    'value': 75,
-                    'unit': 'lb'
-                }
-            },
-            {
-                'type': 'ingredient',
-                'id': 'aW5ncmVkaWVudDoyNDQ2MzA=',
-                'name': 'oil, olive',
-                'allergens': [],
-                'usage': {
-                    'value': 6,
-                    'unit': 'lb'
-                }
-            },
-            {
-                'type': 'ingredient',
-                'id': 'aW5ncmVkaWVudDoyNDQ1MzU=',
-                'name': 'juice, lemon',
-                'allergens': [],
-                'usage': {
-                    'value': 6,
-                    'unit': 'lb'
-                }
-            },
+                "unit": "lb",
+                "value": 0.09374999991732665
+            }
         ],
-    },
-    {
-        'type': 'ingredient',
-        'id': 'aW5ncmVkaWVudDoyNDUyMDQ=',
-        'name': "crackers, Mary's seeded GF, SEND TO PLATE",
-        'allergens': ['sesame_seeds'],
-        'cuppingContainer': '12-oz-clean-round-sided-INSERT',
-        'usage': {
-            'value': 0.75,
-            'unit': 'oz'
-        },
-        'quantityValues':[{
-            'value': 0.75,
-            'unit': 'oz'
-        }, {
-            'value': 0.04687499995866332,
-            'unit': 'lb'
-        }],
-        'binWeight': {
-            'value': 60.0,
-            'unit': 'lb'
-        },
-    },
-    {
-        'type': 'recipe',
-        'id': 'cmVjaXBlOjIyMzU3MQ==',
-        'name': 'Red Wine Vinaigrette 2oz',
-        'allergens': [],
-        'cuppingContainer': '2 oz WINPAK',
-        'usage': {
-            'value': 2,
-            'unit': 'oz'
-        },
-        'quantityValues': [{
-            'value': 2,
-            'unit': 'oz'
-        }, {
-            'value': 0.12499999988976886,
-            'unit': 'lb'
-        }],
-        'binWeight': {
-            'value': 60.0,
-            'unit': 'lb'
-        },
-        'instructions': [],
-        'recipeComponents': [
+        "recipeComponents": [
             {
-                'type': 'recipe',
-                'id': 'cmVjaXBlOjE3NDI4OA==',
-                'name': 'Red Wine Vinaigrette BASE',
-                'allergens': [],
-                'usage': {
-                    'value': 2,
-                    'unit': 'oz'
+                "allergens": [],
+                "id": "cmVjaXBlOjIxNjA2MA==",
+                "name": "Brine for \"Feta\"",
+                "type": "recipe",
+                "usage": {
+                    "unit": "lb",
+                    "value": 25
+                }
+            },
+            {
+                "allergens": [
+                    "soy"
+                ],
+                "id": "cmVjaXBlOjE5MDA5MQ==",
+                "name": "Small Diced Tofu (1/4\")",
+                "type": "recipe",
+                "usage": {
+                    "unit": "lb",
+                    "value": 35
                 }
             }
         ],
+        "type": "recipe",
+        "usage": {
+            "unit": "oz",
+            "value": 1.5
+        }
+    },
+    {
+        "allergens": [],
+        "binWeight": {
+            "unit": "lb",
+            "value": 30.0
+        },
+        "cuppingContainer": None,
+        "id": "aW5ncmVkaWVudDoyNDQ1NjE=",
+        "name": "lettuce, spring mix, SEND TO PLATE",
+        "quantityValues": [
+            {
+                "unit": "oz",
+                "value": 2.5
+            },
+            {
+                "unit": "lb",
+                "value": 0.15624999986221108
+            }
+        ],
+        "type": "ingredient",
+        "usage": {
+            "unit": "oz",
+            "value": 2.5
+        }
+    },
+    {
+        "allergens": [
+            "sesame_seeds",
+            "tree_nuts"
+        ],
+        "binWeight": {
+            "unit": "lb",
+            "value": 40.0
+        },
+        "cuppingContainer": None,
+        "id": "aW5ncmVkaWVudDoyNzQ4ODA=",
+        "name": "crispy roasted chickpeas, 0.85 oz bag, SEND TO PLATE",
+        "quantityValues": [
+            {
+                "unit": "oz",
+                "value": 0.85
+            },
+            {
+                "unit": "lb",
+                "value": 0.05312499995315176
+            }
+        ],
+        "type": "ingredient",
+        "usage": {
+            "unit": "each",
+            "value": 1
+        }
+    },
+    {
+        "allergens": [],
+        "binWeight": {
+            "unit": "lb",
+            "value": 60.0
+        },
+        "cuppingContainer": None,
+        "id": "cmVjaXBlOjE3MDU4NA==",
+        "instructions": [
+            {
+                "id": 1,
+                "text": "The hobart must be used for this task, do not mix by hand."
+            },
+            {
+                "id": 2,
+                "text": "Latch bowl into the hobart, ensuring it is secured. While it is lowered, add in the garbanzo beans, lemon juice, and olive oil."
+            },
+            {
+                "id": 3,
+                "text": "Equip the PADDLE attachment, and patiently press the up arrow to rise the bowl until locked in place. Slide over the safeguard."
+            },
+            {
+                "id": 4,
+                "text": "Mix on Level 1 for 2 minutes to mash the beans."
+            },
+            {
+                "id": 5,
+                "text": "Slide the safeguard back, and add the remaining ingredients to the mixture. Mix again for 1 minute until fully combined, while pausing every now and then to scrape down the sides and bottom of bowl with a rubber spatula."
+            },
+            {
+                "id": 6,
+                "text": "Lower the bowl, unlatch and grab a buddy to help pour mixture into a lexan."
+            },
+            {
+                "id": 7,
+                "text": "Clean the entire machine after each project, take the bowl and attachments back to the dishpit."
+            }
+        ],
+        "name": "Smashed Chickpea Salad - COOKED GARBANZOS",
+        "quantityValues": [
+            {
+                "unit": "oz",
+                "value": 3.0
+            },
+            {
+                "unit": "lb",
+                "value": 0.1874999998346533
+            }
+        ],
+        "recipeComponents": [
+            {
+                "allergens": [],
+                "id": "aW5ncmVkaWVudDoyNDQ4MzQ=",
+                "name": "spice, sumac",
+                "type": "ingredient",
+                "usage": {
+                    "unit": "oz",
+                    "value": 0.75
+                }
+            },
+            {
+                "allergens": [],
+                "id": "aW5ncmVkaWVudDoyNDQ3OTM=",
+                "name": "spice, black pepper, ground",
+                "type": "ingredient",
+                "usage": {
+                    "unit": "oz",
+                    "value": 2
+                }
+            },
+            {
+                "allergens": [],
+                "id": "cmVjaXBlOjE3NjQ4MA==",
+                "name": "Cooked Garbanzo Beans",
+                "type": "recipe",
+                "usage": {
+                    "unit": "lb",
+                    "value": 75
+                }
+            },
+            {
+                "allergens": [],
+                "id": "aW5ncmVkaWVudDoyNDQ2MzA=",
+                "name": "oil, olive",
+                "type": "ingredient",
+                "usage": {
+                    "unit": "lb",
+                    "value": 6
+                }
+            },
+            {
+                "allergens": [],
+                "id": "aW5ncmVkaWVudDoyNDQ1MzU=",
+                "name": "juice, lemon",
+                "type": "ingredient",
+                "usage": {
+                    "unit": "lb",
+                    "value": 6
+                }
+            }
+        ],
+        "type": "recipe",
+        "usage": {
+            "unit": "oz",
+            "value": 3
+        }
+    },
+    {
+        "allergens": [],
+        "binWeight": {
+            "unit": "lb",
+            "value": 60.0
+        },
+        "cuppingContainer": "2 oz WINPAK",
+        "id": "cmVjaXBlOjIyMzU3MQ==",
+        "instructions": [],
+        "name": "Red Wine Vinaigrette 2oz",
+        "quantityValues": [
+            {
+                "unit": "oz",
+                "value": 2.0
+            },
+            {
+                "unit": "lb",
+                "value": 0.12499999988976886
+            }
+        ],
+        "recipeComponents": [
+            {
+                "allergens": [],
+                "id": "cmVjaXBlOjE3NDI4OA==",
+                "name": "Red Wine Vinaigrette BASE",
+                "type": "recipe",
+                "usage": {
+                    "unit": "oz",
+                    "value": 2
+                }
+            }
+        ],
+        "type": "recipe",
+        "usage": {
+            "unit": "oz",
+            "value": 2
+        }
     }
 ]
 
@@ -1250,7 +2221,7 @@ def mock_ops_menu(date, location_name=DEFAULT_LOCATION, menu_type=DEFAULT_MENU_T
                                 }
                             ]
                         },
-                        'recipeTreeComponents': mock_recipeTreeComponents
+                        'recipeTreeComponents': MOCK_RECIPE_TREE_COMPONENTS
                     },
                     'volume': 923,
                     'unit': {
@@ -1297,7 +2268,7 @@ def mock_ops_menu(date, location_name=DEFAULT_LOCATION, menu_type=DEFAULT_MENU_T
                                 }
                             ]
                         },
-                        'recipeTreeComponents': mock_recipeTreeComponents
+                        'recipeTreeComponents': MOCK_RECIPE_TREE_COMPONENTS
                     },
                     'volume': 1228,
                     'unit': {
@@ -1333,7 +2304,7 @@ def mock_ops_menu(date, location_name=DEFAULT_LOCATION, menu_type=DEFAULT_MENU_T
                             }
                         ],
                         'files': {},
-                        'recipeTreeComponents': mock_recipeTreeComponents
+                        'recipeTreeComponents': MOCK_RECIPE_TREE_COMPONENTS
                     },
                     'volume': 549,
                     'unit': {
@@ -1369,7 +2340,7 @@ def mock_ops_menu(date, location_name=DEFAULT_LOCATION, menu_type=DEFAULT_MENU_T
                             }
                         ],
                         'files': {},
-                        'recipeTreeComponents': mock_recipeTreeComponents
+                        'recipeTreeComponents': MOCK_RECIPE_TREE_COMPONENTS
                     },
                     'volume': 123,
                     'unit': {
@@ -1405,7 +2376,7 @@ def mock_ops_menu(date, location_name=DEFAULT_LOCATION, menu_type=DEFAULT_MENU_T
                             }
                         ],
                         'files': {},
-                        'recipeTreeComponents': mock_recipeTreeComponents
+                        'recipeTreeComponents': MOCK_RECIPE_TREE_COMPONENTS
                     },
                     'volume': 321,
                     'unit': {
@@ -1441,7 +2412,7 @@ def mock_ops_menu(date, location_name=DEFAULT_LOCATION, menu_type=DEFAULT_MENU_T
                             }
                         ],
                         'files': {},
-                        'recipeTreeComponents': mock_recipeTreeComponents
+                        'recipeTreeComponents': MOCK_RECIPE_TREE_COMPONENTS
                     },
                     'volume': 456,
                     'unit': {
@@ -1467,7 +2438,7 @@ def mock_ops_menu(date, location_name=DEFAULT_LOCATION, menu_type=DEFAULT_MENU_T
                         'name': 'Juice',
                         'categoryValues': [],
                         'files': {},
-                        'recipeTreeComponents': mock_recipeTreeComponents
+                        'recipeTreeComponents': MOCK_RECIPE_TREE_COMPONENTS
                     },
                     'volume': 199,
                     'unit': {

--- a/tests/mock_responses/mock_ops_menu_data.py
+++ b/tests/mock_responses/mock_ops_menu_data.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from galley.common import DEFAULT_LOCATION, DEFAULT_MENU_TYPE
 from galley.enums import IngredientCategoryTagTypeEnum, MenuCategoryEnum, MenuItemCategoryEnum, PreparationEnum, RecipeCategoryTagTypeEnum, IngredientCategoryValueEnum, DietaryFlagEnum, UnitEnum
 
@@ -1946,7 +1947,7 @@ def mock_ops_menu(date, location_name=DEFAULT_LOCATION, menu_type=DEFAULT_MENU_T
                                 }
                             ]
                         },
-                        'recipeTreeComponents': MOCK_RECIPE_TREE_COMPONENTS
+                        'recipeTreeComponents': deepcopy(MOCK_RECIPE_TREE_COMPONENTS)
                     },
                     'volume': 923,
                     'unit': {
@@ -1993,7 +1994,7 @@ def mock_ops_menu(date, location_name=DEFAULT_LOCATION, menu_type=DEFAULT_MENU_T
                                 }
                             ]
                         },
-                        'recipeTreeComponents': MOCK_RECIPE_TREE_COMPONENTS
+                        'recipeTreeComponents': deepcopy(MOCK_RECIPE_TREE_COMPONENTS)
                     },
                     'volume': 1228,
                     'unit': {
@@ -2029,7 +2030,7 @@ def mock_ops_menu(date, location_name=DEFAULT_LOCATION, menu_type=DEFAULT_MENU_T
                             }
                         ],
                         'files': {},
-                        'recipeTreeComponents': MOCK_RECIPE_TREE_COMPONENTS
+                        'recipeTreeComponents': deepcopy(MOCK_RECIPE_TREE_COMPONENTS)
                     },
                     'volume': 549,
                     'unit': {
@@ -2065,7 +2066,7 @@ def mock_ops_menu(date, location_name=DEFAULT_LOCATION, menu_type=DEFAULT_MENU_T
                             }
                         ],
                         'files': {},
-                        'recipeTreeComponents': MOCK_RECIPE_TREE_COMPONENTS
+                        'recipeTreeComponents': deepcopy(MOCK_RECIPE_TREE_COMPONENTS)
                     },
                     'volume': 123,
                     'unit': {
@@ -2101,7 +2102,7 @@ def mock_ops_menu(date, location_name=DEFAULT_LOCATION, menu_type=DEFAULT_MENU_T
                             }
                         ],
                         'files': {},
-                        'recipeTreeComponents': MOCK_RECIPE_TREE_COMPONENTS
+                        'recipeTreeComponents': deepcopy(MOCK_RECIPE_TREE_COMPONENTS)
                     },
                     'volume': 321,
                     'unit': {
@@ -2137,7 +2138,7 @@ def mock_ops_menu(date, location_name=DEFAULT_LOCATION, menu_type=DEFAULT_MENU_T
                             }
                         ],
                         'files': {},
-                        'recipeTreeComponents': MOCK_RECIPE_TREE_COMPONENTS
+                        'recipeTreeComponents': []
                     },
                     'volume': 456,
                     'unit': {
@@ -2163,7 +2164,7 @@ def mock_ops_menu(date, location_name=DEFAULT_LOCATION, menu_type=DEFAULT_MENU_T
                         'name': 'Juice',
                         'categoryValues': [],
                         'files': {},
-                        'recipeTreeComponents': MOCK_RECIPE_TREE_COMPONENTS
+                        'recipeTreeComponents': []
                     },
                     'volume': 199,
                     'unit': {

--- a/tests/test_ops_formatted_queries.py
+++ b/tests/test_ops_formatted_queries.py
@@ -23,7 +23,7 @@ def formatted_ops_menu(date, location_name=DEFAULT_LOCATION, menu_type=DEFAULT_M
             'platePhotoUrl': 'https://cdn.filestackcontent.com/2X5ivrEYQvuEh30DyYot',
             'totalCount': 923,
             'totalCountUnit': 'each',
-            'primaryRecipeComponents': [],
+            'primaryRecipeComponents': MOCK_FORMATTED_PRIMARY_RECIPE_COMPONENTS,
 
         }, {
             'menuItemId': 'MENUITEM2DEF-OPS',
@@ -34,7 +34,7 @@ def formatted_ops_menu(date, location_name=DEFAULT_LOCATION, menu_type=DEFAULT_M
             'platePhotoUrl': 'https://cdn.filestackcontent.com/IQM3KcAkRye81xuN5JY4',
             'totalCount': 1228,
             'totalCountUnit': 'each',
-            'primaryRecipeComponents': [],
+            'primaryRecipeComponents': MOCK_FORMATTED_PRIMARY_RECIPE_COMPONENTS,
 
         }, {
             'menuItemId': 'MENUITEM3GHI-OPS',
@@ -45,7 +45,7 @@ def formatted_ops_menu(date, location_name=DEFAULT_LOCATION, menu_type=DEFAULT_M
             'platePhotoUrl': None,
             'totalCount': 549,
             'totalCountUnit': 'each',
-            'primaryRecipeComponents': [],
+            'primaryRecipeComponents': MOCK_FORMATTED_PRIMARY_RECIPE_COMPONENTS,
 
         }, {
             'menuItemId': 'MENUITEM4JKL-OPS',
@@ -56,7 +56,7 @@ def formatted_ops_menu(date, location_name=DEFAULT_LOCATION, menu_type=DEFAULT_M
             'platePhotoUrl': None,
             'totalCount': 123,
             'totalCountUnit': 'each',
-            'primaryRecipeComponents': [],
+            'primaryRecipeComponents': MOCK_FORMATTED_PRIMARY_RECIPE_COMPONENTS,
         }, {
             'menuItemId': 'MENUITEM5MNO-OPS',
             'mealCode': 'sch',
@@ -66,7 +66,7 @@ def formatted_ops_menu(date, location_name=DEFAULT_LOCATION, menu_type=DEFAULT_M
             'platePhotoUrl': None,
             'totalCount': 321,
             'totalCountUnit': 'each',
-            'primaryRecipeComponents': [],
+            'primaryRecipeComponents': MOCK_FORMATTED_PRIMARY_RECIPE_COMPONENTS,
         }]
     }
     return formatted_ops_menu
@@ -284,9 +284,6 @@ class TestGetFormattedBinWeightData(TestCase):
 
 
 class TestGetFormattedOpsMenuData(TestCase):
-    def setUp(self):
-        self.MOCK_RECIPE_TREE_COMPONENTS = deepcopy(MOCK_RECIPE_TREE_COMPONENTS)
-
     def response(self, *menus):
         return ({
             'data': {
@@ -298,7 +295,7 @@ class TestGetFormattedOpsMenuData(TestCase):
 
     def test_format_primary_recipe_components(self):
         self.maxDiff = None
-        result = format_components(self.MOCK_RECIPE_TREE_COMPONENTS)
+        result = format_components(deepcopy(MOCK_RECIPE_TREE_COMPONENTS))
         self.assertEqual(result, MOCK_FORMATTED_PRIMARY_RECIPE_COMPONENTS)
 
     @mock.patch('galley.queries.make_request_to_galley')
@@ -308,6 +305,28 @@ class TestGetFormattedOpsMenuData(TestCase):
         meal_codes = set(mi['mealCode'] for mi in result[0]['menuItems'])
         self.assertTrue('av' not in meal_codes and 'hla' not in meal_codes)
         self.assertEqual(set(['lm1', 'lv2', 'dv3', 'ssa', 'sch']), meal_codes)
+
+    @mock.patch('galley.queries.make_request_to_galley')
+    def test_get_formatted_ops_menu_data_successful_for_one_valid_menu(self, mock_retrieval_method):
+        self.maxDiff = None
+        mock_retrieval_method.return_value = self.response(mock_ops_menu('2022-03-28'))
+        result = get_formatted_ops_menu_data(['2022-03-28'])
+        self.assertEqual(result, [formatted_ops_menu('2022-03-28')])
+
+    @mock.patch('galley.queries.make_request_to_galley')
+    def test_get_formatted_ops_menu_data_successful_for_multiple_valid_menus(self, mock_retrieval_method):
+        self.maxDiff = None
+        mock_retrieval_method.return_value = self.response(
+            mock_ops_menu('2022-03-28'),
+            mock_ops_menu('2022-04-04'),
+            mock_ops_menu('2022-04-18')
+        )
+        result = get_formatted_ops_menu_data(['2022-03-28', '2022-04-04', '2022-04-18'])
+        self.assertEqual(result, [
+            formatted_ops_menu('2022-03-28'),
+            formatted_ops_menu('2022-04-04'),
+            formatted_ops_menu('2022-04-18')
+        ])
 
     @mock.patch('galley.queries.make_request_to_galley')
     def test_get_formatted_ops_menu_data_exception(self, mock_retrieval_method):

--- a/tests/test_ops_formatted_queries.py
+++ b/tests/test_ops_formatted_queries.py
@@ -1,25 +1,10 @@
+from copy import deepcopy
 from unittest import TestCase, mock
-
 from galley.common import DEFAULT_LOCATION, DEFAULT_MENU_TYPE
-from galley.enums import DietaryFlagEnum as DF
-from galley.formatted_queries import (
-    get_menu_type,
-    get_item_code
-)
-from galley.formatted_ops_queries import (
-    FormattedRecipeComponent,
-    format_ops_menu_rtc_data,
-    get_cupping_container,
-    get_formatted_ops_menu_data,
-    format_instructions,
-    format_allergens,
-    format_bin_weight
-)
-from tests.mock_responses.mock_ops_menu_data import (
-    mock_ops_menu,
-    mock_recipeTreeComponents,
-    mock_formatted_primaryRecipeComponents as mock_primaryComponents,
-)
+from galley.enums import DietaryFlagEnum as DF, PreparationEnum
+from galley.formatted_queries import get_menu_type, get_item_code
+from galley.formatted_ops_queries import RecipeItem, format_components, get_formatted_ops_menu_data
+from tests.mock_responses.mock_ops_menu_data import mock_ops_menu, MOCK_RECIPE_TREE_COMPONENTS, MOCK_FORMATTED_PRIMARY_RECIPE_COMPONENTS
 
 
 def formatted_ops_menu(date, location_name=DEFAULT_LOCATION, menu_type=DEFAULT_MENU_TYPE):
@@ -38,7 +23,7 @@ def formatted_ops_menu(date, location_name=DEFAULT_LOCATION, menu_type=DEFAULT_M
             'platePhotoUrl': 'https://cdn.filestackcontent.com/2X5ivrEYQvuEh30DyYot',
             'totalCount': 923,
             'totalCountUnit': 'each',
-            'primaryRecipeComponents': mock_primaryComponents,
+            'primaryRecipeComponents': [],
 
         }, {
             'menuItemId': 'MENUITEM2DEF-OPS',
@@ -49,7 +34,7 @@ def formatted_ops_menu(date, location_name=DEFAULT_LOCATION, menu_type=DEFAULT_M
             'platePhotoUrl': 'https://cdn.filestackcontent.com/IQM3KcAkRye81xuN5JY4',
             'totalCount': 1228,
             'totalCountUnit': 'each',
-            'primaryRecipeComponents': mock_primaryComponents,
+            'primaryRecipeComponents': [],
 
         }, {
             'menuItemId': 'MENUITEM3GHI-OPS',
@@ -60,7 +45,7 @@ def formatted_ops_menu(date, location_name=DEFAULT_LOCATION, menu_type=DEFAULT_M
             'platePhotoUrl': None,
             'totalCount': 549,
             'totalCountUnit': 'each',
-            'primaryRecipeComponents': mock_primaryComponents,
+            'primaryRecipeComponents': [],
 
         }, {
             'menuItemId': 'MENUITEM4JKL-OPS',
@@ -71,7 +56,7 @@ def formatted_ops_menu(date, location_name=DEFAULT_LOCATION, menu_type=DEFAULT_M
             'platePhotoUrl': None,
             'totalCount': 123,
             'totalCountUnit': 'each',
-            'primaryRecipeComponents': mock_primaryComponents,
+            'primaryRecipeComponents': [],
         }, {
             'menuItemId': 'MENUITEM5MNO-OPS',
             'mealCode': 'sch',
@@ -81,7 +66,7 @@ def formatted_ops_menu(date, location_name=DEFAULT_LOCATION, menu_type=DEFAULT_M
             'platePhotoUrl': None,
             'totalCount': 321,
             'totalCountUnit': 'each',
-            'primaryRecipeComponents': mock_primaryComponents,
+            'primaryRecipeComponents': [],
         }]
     }
     return formatted_ops_menu
@@ -111,110 +96,197 @@ class TestGetMenuTypeFromMenuCategoryValues(TestCase):
 
 class TestFormattedRecipeInstructions(TestCase):
     def test_format_instructions_successful(self):
-        response = [{"text": "Please keep in mind the tamper seal from bottled containers can fall into the recipe you are making. Be sure to discard any tamper seals immediately after breaking the seal.",
-                     "position": 0},
-                    {"text": "In the blixer combine all of the ingredients and blend on intervals of 30 seconds until the texture is smooth and creamy.",
-                     "position": 1},
-                    {"text": "Pour into lexans.",
-                     "position": 2}]
-        expected = [{"id": 1,
-                     "text": "Please keep in mind the tamper seal from bottled containers can fall into the recipe you are making. Be sure to discard any tamper seals immediately after breaking the seal."},
-                    {"id": 2,
-                     "text": "In the blixer combine all of the ingredients and blend on intervals of 30 seconds until the texture is smooth and creamy."},
-                    {"id": 3,
-                     "text": "Pour into lexans."}]
-        result = format_instructions(response)
+        recipeitem = {
+            "preparations": [],
+            "ingredient": None,
+            "subRecipe": {
+                "recipeInstructions": [
+                    {"text": "In blixer combine half of the liquids to break up the red onion and garlic.", "position": 0},
+                    {"text": "Slowly add in oil through opening on the lid until emulsified.", "position": 1},
+                    {"text": "Pour into lexans.", "position": 2}
+                ]
+            }
+        }
+        expected = [
+            {"id": 1, "text": "In blixer combine half of the liquids to break up the red onion and garlic."},
+            {"id": 2, "text": "Slowly add in oil through opening on the lid until emulsified."},
+            {"id": 3, "text": "Pour into lexans."}
+        ]
+        result = RecipeItem(recipeitem=recipeitem).format_instructions()
         self.assertEqual(result, expected)
 
     def test_format_instructions_empty(self):
-        result = format_instructions([])
+        recipeitem = {
+            "preparations": [],
+            "ingredient": None,
+            "subRecipe": {
+                "recipeInstructions": []
+            }
+        }
+        result = RecipeItem(recipeitem=recipeitem).format_instructions()
         self.assertEqual(result, [])
 
     def test_format_instructions_None(self):
-        result = format_instructions(None)
+        recipeitem = {
+            "preparations": [],
+            "ingredient": None,
+            "subRecipe": {
+                "recipeInstructions": None
+            }
+        }
+        result = RecipeItem(recipeitem=recipeitem).format_instructions()
         self.assertEqual(result, [])
 
 
 class TestFormattedCuppingContainerData(TestCase):
     def test_get_cupping_container_data_successful(self):
-        mock_data = mock_recipeTreeComponents[4]['recipeItem']
-        result = get_cupping_container(mock_data['preparations'])
+        recipeitem = {
+            "preparations": [
+                {"id": PreparationEnum.TWO_OZ_WINPAK.value, "name": "2 oz WINPAK"},
+                {"id": PreparationEnum.STANDALONE.value, "name": "standalone"}
+            ],
+            "ingredient": None,
+            "subRecipe": {}
+        }
+        result = RecipeItem(recipeitem=recipeitem).get_cupping_container()
         self.assertEqual(result, '2 oz WINPAK')
 
     def test_get_cupping_container_data_empty_preparations(self):
-        mock_data = mock_recipeTreeComponents[1]['recipeItem']
-        result = get_cupping_container(mock_data['preparations'])
+        recipeitem = {
+            "preparations": [],
+            "ingredient": None,
+            "subRecipe": {}
+        }
+        result = RecipeItem(recipeitem=recipeitem).get_cupping_container()
         self.assertEqual(result, None)
 
     def test_get_cupping_container_data_null_preparations(self):
-        mock_rtc = mock_recipeTreeComponents[1]
-        mock_rtc['recipeItem']['preparations'] = None
-        result = FormattedRecipeComponent(mock_rtc) \
-                .to_primary_component_dict()
-        self.assertEqual(result['cuppingContainer'], None)
+        recipeitem = {
+            "preparations": None,
+            "ingredient": None,
+            "subRecipe": {}
+        }
+        result = RecipeItem(recipeitem=recipeitem).get_cupping_container()
+        self.assertEqual(result, None)
 
-    def test_get_cupping_container_from_nested_primary_component(self):
-        mock_rtc = mock_recipeTreeComponents[0]
-        result = format_ops_menu_rtc_data([mock_rtc])[0]
-        self.assertEqual(result['id'], 'cmVjaXBlOjE4OTcwNA==')
-        self.assertEqual(result['cuppingContainer'], '2 oz RAM')
-        self.assertEqual(result, mock_primaryComponents[0])
+
+def idx(key, value):
+    return MOCK_RECIPE_TREE_COMPONENTS.index(next(filter(
+        lambda rtc: rtc[key] == value,
+        MOCK_RECIPE_TREE_COMPONENTS
+    )))
 
 
 class TestFormattedAllergenData(TestCase):
+    def setUp(self):
+        self.MOCK_RECIPE_TREE_COMPONENTS = deepcopy(MOCK_RECIPE_TREE_COMPONENTS)
+
     def test_format_recipe_allergen_data_successful(self):
-        mock_data = mock_recipeTreeComponents[0]['recipeItem']['subRecipe']
-        mock_data['dietaryFlagsWithUsage'] = [
-            {'dietaryFlag': {'id': DF.PEANUTS.value, 'name': 'peanuts'}},
-            {'dietaryFlag': {'id': DF.SOY_BEANS.value, 'name': 'soy beans'}}
-        ]
-        expected = ['peanuts', 'soy']
-        result = format_allergens(mock_data['dietaryFlagsWithUsage'])
-        self.assertEqual(result, expected)
+        recipeitem = self.MOCK_RECIPE_TREE_COMPONENTS[idx("id", "hdeta8wr90j")]['recipeItem']
+        result = RecipeItem(recipeitem=recipeitem).format_allergens()
+        self.assertEqual(result, ['soy'])
 
     def test_format_ingredient_allergen_data_successful(self):
-        mock_data = mock_recipeTreeComponents[0]['recipeItem']['subRecipe']\
-                    ['recipeTreeComponents'][3]['recipeItem']['ingredient']\
-                    ['dietaryFlags']
-        expected = ['sesame_seeds', 'tree_nuts']
-        result = format_allergens(mock_data, is_recipe=False)
-        self.assertEqual(result, expected)
+        recipeitem = self.MOCK_RECIPE_TREE_COMPONENTS[idx("id", "8o8ode59qdc")]['recipeItem']
+        result = RecipeItem(recipeitem=recipeitem).format_allergens()
+        self.assertEqual(result, ['sesame_seeds', 'tree_nuts'])
 
-    def test_format_allergen_data_empty(self):
-        result1 = format_allergens([])
-        result2 = format_allergens([], is_recipe=False)
-        self.assertEqual(result1, [])
-        self.assertEqual(result2, [])
+    def test_format_recipe_allergen_data_empty(self):
+        recipeitem = {
+            "preparations": [],
+            "ingredient": None,
+            "subRecipe": {
+                "dietaryFlagsWithUsages": []
+            }
+        }
+        result = RecipeItem(recipeitem=recipeitem).format_allergens()
+        self.assertEqual(result, [])
 
-    def test_format_allergen_data_None(self):
-        result1 = format_allergens(None)
-        result2 = format_allergens(None, is_recipe=False)
-        self.assertEqual(result1, [])
-        self.assertEqual(result2, [])
+    def test_format_ingredient_allergen_data_empty(self):
+        recipeitem = {
+            "preparations": [],
+            "ingredient": {
+                "dietaryFlags": []
+            },
+            "subRecipe": None
+        }
+        result = RecipeItem(recipeitem=recipeitem).format_allergens()
+        self.assertEqual(result, [])
+
+    def test_format_recipe_allergen_data_None(self):
+        recipeitem = {
+            "preparations": [],
+            "ingredient": None,
+            "subRecipe": {
+                "dietaryFlagsWithUsages": None
+            }
+        }
+        result = RecipeItem(recipeitem=recipeitem).format_allergens()
+        self.assertEqual(result, [])
+
+    def test_format_recipe_allergen_data_None(self):
+        recipeitem = {
+            "preparations": [],
+            "ingredient": {
+                "dietaryFlags": None
+            },
+            "subRecipe": None
+        }
+        result = RecipeItem(recipeitem=recipeitem).format_allergens()
+        self.assertEqual(result, [])
 
 
 class TestGetFormattedBinWeightData(TestCase):
-    def test_get_formatted_dynamic_bin_weight_data_successful(self):
-        mock_response = mock_recipeTreeComponents[0]['recipeItem']['subRecipe'] \
-            ['recipeTreeComponents'][0]['recipeItem']['subRecipe']['categoryValues']
-        expected = { 'value': 50, 'unit': 'lb' }
-        result = format_bin_weight(mock_response)
-        self.assertEqual(result, expected)
+    def setUp(self):
+        self.MOCK_RECIPE_TREE_COMPONENTS = deepcopy(MOCK_RECIPE_TREE_COMPONENTS)
 
-    def test_get_formatted_bin_weight_data_empty(self):
-        mock_response = mock_recipeTreeComponents[0]['recipeItem']['subRecipe'] \
-            ['recipeTreeComponents'][1]['recipeItem']['subRecipe']['categoryValues']
-        expected_default = { 'value': 60, 'unit': 'lb' }
-        result = format_bin_weight(mock_response)
-        self.assertEqual(result, expected_default)
+    def test_get_formatted_dynamic_recipe_bin_weight_data_successful(self):
+        recipeitem = self.MOCK_RECIPE_TREE_COMPONENTS[idx("id", "d44pdeapsdk")]['recipeItem']
+        result = RecipeItem(recipeitem=recipeitem).format_bin_weight()
+        self.assertEqual(result, {'value': 50, 'unit': 'lb'})
 
-    def test_get_formatted_bin_weight_data_None(self):
-        expected_default = { 'value': 60, 'unit': 'lb' }
-        result = format_bin_weight(None)
-        self.assertEqual(result, expected_default)
+    def test_get_formatted_dynamic_ingredient_bin_weight_data_successful(self):
+        recipeitem = self.MOCK_RECIPE_TREE_COMPONENTS[idx("id", "3oiimc548lt")]['recipeItem']
+        result = RecipeItem(recipeitem=recipeitem).format_bin_weight()
+        self.assertEqual(result, {'value': 30, 'unit': 'lb'})
+
+    def test_get_formatted_recipe_bin_weight_with_recipe_category_values_empty(self):
+        recipeitem = self.MOCK_RECIPE_TREE_COMPONENTS[idx("id", "wuet0e3vilq")]['recipeItem']
+        result = RecipeItem(recipeitem=recipeitem).format_bin_weight()
+        self.assertEqual(result, {'value': 60, 'unit': 'lb'})
+
+    def test_get_formatted_ingredient_bin_weight_with_ingredient_category_values_empty(self):
+        recipeitem = self.MOCK_RECIPE_TREE_COMPONENTS[idx("id", "ss91mevjky")]['recipeItem']
+        result = RecipeItem(recipeitem=recipeitem).format_bin_weight()
+        self.assertEqual(result, {'value': 60, 'unit': 'lb'})
+
+    def test_get_formatted_recipe_bin_weight_with_recipe_category_values_None(self):
+        recipeitem = {
+            "preparations": [],
+            "ingredient": {
+                "categoryValues": None
+            },
+            "subRecipe": None
+        }
+        result = RecipeItem(recipeitem=recipeitem).format_bin_weight()
+        self.assertEqual(result, {'value': 60, 'unit': 'lb'})
+
+    def test_get_formatted_ingredient_bin_weight_with_ingredient_category_values_None(self):
+        recipeitem = {
+            "preparations": [],
+            "ingredient": None,
+            "subRecipe": {
+                "categoryValues": None
+            }
+        }
+        result = RecipeItem(recipeitem=recipeitem).format_bin_weight()
+        self.assertEqual(result, {'value': 60, 'unit': 'lb'})
 
 
 class TestGetFormattedOpsMenuData(TestCase):
+    def setUp(self):
+        self.MOCK_RECIPE_TREE_COMPONENTS = deepcopy(MOCK_RECIPE_TREE_COMPONENTS)
+
     def response(self, *menus):
         return ({
             'data': {
@@ -224,31 +296,18 @@ class TestGetFormattedOpsMenuData(TestCase):
             }
         })
 
+    def test_format_primary_recipe_components(self):
+        self.maxDiff = None
+        result = format_components(self.MOCK_RECIPE_TREE_COMPONENTS)
+        self.assertEqual(result, MOCK_FORMATTED_PRIMARY_RECIPE_COMPONENTS)
+
     @mock.patch('galley.queries.make_request_to_galley')
     def test_get_formatted_ops_menu_data_returns_whitelisted_meal_codes(self, mock_retrieval_method):
         mock_retrieval_method.return_value = self.response(mock_ops_menu('2022-03-28'))
         result = get_formatted_ops_menu_data(['2022-03-28'])
-        meal_codes = {mi['mealCode'] for mi in result[0]['menuItems']}
+        meal_codes = set(mi['mealCode'] for mi in result[0]['menuItems'])
         self.assertTrue('av' not in meal_codes and 'hla' not in meal_codes)
-        self.assertEqual({'lm1', 'lv2', 'dv3', 'ssa', 'sch'}, meal_codes)
-
-    @mock.patch('galley.queries.make_request_to_galley')
-    def test_get_formatted_ops_menu_data_successful_for_one_valid_menu(self, mock_retrieval_method):
-        self.maxDiff = None
-        mock_retrieval_method.return_value = self.response(mock_ops_menu('2022-03-28'))
-        result = get_formatted_ops_menu_data(['2022-03-28'])
-        self.assertEqual(result, [formatted_ops_menu('2022-03-28')])
-
-    @mock.patch('galley.queries.make_request_to_galley')
-    def test_get_formatted_ops_menu_data_successful_for_multiple_valid_menus(self, mock_retrieval_method):
-        self.maxDiff = None
-        mock_retrieval_method.return_value = self.response(mock_ops_menu('2022-03-28'),
-                                                           mock_ops_menu('2022-04-04'),
-                                                           mock_ops_menu('2022-04-18'))
-        result = get_formatted_ops_menu_data(['2022-03-28', '2022-04-04', '2022-04-18'])
-        self.assertEqual(result, [formatted_ops_menu('2022-03-28'),
-                                  formatted_ops_menu('2022-04-04'),
-                                  formatted_ops_menu('2022-04-18')])
+        self.assertEqual(set(['lm1', 'lv2', 'dv3', 'ssa', 'sch']), meal_codes)
 
     @mock.patch('galley.queries.make_request_to_galley')
     def test_get_formatted_ops_menu_data_exception(self, mock_retrieval_method):
@@ -257,9 +316,9 @@ class TestGetFormattedOpsMenuData(TestCase):
             get_formatted_ops_menu_data([])
 
     @mock.patch('galley.formatted_ops_queries.get_raw_menu_data')
-    def test_get_formatted_ops_menu_data_args_defaults(self, mock_gromd):
+    def test_get_formatted_ops_menu_data_args_defaults(self, mock_raw_menu_data):
         dates = ['2022-03-28', '2022-04-04']
         get_formatted_ops_menu_data(dates)
-        mock_gromd.assert_called_with(dates, DEFAULT_LOCATION, DEFAULT_MENU_TYPE, is_ops=True)
+        mock_raw_menu_data.assert_called_with(dates, DEFAULT_LOCATION, DEFAULT_MENU_TYPE, is_ops=True)
         get_formatted_ops_menu_data(dates, 'Montana', 'staging')
-        mock_gromd.assert_called_with(dates, 'Montana', 'staging', is_ops=True)
+        mock_raw_menu_data.assert_called_with(dates, 'Montana', 'staging', is_ops=True)

--- a/tests/test_ops_queries.py
+++ b/tests/test_ops_queries.py
@@ -4,229 +4,28 @@ from galley.enums import LocationEnum
 from galley.queries import (get_ops_menu_query,
                             get_ops_recipe_item_connection_query,
                             get_raw_recipe_items_data_via_connection)
+from tests.test_queries import get_argument_from_query_selector
+
 
 logger = logging.getLogger(__name__)
 
 
 class TestOpsMenuDataQuery(TestCase):
-    def setUp(self) -> None:
-        self.expected_query = '''query {
-            viewer {
-            menus(where: {date: ["2022-03-28"], locationId: "bG9jYXRpb246MTkyOA=="}) {
-            id
-            name
-            date
-            location {
-            name
-            }
-            categoryValues {
-            id
-            name
-            category {
-            id
-            name
-            itemType
-            }
-            }
-            menuItems {
-            id
-            recipeId
-            categoryValues {
-            id
-            name
-            category {
-            id
-            name
-            itemType
-            }
-            }
-            recipe {
-            files {
-            photos {
-            sourceUrl
-            caption
-            }
-            }
-            id
-            name
-            categoryValues {
-            id
-            name
-            category {
-            id
-            name
-            itemType
-            }
-            }
-            recipeTreeComponents(levels: [1]) {
-            quantityUnitValues {
-            value
-            unit {
-            id
-            name
-            }
-            }
-            quantity
-            unit {
-            id
-            name
-            }
-            recipeItem {
-            preparations {
-            id
-            name
-            }
-            ingredient {
-            id
-            name
-            externalName
-            categoryValues {
-            id
-            name
-            category {
-            id
-            name
-            itemType
-            }
-            }
-            dietaryFlags {
-            id
-            name
-            }
-            }
-            subRecipe {
-            id
-            name
-            externalName
-            categoryValues {
-            id
-            name
-            category {
-            id
-            name
-            itemType
-            }
-            }
-            recipeInstructions {
-            text
-            position
-            }
-            dietaryFlagsWithUsages {
-            dietaryFlag {
-            id
-            name
-            }
-            }
-            recipeTreeComponents(levels: [1]) {
-            quantityUnitValues {
-            value
-            unit {
-            id
-            name
-            }
-            }
-            quantity
-            unit {
-            id
-            name
-            }
-            recipeItem {
-            preparations {
-            id
-            name
-            }
-            ingredient {
-            id
-            name
-            externalName
-            categoryValues {
-            id
-            name
-            category {
-            id
-            name
-            itemType
-            }
-            }
-            dietaryFlags {
-            id
-            name
-            }
-            }
-            subRecipe {
-            id
-            name
-            externalName
-            categoryValues {
-            id
-            name
-            category {
-            id
-            name
-            itemType
-            }
-            }
-            recipeInstructions {
-            text
-            position
-            }
-            dietaryFlagsWithUsages {
-            dietaryFlag {
-            id
-            name
-            }
-            }
-            recipeTreeComponents(levels: [1]) {
-            quantity
-            unit {
-            id
-            name
-            }
-            recipeItem {
-            ingredient {
-            id
-            name
-            externalName
-            dietaryFlags {
-            id
-            name
-            }
-            }
-            subRecipe {
-            id
-            name
-            externalName
-            dietaryFlagsWithUsages {
-            dietaryFlag {
-            id
-            name
-            }
-            }
-            }
-            }
-            }
-            }
-            }
-            }
-            }
-            }
-            }
-            }
-            volume
-            unit {
-            id
-            name
-            }
-            }
-            }
-            }
-            }'''.replace(' '*12, '')
-
-    def test_get_ops_menu_query(self):
+    def test_get_ops_menu_query_should_include_locationVendorItems_with_locationId(self):
         query = get_ops_menu_query(dates=["2022-03-28"], location_id=LocationEnum.VACAVILLE.value)
-        query_str = bytes(query).decode('utf-8')
-        self.maxDiff = None
-        self.assertEqual(query_str, self.expected_query)
+        arg = get_argument_from_query_selector(
+            query.viewer.menus.menuItems.recipe.recipeTreeComponents.recipeItem.ingredient.locationVendorItems,
+            'location_ids'
+        )
+        self.assertEqual(arg, [LocationEnum.VACAVILLE.value])
+
+    def test_get_ops_menu_query_should_include_dietaryFlagsWithUsages_with_locationId(self):
+        query = get_ops_menu_query(dates=["2022-03-28"], location_id=LocationEnum.VACAVILLE.value)
+        arg = get_argument_from_query_selector(
+            query.viewer.menus.menuItems.recipe.recipeTreeComponents.recipeItem.subRecipe.dietaryFlagsWithUsages,
+            'location_id'
+        )
+        self.assertEqual(arg, LocationEnum.VACAVILLE.value)
 
 
 class TestOpsRecipeItemConnectionQuery(TestCase):

--- a/tests/test_ops_queries.py
+++ b/tests/test_ops_queries.py
@@ -11,6 +11,14 @@ logger = logging.getLogger(__name__)
 
 
 class TestOpsMenuDataQuery(TestCase):
+    def test_get_ops_menu_query_should_include_recipeTreeComponents_with_levels_0_to_3(self):
+        query = get_ops_menu_query(dates=["2022-03-28"], location_id=LocationEnum.VACAVILLE.value)
+        arg = get_argument_from_query_selector(
+            query.viewer.menus.menuItems.recipe.recipeTreeComponents,
+            'levels'
+        )
+        self.assertEqual(arg, [0, 1, 2, 3])
+
     def test_get_ops_menu_query_should_include_locationVendorItems_with_locationId(self):
         query = get_ops_menu_query(dates=["2022-03-28"], location_id=LocationEnum.VACAVILLE.value)
         arg = get_argument_from_query_selector(


### PR DESCRIPTION
## Description
- Refactors `get_ops_menu_query` and `get_formatted_ops_menu_data` that powers all menu/recipe data Okra receives to reduce inefficiencies caused by querying nested `recipeTreeComponents` and `quantityUnitValues`
- Query pulls in the entire flattened list of `recipeTreeComponents` and uses `ancestorComponentIds` to filter and build a DAG recipe mapping for plating and staging data
- Query replaces `quantityUnitValues` with `unit.UnitValues` for unit conversions


## Test Plan
1. Run a previous version of galley-sdk **before** v0.45.0
2. Open python shell and run:
```python
from galley.formatted_ops_queries import *; from pprint import pprint

pprint(get_formatted_ops_menu_data(['2023-04-10', '2023-04-13', '2023-04-17', '2023-04-20', '2023-04-24', '2023-04-27'], 'Vacaville'))
```
3. Copy and paste output in a [diff checker](https://www.diffchecker.com/)
4. Checkout this branch
5. Repeat Step 2 and Step 3 to compare the diff

- [x] Verify `get_formatted_ops_menu_data` in v0.46.0 returns the same shape and data values as it did prior to v0.45.0


## Versioning
0.45.0 → 0.46.0