### PR TITLE
(ENG-2578) Add files to get_menu_query

### DIFF
--- a/galley/queries.py
+++ b/galley/queries.py
@@ -83,7 +83,7 @@ def recipe_connection_query(
     query.viewer.recipeConnection.edges()
     query.viewer.recipeConnection.pageInfo()
     query.viewer.recipeConnection.totalCount()
-    query.viewer.recipeConnection.edges.node.__fields__('id', 'externalName', 'name', 'notes', 'description', 'categoryValues')
+    query.viewer.recipeConnection.edges.node.__fields__('id', 'externalName', 'name', 'notes', 'description', 'categoryValues', 'files')
     query.viewer.recipeConnection.edges.node.dietaryFlagsWithUsages(location_id=location_id)
     query.viewer.recipeConnection.edges.node.reconciledNutritionals(location_id=location_id)
     query.viewer.recipeConnection.edges.node.recipeItems.__fields__('recipeId', 'preparations', 'quantity')

--- a/galley/queries.py
+++ b/galley/queries.py
@@ -146,7 +146,7 @@ def get_menu_query(dates: List[str], location_id: str) -> Operation:
     query = Operation(Query)
     query.viewer.menus(where=MenuFilterInput(date=dates, locationId=location_id)).__fields__('id', 'name', 'date', 'location', 'categoryValues', 'menuItems')
     query.viewer.menus.menuItems.__fields__('id', 'recipeId', 'categoryValues', 'recipe')
-    query.viewer.menus.menuItems.recipe.__fields__('externalName', 'name', 'recipeItems', 'categoryValues', 'isDish')
+    query.viewer.menus.menuItems.recipe.__fields__('externalName', 'name', 'recipeItems', 'categoryValues', 'files', 'isDish')
     query.viewer.menus.menuItems.recipe.dietaryFlagsWithUsages(location_id=location_id)
     query.viewer.menus.menuItems.recipe.recipeItems.__fields__('subRecipeId', 'preparations')
     query.viewer.menus.menuItems.recipe.recipeItems.preparations.__fields__('id', 'name')

--- a/galley/types.py
+++ b/galley/types.py
@@ -264,6 +264,7 @@ class RecipeNode(Node):
     recipeItems = Field(RecipeItem)
     dietaryFlagsWithUsages = Field(DietaryFlagsWithUsages, args=ArgDict(location_id=ID))
     ingredientsWithUsages = Field(list_of(IngredientWithUsages))
+    files = Field(Files)
 
 
 class RecipeEdge(Type):


### PR DESCRIPTION
## Description
Revision PR to add 'files' to `get_menu_query`

## Test Plan
In the python shell run the following: 
```python
from galley.formatted_queries import *
from galley.formatted_ops_queries import *

VACA, BURL = 'Vacaville', 'Burlington'
DATES = ['2024-03-04', '2024-03-11', '2024-03-18']

# thistle-web
get_formatted_menu_data(dates=DATES, location_name=VACA)
get_formatted_menu_data(dates=DATES, location_name=BURL)
get_formatted_recipes_data(["cmVjaXBlOjE5MDkwMg=="], VACA)
get_formatted_recipes_data(["cmVjaXBlOjE5MDkwMg=="], BURL)

# okra
get_formatted_ops_menu_data(dates=DATES, location_name=VACA)
get_formatted_ops_menu_data(dates=DATES, location_name=BURL)
```
- [x] Successfully pulls all recipe data with correct photos for 'menu' and 'plating'

## Versioning
No change
