### PR TITLE
Filter preparation field to fix request timeout

### DIFF
--- a/galley/formatted_ops_queries.py
+++ b/galley/formatted_ops_queries.py
@@ -40,6 +40,7 @@ ALLERGEN_LABELS = {
     DietaryFlagEnum.PORK.name: 'pork',
 }
 
+
 class RecipeItem:
     def __init__(
         self,

--- a/galley/queries.py
+++ b/galley/queries.py
@@ -108,6 +108,7 @@ def recipe_connection_query(
     query.viewer.recipeConnection.edges.node.dietaryFlagsWithUsages(location_id=location_id)
     query.viewer.recipeConnection.edges.node.reconciledNutritionals(location_id=location_id)
     query.viewer.recipeConnection.edges.node.recipeItems.__fields__('id', 'recipeId', 'preparations', 'quantity')
+    query.viewer.recipeConnection.edges.node.recipeItems.preparations.__fields__('id', 'name')
     query.viewer.recipeConnection.edges.node.recipeItems.unit.__fields__('id', 'name')
     query.viewer.recipeConnection.edges.node.recipeItems.unit.unitValues.__fields__('value')
     query.viewer.recipeConnection.edges.node.recipeItems.unit.unitValues.unit.__fields__('id', 'name')
@@ -198,11 +199,12 @@ def get_ops_menu_query(dates: List[str], location_id: str) -> Operation:
     query.viewer.menus.menuItems.recipe.recipeTreeComponents.unit.unitValues.__fields__('value')
     query.viewer.menus.menuItems.recipe.recipeTreeComponents.unit.unitValues.unit.__fields__('id', 'name')
     query.viewer.menus.menuItems.recipe.recipeTreeComponents.recipeItem.__fields__('preparations', 'quantity')
+    query.viewer.menus.menuItems.recipe.recipeTreeComponents.recipeItem.preparations.__fields__('id', 'name')
     query.viewer.menus.menuItems.recipe.recipeTreeComponents.recipeItem.unit.__fields__('id', 'name')
     query.viewer.menus.menuItems.recipe.recipeTreeComponents.recipeItem.ingredient.locationVendorItems(location_ids=[location_id])
     query.viewer.menus.menuItems.recipe.recipeTreeComponents.recipeItem.ingredient.__fields__('id', 'name', 'externalName', 'categoryValues', 'dietaryFlags')
     query.viewer.menus.menuItems.recipe.recipeTreeComponents.recipeItem.subRecipe.__fields__('id', 'name', 'externalName', 'categoryValues', 'recipeInstructions')
-    query.viewer.menus.menuItems.recipe.recipeTreeComponents.recipeItem.subRecipe.allIngredientsWithUsages.ingredient.__fields__('name', 'externalName')
+    query.viewer.menus.menuItems.recipe.recipeTreeComponents.recipeItem.subRecipe.allIngredientsWithUsages(location_id=location_id).ingredient.__fields__('name', 'externalName')
     query.viewer.menus.menuItems.recipe.recipeTreeComponents.recipeItem.subRecipe.dietaryFlagsWithUsages(location_id=location_id)
     return query
 

--- a/galley/types.py
+++ b/galley/types.py
@@ -172,7 +172,7 @@ class SubRecipe(Type):
     recipeTreeComponents = Field(RecipeTreeComponent, args=ArgDict(levels=list_of(Int)))
     dietaryFlagsWithUsages = Field('DietaryFlagsWithUsages', args=ArgDict(location_id=ID))
     categoryValues = Field(CategoryValue)
-    allIngredientsWithUsages = Field(list_of(IngredientWithUsages))
+    allIngredientsWithUsages = Field(list_of(IngredientWithUsages), args=ArgDict(location_id=ID))
 
 
 class RecipeItem(Type):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # are dependencies that are required on remote installs, not local development.
 setup(
     name='galley_sdk',
-    version='1.6.0',
+    version='1.7.0',
     packages=['galley'],
     install_requires=['sgqlc==14.0', 'backoff==1.11.1']
 )


### PR DESCRIPTION
## Description
Our menu ops query was consistently timing out after we added the `recipeItemPreparations` field to the `Preparation` type. If this field isn't filtered out of the query, it causes an excessive amount of data to be returned, leading to timeouts. Updating the query to only return the `id` and `name` fields for preparations allows the request to complete successfully for all expected menu dates per facility.

## Test Plan
In python interactive shell, run:

```python
from galley.formatted_ops_queries import *; 

BASE_CODES = ['s', 'b', 'lv', 'lm', 'dv', 'dm', 't']
BASE_MEALS = {f'{b}{n+1}' for b in BASE_CODES for n in range(6)}
JAR_SALADS = {'ssa', 'ssb', 'ssc', 'ssd'}
SIDE_SOUPS = {'scw', 'sp',  'sm',  'sch'}
THISTLE_CLASSICS = {'cwsv', 'cwsm', 'cptv', 'cptm'}
PRODUCT_CODES_ALLOWED = BASE_MEALS | JAR_SALADS | SIDE_SOUPS | THISTLE_CLASSICS
DATES = ['2025-04-07', '2025-04-10', '2025-04-14', '2025-04-17', '2025-04-21', '2025-04-24', '2025-04-28', '2025-05-01']

get_formatted_ops_menu_data(dates=DATES, product_codes_filter=PRODUCT_CODES_ALLOWED)
```

- [ ] Confirm menu data is returned successfully for all dates — no timeout error is thrown 
 
## Versioning
v1.6.0 → v1.7.0
