### PR TITLE
(ENG-3034) Update formatted menu query to retrieve volume count

### DIFF
--- a/galley/formatted_queries.py
+++ b/galley/formatted_queries.py
@@ -519,6 +519,7 @@ def get_formatted_menu_data(
                 'recipeMenuPhotoUrl': formatted_recipe_dict.get('menuPhotoUrl', ''),
                 'recipeName': formatted_recipe_dict.get('externalName', ''),
                 'recipeProteinType': formatted_recipe_dict.get('proteinType', ''),
+                'volume': menu_item.get('volume'),
             })
         formatted_menus.append(formatted_menu)
     return formatted_menus

--- a/galley/queries.py
+++ b/galley/queries.py
@@ -145,7 +145,7 @@ def get_raw_recipes_data(recipe_ids: List[str], location_name: str) -> Optional[
 def get_menu_query(dates: List[str], location_id: str) -> Operation:
     query = Operation(Query)
     query.viewer.menus(where=MenuFilterInput(date=dates, locationId=location_id)).__fields__('id', 'name', 'date', 'location', 'categoryValues', 'menuItems')
-    query.viewer.menus.menuItems.__fields__('id', 'recipeId', 'categoryValues', 'recipe')
+    query.viewer.menus.menuItems.__fields__('id', 'recipeId', 'categoryValues', 'recipe', 'volume')
     query.viewer.menus.menuItems.recipe.__fields__('externalName', 'name', 'recipeItems', 'categoryValues', 'files', 'isDish')
     query.viewer.menus.menuItems.recipe.dietaryFlagsWithUsages(location_id=location_id)
     query.viewer.menus.menuItems.recipe.recipeItems.__fields__('subRecipeId', 'preparations')

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # are dependencies that are required on remote installs, not local development.
 setup(
     name='galley_sdk',
-    version='1.3.0',
+    version='1.4.0',
     packages=['galley'],
     install_requires=['sgqlc==14.0', 'backoff==1.11.1']
 )

--- a/tests/mock_responses/mock_menu_data.py
+++ b/tests/mock_responses/mock_menu_data.py
@@ -23,6 +23,7 @@ def mock_menu(date, location_name= DEFAULT_LOCATION, menu_type=DEFAULT_MENU_TYPE
             {
                 'id': 'MENUITEM1ABC',
                 'recipeId': 'RECIPE1ABC',
+                'volume': 100,
                 'categoryValues': [{
                     'name': 'dv1',
                     'category': {
@@ -108,6 +109,7 @@ def mock_menu(date, location_name= DEFAULT_LOCATION, menu_type=DEFAULT_MENU_TYPE
             {
                 'id': 'MENUITEM2DEF',
                 'recipeId': 'RECIPE2DEF',
+                'volume': 0,
                 'categoryValues': [
                     {
                         'name': 'dv2',
@@ -211,6 +213,7 @@ def mock_menu(date, location_name= DEFAULT_LOCATION, menu_type=DEFAULT_MENU_TYPE
             {
                 'id': 'MENUITEM3GHI',
                 'recipeId': 'RECIPE3GHI',
+                'volume': None,
                 'categoryValues': [{
                     'name': 'lm2',
                     'category': {
@@ -302,6 +305,7 @@ def mock_menu(date, location_name= DEFAULT_LOCATION, menu_type=DEFAULT_MENU_TYPE
             {
                 'id': 'MENUITEM4JKL',
                 'recipeId': 'RECIPE4JKL',
+                'volume': 300,
                 'categoryValues': [{
                     'name': 'non-sellable soup',
                     'category': {

--- a/tests/test_formatted_queries.py
+++ b/tests/test_formatted_queries.py
@@ -78,6 +78,7 @@ def formatted_menu(date, onlySellableMenuItems=False):
             'recipeMenuPhotoUrl': 'https://cdn.filestackcontent.com/Recipe_1_Menu',
             'recipeName': 'Test Recipe Name 1',
             'recipeProteinType': 'vegan',
+            'volume': 100,
         }, {
             'allergens': SELLABLE_RECIPE_ALLERGENS,
             'baseMeal': '',
@@ -92,6 +93,7 @@ def formatted_menu(date, onlySellableMenuItems=False):
             'recipeMenuPhotoUrl': 'https://cdn.filestackcontent.com/Recipe_2_Menu',
             'recipeName': 'Test Recipe Name 2',
             'recipeProteinType': 'vegan',
+            'volume': 0,
         }, {
             'allergens': STANDALONE_ALLERGENS,
             'baseMeal': '',
@@ -106,6 +108,7 @@ def formatted_menu(date, onlySellableMenuItems=False):
             'recipeMenuPhotoUrl': 'https://cdn.filestackcontent.com/Recipe_3_Menu',
             'recipeName': 'Test Recipe Name 3',
             'recipeProteinType': 'meat',
+            'volume': None,
         }]
     }
     if not onlySellableMenuItems:
@@ -123,6 +126,7 @@ def formatted_menu(date, onlySellableMenuItems=False):
             'recipeMenuPhotoUrl': None,
             'recipeName': 'Test Recipe Name 4',
             'recipeProteinType': '',
+            'volume': 300,
         })
     return formatted_menu
 


### PR DESCRIPTION
## Description
Formatted menu query now returns `volume` for each menu item in a menu cycle.

## Test Plan
```python
python
```

```python
from galley.formatted_queries import *
from pprint import pprint

pprint(get_formatted_menu_data(dates=["2024-09-09", "2024-09-12"]))
```

- [ ] Confirm a volume count is returned for each menu item and matches the exact value in Galley



## Versioning
1.3.0 → 1.4.0
