### PR TITLE
Update ops query to include a flattened list of all subrecipe ingredients

### DIFF
--- a/galley/formatted_ops_queries.py
+++ b/galley/formatted_ops_queries.py
@@ -168,6 +168,11 @@ class RecipeItem:
             'unit': unit.get('name')
         }
 
+    def format_ingredients(self) -> List[Dict]:
+        return [
+            ingredient.get('name') for item in self.all_ingredients if (ingredient := item.get('ingredient', {}))
+        ]
+
     def to_primary_component_dict(self):
         component: Dict = {
             'allergens': self.format_allergens(),
@@ -196,14 +201,12 @@ class RecipeItem:
                     for component in self.components
                     if component.get('recipeItem')
                 ],
-                'ingredients': [
-                    ingredient.get('name') for item in self.all_ingredients if (ingredient := item.get('ingredient', {}))
-                ]
+                'ingredients': self.format_ingredients(),
             }
         return component
 
     def to_subcomponent_dict(self):
-        subcomponent: Dict = {
+        subcomponent = {
             'allergens': self.format_allergens(),
             'id': self.data.get('id'),
             # Contains the ingredients list for pre-fab ingredients
@@ -213,9 +216,7 @@ class RecipeItem:
             'usage': self.format_usage(),
         }
         if self.type == SUBRECIPE:
-            subcomponent['ingredients'] = [
-                ingredient.get('name') for item in self.all_ingredients if (ingredient := item.get('ingredient', {}))
-            ]
+            subcomponent['ingredients'] = self.format_ingredients()
         return subcomponent
 
 

--- a/galley/formatted_ops_queries.py
+++ b/galley/formatted_ops_queries.py
@@ -173,9 +173,9 @@ class RecipeItem:
             'allergens': self.format_allergens(),
             'binWeight': self.format_bin_weight(),
             'cuppingContainer': self.get_cupping_container(),
-            # External name contains the ingredients list for pre-fab ingredients
-            'externalName': self.data.get('externalName'),
             'id': self.data.get('id'),
+            # Contains the ingredients list for pre-fab ingredients
+            'label': self.data.get('externalName'),
             'name': self.data.get('name'),
             'quantityValues': self.format_quantity_values(),
             'type': self.type,
@@ -196,7 +196,7 @@ class RecipeItem:
                     for component in self.components
                     if component.get('recipeItem')
                 ],
-                'allIngredients': [
+                'ingredients': [
                     ingredient.get('name') for item in self.all_ingredients if (ingredient := item.get('ingredient', {}))
                 ]
             }
@@ -206,14 +206,14 @@ class RecipeItem:
         subcomponent: Dict = {
             'allergens': self.format_allergens(),
             'id': self.data.get('id'),
+            # Contains the ingredients list for pre-fab ingredients
+            'label': self.data.get('externalName'),
             'name': self.format_name(),
-            # External name contains the ingredients list for pre-fab ingredients
-            'externalName': self.data.get('externalName'),
             'type': self.type,
             'usage': self.format_usage(),
         }
         if self.type == SUBRECIPE:
-            subcomponent['allIngredients'] = [
+            subcomponent['ingredients'] = [
                 ingredient.get('name') for item in self.all_ingredients if (ingredient := item.get('ingredient', {}))
             ]
         return subcomponent

--- a/galley/formatted_ops_queries.py
+++ b/galley/formatted_ops_queries.py
@@ -173,6 +173,8 @@ class RecipeItem:
             'allergens': self.format_allergens(),
             'binWeight': self.format_bin_weight(),
             'cuppingContainer': self.get_cupping_container(),
+            # External name contains the ingredients list for pre-fab ingredients
+            'externalName': self.data.get('externalName'),
             'id': self.data.get('id'),
             'name': self.data.get('name'),
             'quantityValues': self.format_quantity_values(),
@@ -205,6 +207,8 @@ class RecipeItem:
             'allergens': self.format_allergens(),
             'id': self.data.get('id'),
             'name': self.format_name(),
+            # External name contains the ingredients list for pre-fab ingredients
+            'externalName': self.data.get('externalName'),
             'type': self.type,
             'usage': self.format_usage(),
         }

--- a/galley/formatted_ops_queries.py
+++ b/galley/formatted_ops_queries.py
@@ -56,6 +56,7 @@ class RecipeItem:
         self.preparations = recipeitem.pop('preparations', []) or []
         self.instructions = self.data.pop('recipeInstructions', []) or []
         self.unit_values = self.usage['unit'].pop('unitValues', []) or []
