### PR TITLE
Upgrade to Python 3.9 and upgrade dependencies

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,8 +1,8 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.245.2/containers/python-3/.devcontainer/base.Dockerfile
 
-# [Choice] Python version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.10, 3.9, 3.8, 3.7, 3.6, 3-bullseye, 3.10-bullseye, 3.9-bullseye, 3.8-bullseye, 3.7-bullseye, 3.6-bullseye, 3-buster, 3.10-buster, 3.9-buster, 3.8-buster, 3.7-buster, 3.6-buster
+# [Choice] Python version (use -bookworm or -bullseye variants on local arm64/Apple Silicon): 3, 3.13, 3.12, 3.11, 3.10, 3.9, 3-bookworm, 3.13-bookworm, 3.12-bookworm, 3.11-bookworm, 3.10-bookworm, 3.9-bookworm, 3-bullseye, 3.13-bullseye, 3.12-bullseye, 3.11-bullseye, 3.10-bullseye, 3.9-bullseye, 3-buster, 3.12-buster, 3.11-buster, 3.10-buster, 3.9-buster
 ARG VARIANT="3.10-bullseye"
-FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT}
+FROM mcr.microsoft.com/devcontainers/python:1-${VARIANT}
 
 # [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
 ARG NODE_VERSION="none"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,11 +5,11 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"context": "..",
-		"args": { 
-			// Update 'VARIANT' to pick a Python version: 3, 3.10, 3.9, 3.8, 3.7, 3.6
+		"args": {
+			// Update 'VARIANT' to pick a Python version: 3, 3.11, 3.10, 3.9
 			// Append -bullseye or -buster to pin to an OS version.
 			// Use -bullseye variants on local on arm64/Apple Silicon.
-			"VARIANT": "3.8",
+			"VARIANT": "3.9",
 			// Options
 			"NODE_VERSION": "none"
 		}
@@ -20,7 +20,7 @@
 		// Configure properties specific to VS Code.
 		"vscode": {
 			// Set *default* container specific settings.json values on container create.
-			"settings": { 
+			"settings": {
 				"python.defaultInterpreterPath": "/usr/local/bin/python",
 				"python.linting.enabled": true,
 				"python.linting.pylintEnabled": false,
@@ -45,7 +45,7 @@
 				],
 				"python.testing.pytestEnabled": false
 			},
-			
+
 			// Add the IDs of extensions you want installed when the container is created.
 			"extensions": [
 				"ms-python.python",
@@ -65,7 +65,7 @@
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// fix for git as per https://www.kenmuse.com/blog/avoiding-dubious-ownership-in-dev-containers/
 	"postStartCommand": "git config --global --add safe.directory ${containerWorkspaceFolder} && pip install -r requirements.txt",
-	
+
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode",
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ This is a Python SDK for interacting with the graphql API published by Galley (r
 ## Installation
 To set up your environment and install the required dependencies for local development, you will may use both Python and a virtual environment tool like [virtualenv](https://virtualenv.pypa.io/en/latest/#) or [pyenv-virtualenv](https://github.com/pyenv/pyenv-virtualenv) or the supplied [Development Container](https://containers.dev/).
 
-> :warning: Python version >3.8 is currently unsupported. You will have to downgrade Python (not recommended) or use pyenv-virtualenv to use galley-sdk.
-
 ### virtualenv steps
 ```
 $ git clone git@github.com:Thistle/galley-sdk.git
@@ -26,13 +24,13 @@ To use galley-sdk in pyenv-virtualenv:
 ```
 $ git clone git@github.com:Thistle/galley-sdk.git
 $ cd galley-sdk
-$ pyenv install 3.8.13
-$ pyenv virtualenv 3.8.13 py38
-$ pyenv activate py38
+$ pyenv install 3.9
+$ pyenv virtualenv 3.9 py39
+$ pyenv activate py39
 $ pip install -r requirements.txt
 ```
 
-> Note: When using galley-sdk in the future, make sure you run `pyenv activate py38` beforehand to be in the correct virtual envrionment.
+> Note: When using galley-sdk in the future, make sure you run `pyenv activate py39` beforehand to be in the correct virtual envrionment.
 
 ### Using the supplied Development Container
 To use the development container you will need a docker environment installed.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-backoff==1.11.1
-mypy==0.782
-python-dotenv==0.19.1
+backoff==2.2.1
+mypy==1.17.1
+python-dotenv==1.1.1
 sgqlc==14.0

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # are dependencies that are required on remote installs, not local development.
 setup(
     name='galley_sdk',
-    version='1.7.0',
+    version='1.8.0',
     packages=['galley'],
-    install_requires=['sgqlc==14.0', 'backoff==1.11.1']
+    install_requires=['sgqlc==14.0', 'backoff>=2.0.0']
 )


### PR DESCRIPTION
## Description

This is in service of shipping [thistle-web/7708](https://github.com/Thistle/thistle-web/pull/7708), a bulk dependency upgrade. The initial draft of that dependabot PR fails because the newer `segment-analytics-python` library depends on a newer version of `backoff`, and thistle-web is locked to `backoff-1.11.1` because that's what's specified in galley-sdk. This PR updates the backoff version in requirements.txt but also relaxes the backoff requirement in setup.py, allowing anything >= 2.0.

While we're at it:

* Upgrade to Python 3.9 as the minimum supported Python version for this library, given that we were already using some Python 3.9 syntax and the tests didn't pass on Python 3.8 because of it. The README had a note that Python >3.8 wouldn't work; that seems to be related to our use of a very old version of mypy that didn't support Python 3.9. So...
* Also upgrade `mypy` and `python-dotenv`
* Don't upgrade `sgqlc` (from 14.0 to 16.5) because there's a breaking change in 15.0 and we don't need to address it right now to unblock the thistle-web upgrades.

## Test Plan

- [ ] Run tests as directed in README. All tests pass.

I think that's enough testing for now. The only change that could affect application code is the `backoff` upgrade, and the test suite here includes tests of the retry behavior that still pass. We can verify that the galley integration still works when we review the PR on the thistle-web side.

## Versioning

- [ ] Version in setup.py updated
