### PR TITLE
Add sesame seeds dietaryFlag to formatted queries allergen labels

### DIFF
--- a/galley/enums.py
+++ b/galley/enums.py
@@ -98,6 +98,8 @@ class EntityMediaEnum(Enum):
 
 class DietaryFlagEnum(Enum):
     # Enum for Dietary Flags
+    # TODO: Remove or update the ids from the
+    # enum since these are currently outdated
     BEEF = ('ZGlldGFyeUZsYWc6MTM3', 'beef')
     CELERY = ('ZGlldGFyeUZsYWc6MTA=', 'celery')
     COCONUT = ('ZGlldGFyeUZsYWc6OTc=', 'coconut')

--- a/galley/formatted_queries.py
+++ b/galley/formatted_queries.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 
 ALLERGEN_LABELS = {
     DietaryFlagEnum.SMOKED_MEATS.name: 'smoked meats',
+    DietaryFlagEnum.SESAME_SEEDS.name: 'sesame',
     DietaryFlagEnum.SHELLFISH.name: 'shellfish',
     DietaryFlagEnum.TREE_NUTS.name: 'tree nuts',
     DietaryFlagEnum.SOYBEANS.name: 'soy',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # are dependencies that are required on remote installs, not local development.
 setup(
     name='galley_sdk',
-    version='1.1.0',
+    version='1.2.0',
     packages=['galley'],
     install_requires=['sgqlc==14.0', 'backoff==1.11.1']
 )


### PR DESCRIPTION
## Description
This is to add "sesame" to our allergen labels in thistle-web by mapping to the "sesame seeds" dietaryFlag in Galley.

## Test Plan
- [x] Confirm `get_formatted_menu_data` pulls in 'sesame' allergen
```python
from galley.formatted_queries import *

VACA, BURL = 'Vacaville', 'Burlington'
DATES = ['2024-03-04', '2024-03-11', '2024-03-18']

get_formatted_menu_data(dates=DATES, location_name=VACA)
get_formatted_menu_data(dates=DATES, location_name=BURL)
```

- [x] Confirm `get_formatted_recipes_data` pulls in 'sesame' allergen
```python
from galley.formatted_queries import *

VACA, BURL = 'Vacaville', 'Burlington'
DATES = ['2024-03-04', '2024-03-11', '2024-03-18']
RECIPES = ['cmVjaXBlOjE4MTY2OQ==', 'cmVjaXBlOjE4MTY3MA==']

get_formatted_recipes_data(RECIPES, location_name=VACA)
get_formatted_recipes_data(RECIPES, location_name=BURL)
```

## Versioning
v1.1.0 -> v1.2.0