+        self.all_ingredients = self.data.pop('allIngredientsWithUsages', []) or []
         self.category_values = self.data.pop('categoryValues', []) or []
         self.dietary_flags = self.data.pop('dietaryFlagsWithUsages', self.data.pop('dietaryFlags', [])) or []
         self.components = components or []
@@ -188,22 +189,30 @@ class RecipeItem:
                         component.get('recipeItem'),
                         component.get('components'),
                         component.get('recipeItem').get('quantity'),
-                        component.get('recipeItem').get('unit')
+                        component.get('recipeItem').get('unit'),
                     ).to_subcomponent_dict()
                     for component in self.components
                     if component.get('recipeItem')
+                ],
+                'allIngredients': [
+                    ingredient.get('name') for item in self.all_ingredients if (ingredient := item.get('ingredient', {}))
                 ]
             }
         return component
 
     def to_subcomponent_dict(self):
-        return {
+        subcomponent: Dict = {
             'allergens': self.format_allergens(),
             'id': self.data.get('id'),
             'name': self.format_name(),
             'type': self.type,
-            'usage': self.format_usage()
+            'usage': self.format_usage(),
         }
+        if self.type == SUBRECIPE:
+            subcomponent['allIngredients'] = [
+                ingredient.get('name') for item in self.all_ingredients if (ingredient := item.get('ingredient', {}))
+            ]
+        return subcomponent
 
 
 def get_plate_photo_url(photos: List) -> Optional[str]:

--- a/galley/queries.py
+++ b/galley/queries.py
@@ -202,6 +202,7 @@ def get_ops_menu_query(dates: List[str], location_id: str) -> Operation:
     query.viewer.menus.menuItems.recipe.recipeTreeComponents.recipeItem.ingredient.locationVendorItems(location_ids=[location_id])
     query.viewer.menus.menuItems.recipe.recipeTreeComponents.recipeItem.ingredient.__fields__('id', 'name', 'externalName', 'categoryValues', 'dietaryFlags')
     query.viewer.menus.menuItems.recipe.recipeTreeComponents.recipeItem.subRecipe.__fields__('id', 'name', 'externalName', 'categoryValues', 'recipeInstructions')
+    query.viewer.menus.menuItems.recipe.recipeTreeComponents.recipeItem.subRecipe.allIngredientsWithUsages.ingredient.__fields__('name')
     query.viewer.menus.menuItems.recipe.recipeTreeComponents.recipeItem.subRecipe.dietaryFlagsWithUsages(location_id=location_id)
     return query
 

--- a/galley/queries.py
+++ b/galley/queries.py
@@ -202,7 +202,7 @@ def get_ops_menu_query(dates: List[str], location_id: str) -> Operation:
     query.viewer.menus.menuItems.recipe.recipeTreeComponents.recipeItem.ingredient.locationVendorItems(location_ids=[location_id])
     query.viewer.menus.menuItems.recipe.recipeTreeComponents.recipeItem.ingredient.__fields__('id', 'name', 'externalName', 'categoryValues', 'dietaryFlags')
     query.viewer.menus.menuItems.recipe.recipeTreeComponents.recipeItem.subRecipe.__fields__('id', 'name', 'externalName', 'categoryValues', 'recipeInstructions')
-    query.viewer.menus.menuItems.recipe.recipeTreeComponents.recipeItem.subRecipe.allIngredientsWithUsages.ingredient.__fields__('name')
+    query.viewer.menus.menuItems.recipe.recipeTreeComponents.recipeItem.subRecipe.allIngredientsWithUsages.ingredient.__fields__('name', 'externalName')
     query.viewer.menus.menuItems.recipe.recipeTreeComponents.recipeItem.subRecipe.dietaryFlagsWithUsages(location_id=location_id)
     return query
 

--- a/galley/types.py
+++ b/galley/types.py
@@ -172,6 +172,7 @@ class SubRecipe(Type):
     recipeTreeComponents = Field(RecipeTreeComponent, args=ArgDict(levels=list_of(Int)))
     dietaryFlagsWithUsages = Field('DietaryFlagsWithUsages', args=ArgDict(location_id=ID))
     categoryValues = Field(CategoryValue)
+    allIngredientsWithUsages = Field(list_of(IngredientWithUsages))
 
 
 class RecipeItem(Type):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # are dependencies that are required on remote installs, not local development.
 setup(
     name='galley_sdk',
-    version='1.4.0',
+    version='1.5.0',
     packages=['galley'],
     install_requires=['sgqlc==14.0', 'backoff==1.11.1']
 )

--- a/tests/mock_responses/mock_ops_menu_data.py
+++ b/tests/mock_responses/mock_ops_menu_data.py
@@ -1699,6 +1699,7 @@ MOCK_FORMATTED_PRIMARY_RECIPE_COMPONENTS = [
             "value": 50.0
         },
         "cuppingContainer": "2 oz RAM",
+        'externalName': None,
         "id": "cmVjaXBlOjE4OTcwNA==",
         "instructions": [
             {
@@ -1721,6 +1722,7 @@ MOCK_FORMATTED_PRIMARY_RECIPE_COMPONENTS = [
             {
                 "allIngredients": ["quinoa", "water"],
                 "allergens": [],
+                'externalName': None,
                 "id": "cmVjaXBlOjE4ODYwNg==",
                 "name": "Cooked Rainbow Quinoa",
                 "type": "recipe",
@@ -1731,6 +1733,7 @@ MOCK_FORMATTED_PRIMARY_RECIPE_COMPONENTS = [
             },
             {
                 "allergens": [],
+                'externalName': 'Kalamata Olives',
                 "id": "aW5ncmVkaWVudDoyNDQ2Mzc=",
                 "name": "olives, kalamata, sliced",
                 "type": "ingredient",
@@ -1742,6 +1745,7 @@ MOCK_FORMATTED_PRIMARY_RECIPE_COMPONENTS = [
             {
                 "allIngredients": ["scallion, sliced"],
                 "allergens": [],
+                'externalName': None,
                 "id": "cmVjaXBlOjE3Mjk2NQ==",
                 "name": "Sliced Scallion",
                 "type": "recipe",
@@ -1765,6 +1769,7 @@ MOCK_FORMATTED_PRIMARY_RECIPE_COMPONENTS = [
             "value": 60.0
         },
         "cuppingContainer": "INSERT12",
+        'externalName': None,
         "id": "cmVjaXBlOjE3NjQ3Mw==",
         "instructions": [
             {
@@ -1799,6 +1804,7 @@ MOCK_FORMATTED_PRIMARY_RECIPE_COMPONENTS = [
             {
                 "allIngredients": ["feta, crumbled"],
                 "allergens": [],
+                'externalName': None,
                 "id": "cmVjaXBlOjIxNjA2MA==",
                 "name": "Brine for \"Feta\"",
                 "type": "recipe",
@@ -1810,6 +1816,7 @@ MOCK_FORMATTED_PRIMARY_RECIPE_COMPONENTS = [
             {
                 "allIngredients": ["tofu, diced", "salt"],
                 "allergens": [SOY],
+                'externalName': None,
                 "id": "cmVjaXBlOjE5MDA5MQ==",
                 "name": "Small Diced Tofu (1/4\")",
                 "type": "recipe",
@@ -1832,6 +1839,7 @@ MOCK_FORMATTED_PRIMARY_RECIPE_COMPONENTS = [
             "value": 30.0
         },
         "cuppingContainer": None,
+        'externalName': 'Spring Mix Lettuce* or Seasonal Greens*§',
         "id": "aW5ncmVkaWVudDoyNDQ1NjE=",
         "name": "lettuce, spring mix, SEND TO PLATE",
         "quantityValues": [
@@ -1858,6 +1866,7 @@ MOCK_FORMATTED_PRIMARY_RECIPE_COMPONENTS = [
         },
         "cuppingContainer": None,
         "id": "aW5ncmVkaWVudDoyNzQ4ODA=",
+        'externalName': 'Crispy Chickpeas (Chickpeas, Sunflower Oil, Sea Salt)',
         "name": "crispy roasted chickpeas, 0.85 oz bag, SEND TO PLATE",
         "quantityValues": [
             {
@@ -1883,6 +1892,7 @@ MOCK_FORMATTED_PRIMARY_RECIPE_COMPONENTS = [
             "value": 60.0
         },
         "cuppingContainer": None,
+        'externalName': None,
         "id": "cmVjaXBlOjE3MDU4NA==",
         "instructions": [
             {
@@ -1928,6 +1938,7 @@ MOCK_FORMATTED_PRIMARY_RECIPE_COMPONENTS = [
         "recipeComponents": [
             {
                 "allergens": [],
+                'externalName': 'Sumac',
                 "id": "aW5ncmVkaWVudDoyNDQ4MzQ=",
                 "name": "spice, sumac",
                 "type": "ingredient",
@@ -1938,6 +1949,7 @@ MOCK_FORMATTED_PRIMARY_RECIPE_COMPONENTS = [
             },
             {
                 "allergens": [],
+                'externalName': 'Black Pepper',
                 "id": "aW5ncmVkaWVudDoyNDQ3OTM=",
                 "name": "spice, black pepper, ground",
                 "type": "ingredient",
@@ -1949,6 +1961,7 @@ MOCK_FORMATTED_PRIMARY_RECIPE_COMPONENTS = [
             {
                 "allIngredients": ["garbanzo beans"],
                 "allergens": [],
+                'externalName': None,
                 "id": "cmVjaXBlOjE3NjQ4MA==",
                 "name": "Cooked Garbanzo Beans",
                 "type": "recipe",
@@ -1959,6 +1972,7 @@ MOCK_FORMATTED_PRIMARY_RECIPE_COMPONENTS = [
             },
             {
                 "allergens": [],
+                'externalName': 'Extra Virgin Olive Oil',
                 "id": "aW5ncmVkaWVudDoyNDQ2MzA=",
                 "name": "oil, olive",
                 "type": "ingredient",
@@ -1969,6 +1983,7 @@ MOCK_FORMATTED_PRIMARY_RECIPE_COMPONENTS = [
             },
             {
                 "allergens": [],
+                'externalName': 'Lemon Juice',
                 "id": "aW5ncmVkaWVudDoyNDQ1MzU=",
                 "name": "juice, lemon",
                 "type": "ingredient",
@@ -1992,6 +2007,7 @@ MOCK_FORMATTED_PRIMARY_RECIPE_COMPONENTS = [
             "value": 60.0
         },
         "cuppingContainer": "2 oz WINPAK",
+        'externalName': 'Red Wine Vinaigrette',
         "id": "cmVjaXBlOjIyMzU3MQ==",
         "instructions": [],
         "name": "Red Wine Vinaigrette 2oz",
@@ -2009,6 +2025,7 @@ MOCK_FORMATTED_PRIMARY_RECIPE_COMPONENTS = [
             {
                 "allIngredients": [],
                 "allergens": [],
+                'externalName': None,
                 "id": "cmVjaXBlOjE3NDI4OA==",
                 "name": "Red Wine Vinaigrette BASE",
                 "type": "recipe",

--- a/tests/mock_responses/mock_ops_menu_data.py
+++ b/tests/mock_responses/mock_ops_menu_data.py
@@ -1692,14 +1692,13 @@ MOCK_RECIPE_TREE_COMPONENTS = [
 
 MOCK_FORMATTED_PRIMARY_RECIPE_COMPONENTS = [
     {
-        "allIngredients": ["quinoa", "water", "olives, kalamata, sliced", "scallion, sliced"],
+        "ingredients": ["quinoa", "water", "olives, kalamata, sliced", "scallion, sliced"],
         "allergens": [],
         "binWeight": {
             "unit": "lb",
             "value": 50.0
         },
         "cuppingContainer": "2 oz RAM",
-        'externalName': None,
         "id": "cmVjaXBlOjE4OTcwNA==",
         "instructions": [
             {
@@ -1707,6 +1706,7 @@ MOCK_FORMATTED_PRIMARY_RECIPE_COMPONENTS = [
                 "text": "Stage lexans for mixing. With sleeved gloves, mix the cucumber, red bell pepper, olives, hemp seeds, parsley and scallions in the quinoa being sure to distribute each ingredient evenly."
             }
         ],
+        'label': None,
         "name": "Olive, Red Pepper & Cucumber Quinoa Pilaf",
         "quantityValues": [
             {
@@ -1720,10 +1720,10 @@ MOCK_FORMATTED_PRIMARY_RECIPE_COMPONENTS = [
         ],
         "recipeComponents": [
             {
-                "allIngredients": ["quinoa", "water"],
+                "ingredients": ["quinoa", "water"],
                 "allergens": [],
-                'externalName': None,
                 "id": "cmVjaXBlOjE4ODYwNg==",
+                'label': None,
                 "name": "Cooked Rainbow Quinoa",
                 "type": "recipe",
                 "usage": {
@@ -1733,8 +1733,8 @@ MOCK_FORMATTED_PRIMARY_RECIPE_COMPONENTS = [
             },
             {
                 "allergens": [],
-                'externalName': 'Kalamata Olives',
                 "id": "aW5ncmVkaWVudDoyNDQ2Mzc=",
+                "label": "Kalamata Olives",
                 "name": "olives, kalamata, sliced",
                 "type": "ingredient",
                 "usage": {
@@ -1743,10 +1743,10 @@ MOCK_FORMATTED_PRIMARY_RECIPE_COMPONENTS = [
                 }
             },
             {
-                "allIngredients": ["scallion, sliced"],
+                "ingredients": ["scallion, sliced"],
                 "allergens": [],
-                'externalName': None,
                 "id": "cmVjaXBlOjE3Mjk2NQ==",
+                "label": None,
                 "name": "Sliced Scallion",
                 "type": "recipe",
                 "usage": {
@@ -1762,14 +1762,13 @@ MOCK_FORMATTED_PRIMARY_RECIPE_COMPONENTS = [
         }
     },
     {
-        "allIngredients": ["tofu, diced", "feta, crumbled", "salt"],
+        "ingredients": ["tofu, diced", "feta, crumbled", "salt"],
         "allergens": [SOY],
         "binWeight": {
             "unit": "lb",
             "value": 60.0
         },
         "cuppingContainer": "INSERT12",
-        'externalName': None,
         "id": "cmVjaXBlOjE3NjQ3Mw==",
         "instructions": [
             {
@@ -1789,6 +1788,7 @@ MOCK_FORMATTED_PRIMARY_RECIPE_COMPONENTS = [
                 "text": "Strain well before serving."
             }
         ],
+        "label": None,
         "name": "Tofu Feta",
         "quantityValues": [
             {
@@ -1802,10 +1802,10 @@ MOCK_FORMATTED_PRIMARY_RECIPE_COMPONENTS = [
         ],
         "recipeComponents": [
             {
-                "allIngredients": ["feta, crumbled"],
+                "ingredients": ["feta, crumbled"],
                 "allergens": [],
-                'externalName': None,
                 "id": "cmVjaXBlOjIxNjA2MA==",
+                "label": None,
                 "name": "Brine for \"Feta\"",
                 "type": "recipe",
                 "usage": {
@@ -1814,10 +1814,10 @@ MOCK_FORMATTED_PRIMARY_RECIPE_COMPONENTS = [
                 }
             },
             {
-                "allIngredients": ["tofu, diced", "salt"],
+                "ingredients": ["tofu, diced", "salt"],
                 "allergens": [SOY],
-                'externalName': None,
                 "id": "cmVjaXBlOjE5MDA5MQ==",
+                "label": None,
                 "name": "Small Diced Tofu (1/4\")",
                 "type": "recipe",
                 "usage": {
@@ -1839,8 +1839,8 @@ MOCK_FORMATTED_PRIMARY_RECIPE_COMPONENTS = [
             "value": 30.0
         },
         "cuppingContainer": None,
-        'externalName': 'Spring Mix Lettuce* or Seasonal Greens*§',
         "id": "aW5ncmVkaWVudDoyNDQ1NjE=",
+        "label": "Spring Mix Lettuce* or Seasonal Greens*§",
         "name": "lettuce, spring mix, SEND TO PLATE",
         "quantityValues": [
             {
@@ -1866,7 +1866,7 @@ MOCK_FORMATTED_PRIMARY_RECIPE_COMPONENTS = [
         },
         "cuppingContainer": None,
         "id": "aW5ncmVkaWVudDoyNzQ4ODA=",
-        'externalName': 'Crispy Chickpeas (Chickpeas, Sunflower Oil, Sea Salt)',
+        "label": "Crispy Chickpeas (Chickpeas, Sunflower Oil, Sea Salt)",
         "name": "crispy roasted chickpeas, 0.85 oz bag, SEND TO PLATE",
         "quantityValues": [
             {
@@ -1885,14 +1885,13 @@ MOCK_FORMATTED_PRIMARY_RECIPE_COMPONENTS = [
         }
     },
     {
-        "allIngredients": ["spice, sumac", "spice, black pepper, ground", "garbanzo beans", "juice, lemon", "olive oil"],
+        "ingredients": ["spice, sumac", "spice, black pepper, ground", "garbanzo beans", "juice, lemon", "olive oil"],
         "allergens": [],
         "binWeight": {
             "unit": "lb",
             "value": 60.0
         },
         "cuppingContainer": None,
-        'externalName': None,
         "id": "cmVjaXBlOjE3MDU4NA==",
         "instructions": [
             {
@@ -1924,6 +1923,7 @@ MOCK_FORMATTED_PRIMARY_RECIPE_COMPONENTS = [
                 "text": "Clean the entire machine after each project, take the bowl and attachments back to the dishpit."
             }
         ],
+        "label": None,
         "name": "Smashed Chickpea Salad - COOKED GARBANZOS",
         "quantityValues": [
             {
@@ -1938,8 +1938,8 @@ MOCK_FORMATTED_PRIMARY_RECIPE_COMPONENTS = [
         "recipeComponents": [
             {
                 "allergens": [],
-                'externalName': 'Sumac',
                 "id": "aW5ncmVkaWVudDoyNDQ4MzQ=",
+                "label": "Sumac",
                 "name": "spice, sumac",
                 "type": "ingredient",
                 "usage": {
@@ -1949,8 +1949,8 @@ MOCK_FORMATTED_PRIMARY_RECIPE_COMPONENTS = [
             },
             {
                 "allergens": [],
-                'externalName': 'Black Pepper',
                 "id": "aW5ncmVkaWVudDoyNDQ3OTM=",
+                "label": "Black Pepper",
                 "name": "spice, black pepper, ground",
                 "type": "ingredient",
                 "usage": {
@@ -1959,10 +1959,10 @@ MOCK_FORMATTED_PRIMARY_RECIPE_COMPONENTS = [
                 }
             },
             {
-                "allIngredients": ["garbanzo beans"],
+                "ingredients": ["garbanzo beans"],
                 "allergens": [],
-                'externalName': None,
                 "id": "cmVjaXBlOjE3NjQ4MA==",
+                "label": None,
                 "name": "Cooked Garbanzo Beans",
                 "type": "recipe",
                 "usage": {
@@ -1972,8 +1972,8 @@ MOCK_FORMATTED_PRIMARY_RECIPE_COMPONENTS = [
             },
             {
                 "allergens": [],
-                'externalName': 'Extra Virgin Olive Oil',
                 "id": "aW5ncmVkaWVudDoyNDQ2MzA=",
+                "label": "Extra Virgin Olive Oil",
                 "name": "oil, olive",
                 "type": "ingredient",
                 "usage": {
@@ -1983,8 +1983,8 @@ MOCK_FORMATTED_PRIMARY_RECIPE_COMPONENTS = [
             },
             {
                 "allergens": [],
-                'externalName': 'Lemon Juice',
                 "id": "aW5ncmVkaWVudDoyNDQ1MzU=",
+                "label": "Lemon Juice",
                 "name": "juice, lemon",
                 "type": "ingredient",
                 "usage": {
@@ -2000,16 +2000,16 @@ MOCK_FORMATTED_PRIMARY_RECIPE_COMPONENTS = [
         }
     },
     {
-        "allIngredients": [],
+        "ingredients": [],
         "allergens": [],
         "binWeight": {
             "unit": "lb",
             "value": 60.0
         },
         "cuppingContainer": "2 oz WINPAK",
-        'externalName': 'Red Wine Vinaigrette',
         "id": "cmVjaXBlOjIyMzU3MQ==",
         "instructions": [],
+        "label": "Red Wine Vinaigrette",
         "name": "Red Wine Vinaigrette 2oz",
         "quantityValues": [
             {
@@ -2023,10 +2023,10 @@ MOCK_FORMATTED_PRIMARY_RECIPE_COMPONENTS = [
         ],
         "recipeComponents": [
             {
-                "allIngredients": [],
+                "ingredients": [],
                 "allergens": [],
-                'externalName': None,
                 "id": "cmVjaXBlOjE3NDI4OA==",
+                "label": None,
                 "name": "Red Wine Vinaigrette BASE",
                 "type": "recipe",
                 "usage": {

--- a/tests/mock_responses/mock_ops_menu_data.py
+++ b/tests/mock_responses/mock_ops_menu_data.py
@@ -95,6 +95,13 @@ MOCK_RECIPE_TREE_COMPONENTS = [
                             "name": DietaryFlagEnum.SOYBEANS.name,
                         }
                     }
+                ],
+                "allIngredientsWithUsages": [
+                    {
+                        "ingredient": {
+                            "name": "soybean"
+                        }
+                    }
                 ]
             }
         }
@@ -167,7 +174,29 @@ MOCK_RECIPE_TREE_COMPONENTS = [
                         "position": 0
                     }
                 ],
-                "dietaryFlagsWithUsages": []
+                "dietaryFlagsWithUsages": [],
+                "allIngredientsWithUsages": [
+                    {
+                        "ingredient": {
+                            "name": "quinoa"
+                        }
+                    },
+                    {
+                        "ingredient": {
+                            "name": "water"
+                        }
+                    },
+                    {
+                        "ingredient": {
+                            "name": "olives, kalamata, sliced"
+                        }
+                    },
+                    {
+                        "ingredient": {
+                            "name": "scallion, sliced"
+                        }
+                    }
+                ]
             }
         }
     },
@@ -237,7 +266,19 @@ MOCK_RECIPE_TREE_COMPONENTS = [
                         "position": 3
                     }
                 ],
-                "dietaryFlagsWithUsages": []
+                "dietaryFlagsWithUsages": [],
+                "allIngredientsWithUsages": [
+                    {
+                        "ingredient": {
+                            "name": "quinoa"
+                        }
+                    },
+                    {
+                        "ingredient": {
+                            "name": "water"
+                        }
+                    }
+                ]
             }
         }
     },
@@ -368,7 +409,14 @@ MOCK_RECIPE_TREE_COMPONENTS = [
                         "position": 5
                     }
                 ],
-                "dietaryFlagsWithUsages": []
+                "dietaryFlagsWithUsages": [],
+                "allIngredientsWithUsages": [
+                    {
+                        "ingredient": {
+                            "name": "scallion, sliced"
+                        }
+                    }
+                ]
             }
         }
     },
@@ -449,6 +497,23 @@ MOCK_RECIPE_TREE_COMPONENTS = [
                             "name": DietaryFlagEnum.SOYBEANS.name,
                         }
                     }
+                ],
+                "allIngredientsWithUsages": [
+                    {
+                        "ingredient": {
+                            "name": "tofu, diced"
+                        }
+                    },
+                    {
+                        "ingredient": {
+                            "name": "feta, crumbled"
+                        }
+                    },
+                    {
+                        "ingredient": {
+                            "name": "salt"
+                        }
+                    }
                 ]
             }
         }
@@ -507,7 +572,14 @@ MOCK_RECIPE_TREE_COMPONENTS = [
                         "position": 0
                     }
                 ],
-                "dietaryFlagsWithUsages": []
+                "dietaryFlagsWithUsages": [],
+                "allIngredientsWithUsages": [
+                    {
+                        "ingredient": {
+                            "name": "feta, crumbled"
+                        }
+                    }
+                ]
             }
         }
     },
@@ -574,6 +646,18 @@ MOCK_RECIPE_TREE_COMPONENTS = [
                         "dietaryFlag": {
                             "id": DietaryFlagEnum.SOYBEANS.id,
                             "name": DietaryFlagEnum.SOYBEANS.name,
+                        }
+                    }
+                ],
+                "allIngredientsWithUsages": [
+                    {
+                        "ingredient": {
+                            "name": "tofu, diced"
+                        }
+                    },
+                    {
+                        "ingredient": {
+                            "name": "salt"
                         }
                     }
                 ]
@@ -797,7 +881,34 @@ MOCK_RECIPE_TREE_COMPONENTS = [
                         "position": 6
                     }
                 ],
-                "dietaryFlagsWithUsages": []
+                "dietaryFlagsWithUsages": [],
+                "allIngredientsWithUsages": [
+                    {
+                        "ingredient": {
+                            "name": "spice, sumac"
+                        }
+                    },
+                    {
+                        "ingredient": {
+                            "name": "spice, black pepper, ground"
+                        }
+                    },
+                    {
+                        "ingredient": {
+                            "name": "garbanzo beans"
+                        }
+                    },
+                    {
+                        "ingredient": {
+                            "name": "juice, lemon"
+                        }
+                    },
+                    {
+                        "ingredient": {
+                            "name": "olive oil"
+                        }
+                    }
+                ]
             }
         }
     },
@@ -970,7 +1081,14 @@ MOCK_RECIPE_TREE_COMPONENTS = [
                         "position": 3
                     }
                 ],
-                "dietaryFlagsWithUsages": []
+                "dietaryFlagsWithUsages": [],
+                "allIngredientsWithUsages": [
+                    {
+                        "ingredient": {
+                            "name": "garbanzo beans"
+                        }
+                    }
+                ],
             }
         }
     },
@@ -1255,7 +1373,8 @@ MOCK_RECIPE_TREE_COMPONENTS = [
                 "externalName": "Red Wine Vinaigrette",
                 "categoryValues": [],
                 "recipeInstructions": [],
-                "dietaryFlagsWithUsages": []
+                "dietaryFlagsWithUsages": [],
+                "allIngredientsWithUsages": []
             }
         }
     },
@@ -1320,7 +1439,8 @@ MOCK_RECIPE_TREE_COMPONENTS = [
                         "position": 2
                     }
                 ],
-                "dietaryFlagsWithUsages": []
+                "dietaryFlagsWithUsages": [],
+                "allIngredientsWithUsages": []
             }
         }
     },
@@ -1488,7 +1608,14 @@ MOCK_RECIPE_TREE_COMPONENTS = [
                         "position": 1
                     }
                 ],
-                "dietaryFlagsWithUsages": []
+                "dietaryFlagsWithUsages": [],
+                "allIngredientsWithUsages": [
+                    {
+                        "ingredient": {
+                            "name": "garlic, minced"
+                        }
+                    }
+                ]
             }
         }
     },
@@ -1565,6 +1692,7 @@ MOCK_RECIPE_TREE_COMPONENTS = [
 
 MOCK_FORMATTED_PRIMARY_RECIPE_COMPONENTS = [
     {
+        "allIngredients": ["quinoa", "water", "olives, kalamata, sliced", "scallion, sliced"],
         "allergens": [],
         "binWeight": {
             "unit": "lb",
@@ -1591,6 +1719,7 @@ MOCK_FORMATTED_PRIMARY_RECIPE_COMPONENTS = [
         ],
         "recipeComponents": [
             {
+                "allIngredients": ["quinoa", "water"],
                 "allergens": [],
                 "id": "cmVjaXBlOjE4ODYwNg==",
                 "name": "Cooked Rainbow Quinoa",
@@ -1611,6 +1740,7 @@ MOCK_FORMATTED_PRIMARY_RECIPE_COMPONENTS = [
                 }
             },
             {
+                "allIngredients": ["scallion, sliced"],
                 "allergens": [],
                 "id": "cmVjaXBlOjE3Mjk2NQ==",
                 "name": "Sliced Scallion",
@@ -1628,6 +1758,7 @@ MOCK_FORMATTED_PRIMARY_RECIPE_COMPONENTS = [
         }
     },
     {
+        "allIngredients": ["tofu, diced", "feta, crumbled", "salt"],
         "allergens": [SOY],
         "binWeight": {
             "unit": "lb",
@@ -1666,6 +1797,7 @@ MOCK_FORMATTED_PRIMARY_RECIPE_COMPONENTS = [
         ],
         "recipeComponents": [
             {
+                "allIngredients": ["feta, crumbled"],
                 "allergens": [],
                 "id": "cmVjaXBlOjIxNjA2MA==",
                 "name": "Brine for \"Feta\"",
@@ -1676,6 +1808,7 @@ MOCK_FORMATTED_PRIMARY_RECIPE_COMPONENTS = [
                 }
             },
             {
+                "allIngredients": ["tofu, diced", "salt"],
                 "allergens": [SOY],
                 "id": "cmVjaXBlOjE5MDA5MQ==",
                 "name": "Small Diced Tofu (1/4\")",
@@ -1743,6 +1876,7 @@ MOCK_FORMATTED_PRIMARY_RECIPE_COMPONENTS = [
         }
     },
     {
+        "allIngredients": ["spice, sumac", "spice, black pepper, ground", "garbanzo beans", "juice, lemon", "olive oil"],
         "allergens": [],
         "binWeight": {
             "unit": "lb",
@@ -1813,6 +1947,7 @@ MOCK_FORMATTED_PRIMARY_RECIPE_COMPONENTS = [
                 }
             },
             {
+                "allIngredients": ["garbanzo beans"],
                 "allergens": [],
                 "id": "cmVjaXBlOjE3NjQ4MA==",
                 "name": "Cooked Garbanzo Beans",
@@ -1850,6 +1985,7 @@ MOCK_FORMATTED_PRIMARY_RECIPE_COMPONENTS = [
         }
     },
     {
+        "allIngredients": [],
         "allergens": [],
         "binWeight": {
             "unit": "lb",
@@ -1871,6 +2007,7 @@ MOCK_FORMATTED_PRIMARY_RECIPE_COMPONENTS = [
         ],
         "recipeComponents": [
             {
+                "allIngredients": [],
                 "allergens": [],
                 "id": "cmVjaXBlOjE3NDI4OA==",
                 "name": "Red Wine Vinaigrette BASE",


### PR DESCRIPTION
## Description
This sets up the data that OKRA needs to be able to identify allergen ingredients within the subcomponents of the primary components.

## Test Plan
In the python interactive shell, run:
```python
from galley.formatted_ops_queries import *
import json 

BASE_CODES = ['s', 'b', 'lv', 'lm', 'dv', 'dm', 't'] 
BASE_MEALS = {f'{b}{n+1}' for b in BASE_CODES for n in range(6)}
JAR_SALADS = {'ssa', 'ssb', 'ssc', 'ssd'}
SIDE_SOUPS = {'scw', 'sp',  'sm',  'sch'}
THISTLE_CLASSICS = {'cwsv', 'cwsm', 'cptv', 'cptm'}
PRODUCT_CODES_ALLOWED = BASE_MEALS | JAR_SALADS | SIDE_SOUPS | THISTLE_CLASSICS

print(json.dumps(get_formatted_ops_menu_data(dates=["2025-04-10"], product_codes_filter=PRODUCT_CODES_ALLOWED), indent=4))
```
- [x] Confirm all primary components and primary components'`recipeComponents` of type "recipe" return a flattened list of all their ingredients by the internal name e.g. "nuts, pistachio", "almond meal"
- [x] Confirm `externalName` is returned with some components' list of ingredients e.g. 24 Carrot Gold Muffin

## Versioning
1.4.0 → 1.5.0