### PR TITLE
(ENG-2934) Ops query function accepts an approved list of product codes to filter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # are dependencies that are required on remote installs, not local development.
 setup(
     name='galley_sdk',
-    version='1.2.0',
+    version='1.3.0',
     packages=['galley'],
     install_requires=['sgqlc==14.0', 'backoff==1.11.1']
 )


### PR DESCRIPTION
## Description
- The `MEAL_CODES_WHITELIST` has been extracted out of galley-sdk
- `get_formatted_ops_menu_data` accepts a set or list of meal codes to filter from

## Test Plan
1. Run `python`
2. Run
```python
from galley.formatted_ops_queries import *

dates = ['2024-08-05', '2024-08-08']
product_codes_filter = {'lv1', 'dm2', 'lm4', 'dv6', 'cwsv', 'cwsm', 'cptv', 'cptm'}
get_formatted_ops_menu_data(dates, meals)
```
- [x]  Confirm data returned only contains menu items with product codes in `product_codes_filter`

## Versioning
1.2.0 -> 1.3.0
